### PR TITLE
Add $ to v1.0 OData query options

### DIFF
--- a/.azure-pipelines/generate-auth-module.yml
+++ b/.azure-pipelines/generate-auth-module.yml
@@ -38,6 +38,7 @@ jobs:
       pwsh: true
 
   - task: DotNetCoreCLI@2
+    displayName: 'Run Enabled Tests'
     inputs:
       command: 'test'
       projects: '$(System.DefaultWorkingDirectory)/src/Authentication/Authentication.Test/*.csproj'

--- a/.azure-pipelines/generate-auth-module.yml
+++ b/.azure-pipelines/generate-auth-module.yml
@@ -36,6 +36,12 @@ jobs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1'
       arguments: '-RepositoryName $(Repository_Name) -RepositoryApiKey $(Api_Key) -ModuleVersion $(Module_Version) -ArtifactsLocation $(Build.ArtifactStagingDirectory) -Build -EnableSigning'
       pwsh: true
+
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: 'test'
+      projects: '$(System.DefaultWorkingDirectory)/src/Authentication/Authentication.Test/*.csproj'
+      testRunTitle: 'Run Enabled Tests'
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'ESRP DLL Strong Name (Graph Auth Module)'

--- a/.azure-pipelines/validate-pr-auth-module.yml
+++ b/.azure-pipelines/validate-pr-auth-module.yml
@@ -35,6 +35,7 @@ jobs:
       pwsh: true
 
   - task: DotNetCoreCLI@2
+    displayName: 'Run Enabled Tests'
     inputs:
       command: 'test'
       projects: '$(System.DefaultWorkingDirectory)/src/Authentication/Authentication.Test/*.csproj'

--- a/.azure-pipelines/validate-pr-auth-module.yml
+++ b/.azure-pipelines/validate-pr-auth-module.yml
@@ -33,6 +33,12 @@ jobs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1'
       arguments: '-RepositoryName $(Repository_Name) -RepositoryApiKey $(Api_Key) -ModuleVersion $(Module_Version) -ArtifactsLocation $(Build.ArtifactStagingDirectory) -Build'
       pwsh: true
+
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: 'test'
+      projects: '$(System.DefaultWorkingDirectory)/src/Authentication/Authentication.Test/*.csproj'
+      testRunTitle: 'Run Enabled Tests'
   
   - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
     displayName: 'Graph Client Tooling pipeline fail notification'

--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Visual Studio Code
+.vscode/

--- a/src/Authentication/Authentication.Test/Helpers/ODataQueryOptionsHandlerTests.cs
+++ b/src/Authentication/Authentication.Test/Helpers/ODataQueryOptionsHandlerTests.cs
@@ -1,0 +1,92 @@
+namespace Microsoft.Graph.Authentication.Test
+{
+    using Microsoft.Graph.PowerShell.Authentication.Helpers;
+    using System;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    public class ODataQueryOptionsHandlerTests : IDisposable
+    {
+        private HttpMessageInvoker _invoker;
+        private FakeSuccessHandler _fakeSuccessHandler;
+        private ODataQueryOptionsHandler _graphODataHandler;
+        private string _randomGuid;
+
+        public ODataQueryOptionsHandlerTests()
+        {
+            this._fakeSuccessHandler = new FakeSuccessHandler();
+            this._graphODataHandler = new ODataQueryOptionsHandler(_fakeSuccessHandler);
+            this._invoker = new HttpMessageInvoker(_graphODataHandler);
+            this._randomGuid = Guid.NewGuid().ToString();
+        }
+
+        public void Dispose()
+        {
+            this._invoker.Dispose();
+        }
+
+        [Fact]
+        public async Task ShouldAddDollarSignToStandardODataQueryOptionsToV1Endpoint()
+        {
+            // Arrange
+            string topParam = "$top=5";
+            string orderbyParam = "$Orderby=DisplayName";
+            string selectParam = "Select=DisplayName%2CId%2CMail%2CUserType";
+            string filterParam = "filter=graphlearn_courses/courseId%20eq%20'123'";
+            string expandParam = "ExPaNd=members";
+
+            Uri requestUrl = new Uri($"https://graph.microsoft.com/v1.0/users?{topParam}&{orderbyParam}&{selectParam}&{filterParam}&{expandParam}");
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+
+            // Act
+            var response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var sentRequestQuery = response.RequestMessage.RequestUri.Query;
+
+            // Assert
+            Assert.NotEqual(requestUrl.Query, sentRequestQuery);
+            Assert.Contains(topParam, sentRequestQuery);
+            Assert.Contains(orderbyParam, sentRequestQuery);
+            Assert.Contains($"${selectParam}", sentRequestQuery);
+            Assert.Contains($"${filterParam}", sentRequestQuery);
+            Assert.Contains($"${expandParam}", sentRequestQuery);
+            Assert.Equal(5, sentRequestQuery.Split('&').Length);
+        }
+
+        [Fact]
+        public async Task ShouldSkipWhenGraphVersionIsBeta()
+        {
+            // Arrange
+            string topParam = "$top=5";
+            string orderbyParam = "$Orderby=DisplayName";
+            string selectParam = "Select=DisplayName%2CId%2CMail%2CUserType";
+            string filterParam = "filter=graphlearn_courses/courseId%20eq%20'123'";
+            string expandParam = "ExPaNd=members";
+
+            Uri requestUrl = new Uri($"https://graph.microsoft.com/Beta/users?{topParam}&{orderbyParam}&{selectParam}&{filterParam}&{expandParam}");
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+
+            // Act
+            var response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+
+            // Assert
+            Assert.Equal(requestUrl.ToString(), response.RequestMessage.RequestUri.ToString());
+            Assert.Equal(5, response.RequestMessage.RequestUri.Query.Split('&').Length);
+        }
+
+        [Fact]
+        public async Task ShouldSkipWhenQueryIsNotPresent()
+        {
+            // Arrange
+            Uri requestUrl = new Uri($"https://graph.microsoft.com/v1.0/users/_randomGuid");
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+
+            // Act
+            var response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+
+            // Assert
+            Assert.Equal(requestUrl.ToString(), response.RequestMessage.RequestUri.ToString());
+            Assert.Empty(response.RequestMessage.RequestUri.Query);
+        }
+    }
+}

--- a/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
+++ b/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Authentication\Microsoft.Graph.Authentication.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Authentication/Authentication.Test/TestUtils/FakeSuccessHandler.cs
+++ b/src/Authentication/Authentication.Test/TestUtils/FakeSuccessHandler.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Graph.Authentication.Test
+{
+    internal class FakeSuccessHandler : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                RequestMessage = request
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/src/Authentication/Authentication.sln
+++ b/src/Authentication/Authentication.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.29201.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Graph.Authentication", "Authentication\Microsoft.Graph.Authentication.csproj", "{44FF315A-27B2-4401-81A9-1912E6511EE6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Graph.Authentication.Test", "Authentication.Test\Microsoft.Graph.Authentication.Test.csproj", "{416590B4-3A91-4B0D-9B40-3F69438B6D85}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{44FF315A-27B2-4401-81A9-1912E6511EE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44FF315A-27B2-4401-81A9-1912E6511EE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44FF315A-27B2-4401-81A9-1912E6511EE6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{416590B4-3A91-4B0D-9B40-3F69438B6D85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{416590B4-3A91-4B0D-9B40-3F69438B6D85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{416590B4-3A91-4B0D-9B40-3F69438B6D85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{416590B4-3A91-4B0D-9B40-3F69438B6D85}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Authentication/Authentication/Helpers/HttpHelpers.cs
+++ b/src/Authentication/Authentication/Helpers/HttpHelpers.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         {
             IAuthenticationProvider authProvider = AuthenticationHelpers.GetAuthProvider(authConfig);
             IList<DelegatingHandler> defaultHandlers = GraphClientFactory.CreateDefaultHandlers(authProvider);
+
+            // Register ODataQueryOptionsHandler after AuthHandler.
             defaultHandlers.Insert(1, (new ODataQueryOptionsHandler()));
 
             HttpClient httpClient = GraphClientFactory.Create(defaultHandlers);

--- a/src/Authentication/Authentication/Helpers/HttpHelpers.cs
+++ b/src/Authentication/Authentication/Helpers/HttpHelpers.cs
@@ -34,7 +34,11 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         public static HttpClient GetGraphHttpClient(AuthConfig authConfig)
         {
             IAuthenticationProvider authProvider = AuthenticationHelpers.GetAuthProvider(authConfig);
-            HttpClient httpClient = GraphClientFactory.Create(authProvider);
+            IList<DelegatingHandler> defaultHandlers = GraphClientFactory.CreateDefaultHandlers(authProvider);
+            defaultHandlers.Insert(1, (new ODataQueryOptionsHandler()));
+
+            HttpClient httpClient = GraphClientFactory.Create(defaultHandlers);
+
             // Prepend new SDKVersionHeaders
             IEnumerable<string> previousSDKHeaders = httpClient.DefaultRequestHeaders.GetValues(CoreConstants.Headers.SdkVersionHeaderName);
             httpClient.DefaultRequestHeaders.Remove(CoreConstants.Headers.SdkVersionHeaderName);

--- a/src/Authentication/Authentication/Helpers/ODataQueryOptionsHandler.cs
+++ b/src/Authentication/Authentication/Helpers/ODataQueryOptionsHandler.cs
@@ -10,18 +10,13 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+
+    /// <summary>
+    /// A <see cref="DelegatingHandler"/> implementation that is used to properly format OData query parameters.
+    /// </summary>
     public class ODataQueryOptionsHandler : DelegatingHandler
     {
-        public ODataQueryOptionsHandler()
-        {
-
-        }
-        public ODataQueryOptionsHandler(HttpMessageHandler innerHandler)
-        {
-            this.InnerHandler = innerHandler;
-        }
-
-        List<string> _standardODataQueryOptions = new List<string>
+        private List<string> _standardODataQueryOptions = new List<string>
         {
             "count",
             "expand",
@@ -34,6 +29,29 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
             "top"
         };
 
+        /// <summary>
+        /// Creates a new <see cref="ODataQueryOptionsHandler"/>.
+        /// </summary>
+        public ODataQueryOptionsHandler()
+        {
+
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ODataQueryOptionsHandler"/>.
+        /// </summary>
+        /// <param name="innerHandler">Optional <see cref="HttpMessageHandler"/> to be called after <see cref="ODataQueryOptionsHandler"/>.</param>
+        public ODataQueryOptionsHandler(HttpMessageHandler innerHandler)
+        {
+            this.InnerHandler = innerHandler;
+        }
+
+        /// <summary>
+        /// Sends the <see cref="HttpRequestMessage"/>.
+        /// </summary>
+        /// <param name="request">The request to send.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns></returns>
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (request.RequestUri.Segments[1].ToLower().Contains("v1.0") && request.RequestUri.Query != null)

--- a/src/Authentication/Authentication/Helpers/ODataQueryOptionsHandler.cs
+++ b/src/Authentication/Authentication/Helpers/ODataQueryOptionsHandler.cs
@@ -1,0 +1,58 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.PowerShell.Authentication.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    public class ODataQueryOptionsHandler : DelegatingHandler
+    {
+        public ODataQueryOptionsHandler()
+        {
+
+        }
+        public ODataQueryOptionsHandler(HttpMessageHandler innerHandler)
+        {
+            this.InnerHandler = innerHandler;
+        }
+
+        List<string> _standardODataQueryOptions = new List<string>
+        {
+            "count",
+            "expand",
+            "filter",
+            "format",
+            "orderby",
+            "search",
+            "select",
+            "skip",
+            "top"
+        };
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri.Segments[1].ToLower().Contains("v1.0") && request.RequestUri.Query != null)
+            {
+                string newRequestQuery = request.RequestUri.Query;
+                string[] querySegments = newRequestQuery.Split(new char[] { '&', '?' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (string querySegment in querySegments)
+                {
+                    string targetQueryParam = querySegment.Split(new char[] { '=' }).FirstOrDefault();
+                    if (_standardODataQueryOptions.Contains(targetQueryParam.ToLower()))
+                        newRequestQuery = newRequestQuery.Replace(targetQueryParam, $"${targetQueryParam}");
+                }
+
+                UriBuilder uriBuilder = new UriBuilder(request.RequestUri);
+                uriBuilder.Query = newRequestQuery;
+                request.RequestUri = uriBuilder.Uri;
+            }
+
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `$` to standard OData[ query parameters](https://github.com/microsoftgraph/msgraph-sdk-powershell/blob/c6d014a0c93893f920e2e1a4163989fcd51516c8/src/Authentication/Authentication/Helpers/ODataQueryOptionsHandler.cs#L19) targeting `v1.0` endpoint if non is set. On the v1.0, `$` is only optional on a subset of the APIs, and it's [recommended](https://docs.microsoft.com/en-us/graph/query-parameters) to always include `$` on query options targeting `v1.0` endpoint.

The prepending logic also ensures that the values set on query parameter are not modified, and `$` is only prepended to standard OData query options. This is validated by the unit tests.

Closes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/22