### PR TITLE
Update Token Path To UserProfile

### DIFF
--- a/src/Authentication/Authentication/Constants.cs
+++ b/src/Authentication/Authentication/Constants.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Graph.PowerShell.Authentication
         internal const int MaxDeviceCodeTimeOut = 120; // 2 mins timeout.
         internal const string UserCacheFileName = "userTokenCache.bin3";
         internal const string AppCacheFileName = "appTokenCache.bin3";
-        internal static readonly string TokenCacheDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".Graph");
+        internal static readonly string TokenCacheDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".graph");
     }
 }

--- a/src/Authentication/Authentication/Constants.cs
+++ b/src/Authentication/Authentication/Constants.cs
@@ -1,14 +1,20 @@
 ﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
+
 namespace Microsoft.Graph.PowerShell.Authentication
 {
+    using System;
+    using System.IO;
     public static class Constants
     {
         public const string GraphAuthConfigId = "GraphAuthConfigId";
         public const string SDKHeaderValue = "Graph-powershell-{0}-{1}.{2}.{3}";
         internal const string UserParameterSet = "UserParameterSet";
         internal const string AppParameterSet = "AppParameterSet";
-        internal static readonly int MaxDeviceCodeTimeOut = 120; // 2 mins timeout.
+        internal const int MaxDeviceCodeTimeOut = 120; // 2 mins timeout.
+        internal const string UserCacheFileName = "userTokenCache.bin3";
+        internal const string AppCacheFileName = "appTokenCache.bin3";
+        internal static readonly string TokenCacheDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".Graph");
     }
 }

--- a/src/Authentication/Authentication/Helpers/AuthenticationHelpers.cs
+++ b/src/Authentication/Authentication/Helpers/AuthenticationHelpers.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
 {
     using Microsoft.Graph.Auth;
     using Microsoft.Graph.PowerShell.Authentication.Models;
+    using Microsoft.Graph.PowerShell.Authentication.TokenCache;
     using Microsoft.Identity.Client;
     using System;
     using System.IO;
@@ -64,7 +65,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                 lock (FileLock)
                 {
                     args.TokenCache.DeserializeMsalV3(File.Exists(tokenCacheFilePath)
-                        ? TokenCryptoHelpers.DecryptToken(File.ReadAllBytes(tokenCacheFilePath))
+                        ? TokenCryptographer.DecryptToken(File.ReadAllBytes(tokenCacheFilePath))
                         : null,
                         shouldClearExistingCache: true);
                 }
@@ -75,7 +76,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                 {
                     if (args.HasStateChanged)
                     {
-                        File.WriteAllBytes(tokenCacheFilePath, TokenCryptoHelpers.EncryptToken(args.TokenCache.SerializeMsalV3()));
+                        File.WriteAllBytes(tokenCacheFilePath, TokenCryptographer.EncryptToken(args.TokenCache.SerializeMsalV3()));
                     }
                 }
             });

--- a/src/Authentication/Authentication/Helpers/AuthenticationHelpers.cs
+++ b/src/Authentication/Authentication/Helpers/AuthenticationHelpers.cs
@@ -9,19 +9,11 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
     using System;
     using System.IO;
     using System.Linq;
-    using System.Security.Cryptography;
     using System.Security.Cryptography.X509Certificates;
 
     internal static class AuthenticationHelpers
     {
         private static readonly object FileLock = new object();
-        private static readonly string UserCacheFileName = "userTokenCache.bin3";
-        private static readonly string AppCacheFileName = "appTokenCache.bin3";
-
-        /// <summary>
-        /// Path to the token cache.
-        /// </summary>
-        internal static readonly string CacheFilePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
 
         internal static IAuthenticationProvider GetAuthProvider(AuthConfig authConfig)
         {
@@ -32,7 +24,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                    .WithTenantId(authConfig.TenantId)
                    .Build();
 
-                ConfigureTokenCache(publicClientApp.UserTokenCache, Path.Combine(CacheFilePath, UserCacheFileName));
+                ConfigureTokenCache(publicClientApp.UserTokenCache, Constants.UserCacheFileName);
                 return new DeviceCodeProvider(publicClientApp, authConfig.Scopes, async (result) => {
                     await Console.Out.WriteLineAsync(result.Message);
                 });
@@ -45,7 +37,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                 .WithCertificate(string.IsNullOrEmpty(authConfig.CertificateThumbprint) ? GetCertificateByName(authConfig.CertificateName) : GetCertificateByThumbprint(authConfig.CertificateThumbprint))
                 .Build();
 
-                ConfigureTokenCache(confidentialClientApp.AppTokenCache, Path.Combine(CacheFilePath, AppCacheFileName));
+                ConfigureTokenCache(confidentialClientApp.AppTokenCache, Constants.AppCacheFileName);
                 return new ClientCredentialProvider(confidentialClientApp);
             }
         }
@@ -55,19 +47,24 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
             lock (FileLock)
             {
                 if (authConfig.AuthType == AuthenticationType.Delegated)
-                    File.Delete(Path.Combine(CacheFilePath, UserCacheFileName));
+                    File.Delete(Path.Combine(Constants.TokenCacheDirectory, Constants.UserCacheFileName));
                 else
-                    File.Delete(Path.Combine(CacheFilePath, AppCacheFileName));
+                    File.Delete(Path.Combine(Constants.TokenCacheDirectory, Constants.AppCacheFileName));
             }
         }
 
-        private static void ConfigureTokenCache(ITokenCache tokenCache, string tokenCachePath)
+        private static void ConfigureTokenCache(ITokenCache tokenCache, string tokenCacheFile)
         {
+            if (!Directory.Exists(Constants.TokenCacheDirectory))
+                Directory.CreateDirectory(Constants.TokenCacheDirectory);
+
+            string tokenCacheFilePath = Path.Combine(Constants.TokenCacheDirectory, tokenCacheFile);
+
             tokenCache.SetBeforeAccess((TokenCacheNotificationArgs args) => {
                 lock (FileLock)
                 {
-                    args.TokenCache.DeserializeMsalV3(File.Exists(tokenCachePath)
-                        ? TokenCryptoHelpers.DecryptToken(File.ReadAllBytes(tokenCachePath))
+                    args.TokenCache.DeserializeMsalV3(File.Exists(tokenCacheFilePath)
+                        ? TokenCryptoHelpers.DecryptToken(File.ReadAllBytes(tokenCacheFilePath))
                         : null,
                         shouldClearExistingCache: true);
                 }
@@ -78,7 +75,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                 {
                     if (args.HasStateChanged)
                     {
-                        File.WriteAllBytes(tokenCachePath, TokenCryptoHelpers.EncryptToken(args.TokenCache.SerializeMsalV3()));
+                        File.WriteAllBytes(tokenCacheFilePath, TokenCryptoHelpers.EncryptToken(args.TokenCache.SerializeMsalV3()));
                     }
                 }
             });

--- a/src/Authentication/Authentication/Properties/launchSettings.json
+++ b/src/Authentication/Authentication/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Graph.Authentication": {
       "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\PowerShell\\6\\pwsh.exe",
+      "executablePath": "C:\\Program Files\\PowerShell\\7-preview\\pwsh.exe",
       "commandLineArgs": "-NoProfile -NoExit"
     }
   }

--- a/src/Authentication/Authentication/TokenCache/TokenCryptographer.cs
+++ b/src/Authentication/Authentication/TokenCache/TokenCryptographer.cs
@@ -1,15 +1,14 @@
 ﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
-namespace Microsoft.Graph.PowerShell.Authentication.Helpers
+namespace Microsoft.Graph.PowerShell.Authentication.TokenCache
 {
     using System;
-    using System.Security.Cryptography;
 
     /// <summary>
     /// Helper class to handle token encryption and decryption.
     /// </summary>
-    internal static class TokenCryptoHelpers
+    internal static class TokenCryptographer
     {
         /// <summary>
         /// Encrypts the passed buffer based on the host platform.
@@ -19,7 +18,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         public static byte[] EncryptToken(byte[] buffer)
         {
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-                return ProtectedData.Protect(buffer, null, DataProtectionScope.CurrentUser);
+                return WindowsTokenCache.EncryptToken(buffer);
             return buffer;
         }
 
@@ -31,7 +30,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         public static byte[] DecryptToken(byte[] buffer)
         {
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-                return ProtectedData.Unprotect(buffer, null, DataProtectionScope.CurrentUser);
+                return WindowsTokenCache.DecryptToken(buffer);
             return buffer;
         }
     }

--- a/src/Authentication/Authentication/TokenCache/WindowsTokenCache.cs
+++ b/src/Authentication/Authentication/TokenCache/WindowsTokenCache.cs
@@ -1,0 +1,30 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.PowerShell.Authentication.TokenCache
+{
+    using System.Security.Cryptography;
+    internal static class WindowsTokenCache
+    {
+        /// <summary>
+        /// Encrypts the passed buffer using Windows DPAPI.
+        /// </summary>
+        /// <param name="buffer">A <see cref="byte[]"/> to encrypt.</param>
+        /// <returns>An encrypted <see cref="byte[]"/>.</returns>
+        public static byte[] EncryptToken(byte[] buffer)
+        {
+            return ProtectedData.Protect(buffer, null, DataProtectionScope.CurrentUser);
+        }
+
+        /// <summary>
+        /// Decrypts the passed buffer Windows DPAPI.
+        /// </summary>
+        /// <param name="buffer">A <see cref="byte[]"/> to decrypt.</param>
+        /// <returns>An decrypted <see cref="byte[]"/>.</returns>
+        public static byte[] DecryptToken(byte[] buffer)
+        {
+            return ProtectedData.Unprotect(buffer, null, DataProtectionScope.CurrentUser);
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the token cache from the SDKs installation directory to a users profile.

The token will be saved in the following directories for these platforms:
| Windows | Linux | MacOS |
| ------------- |:-------------:| -----:|
| C:\Users\{USERNAME} | /home/{USERNAME} | /Users/{USERNAME} |


It closes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/109