### PR TITLE
[HotFix] Remove FunctionsToExport

### DIFF
--- a/config/ModuleMetadata.json
+++ b/config/ModuleMetadata.json
@@ -10,5 +10,5 @@
     "tags": "MicrosoftGraph;Microsoft;Office365;Graph;PowerShell;GraphServiceClient;Outlook;OneDrive;AzureAD;GraphAPI;Productivity;SharePoint;Intune;SDK;",
     "releaseNotes": "See https://aka.ms/GraphPowerShell-Release.",
     "assemblyOriginatorKeyFile": "35MSSharedLib1024.snk",
-    "version": "0.2.0"
+    "version": "0.2.1"
 }

--- a/src/Beta/Analytics/Analytics/readme.md
+++ b/src/Beta/Analytics/Analytics/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Bookings/Bookings/readme.md
+++ b/src/Beta/Bookings/Bookings/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/CloudCommunications/CloudCommunications/readme.md
+++ b/src/Beta/CloudCommunications/CloudCommunications/readme.md
@@ -46,6 +46,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/DevicesApps.MobileAppManagement/DevicesApps.MobileAppManagement/readme.md
+++ b/src/Beta/DevicesApps.MobileAppManagement/DevicesApps.MobileAppManagement/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/DevicesApps.OfficeConfiguration/DevicesApps.OfficeConfiguration/readme.md
+++ b/src/Beta/DevicesApps.OfficeConfiguration/DevicesApps.OfficeConfiguration/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/DevicesApps.SharedResources/DevicesApps.SharedResources/readme.md
+++ b/src/Beta/DevicesApps.SharedResources/DevicesApps.SharedResources/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Education/Education/readme.md
+++ b/src/Beta/Education/Education/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Files.Drives/Files.Drives/readme.md
+++ b/src/Beta/Files.Drives/Files.Drives/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Files.Permissions/Files.Permissions/readme.md
+++ b/src/Beta/Files.Permissions/Files.Permissions/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Files.Shares/Files.Shares/readme.md
+++ b/src/Beta/Files.Shares/Files.Shares/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Financials/Financials/readme.md
+++ b/src/Beta/Financials/Financials/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.Calendar/Groups.Calendar/readme.md
+++ b/src/Beta/Groups.Calendar/Groups.Calendar/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.Conversation/Groups.Conversation/readme.md
+++ b/src/Beta/Groups.Conversation/Groups.Conversation/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.ConversationThread/Groups.ConversationThread/readme.md
+++ b/src/Beta/Groups.ConversationThread/Groups.ConversationThread/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.DirectoryObject/Groups.DirectoryObject/readme.md
+++ b/src/Beta/Groups.DirectoryObject/Groups.DirectoryObject/readme.md
@@ -89,6 +89,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.Drive/Groups.Drive/readme.md
+++ b/src/Beta/Groups.Drive/Groups.Drive/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.Endpoint/Groups.Endpoint/readme.md
+++ b/src/Beta/Groups.Endpoint/Groups.Endpoint/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.Extension/Groups.Extension/readme.md
+++ b/src/Beta/Groups.Extension/Groups.Extension/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.Functions/Groups.Functions/readme.md
+++ b/src/Beta/Groups.Functions/Groups.Functions/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.Group/Groups.Group/readme.md
+++ b/src/Beta/Groups.Group/Groups.Group/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.LifecyclePolicies/Groups.LifecyclePolicies/readme.md
+++ b/src/Beta/Groups.LifecyclePolicies/Groups.LifecyclePolicies/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.OneNote/Groups.OneNote/readme.md
+++ b/src/Beta/Groups.OneNote/Groups.OneNote/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.Planner/Groups.Planner/readme.md
+++ b/src/Beta/Groups.Planner/Groups.Planner/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.ProfilePhoto/Groups.ProfilePhoto/readme.md
+++ b/src/Beta/Groups.ProfilePhoto/Groups.ProfilePhoto/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Groups.Site/Groups.Site/readme.md
+++ b/src/Beta/Groups.Site/Groups.Site/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.AccessReview/Identity.AccessReview/readme.md
+++ b/src/Beta/Identity.AccessReview/Identity.AccessReview/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.AdministrativeUnits/Identity.AdministrativeUnits/readme.md
+++ b/src/Beta/Identity.AdministrativeUnits/Identity.AdministrativeUnits/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.AppRoleAssignments/Identity.AppRoleAssignments/readme.md
+++ b/src/Beta/Identity.AppRoleAssignments/Identity.AppRoleAssignments/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.Application/Identity.Application/readme.md
+++ b/src/Beta/Identity.Application/Identity.Application/readme.md
@@ -31,10 +31,9 @@ title: $(service-name)
 subject-prefix: ''
 input-file: $(spec-doc-repo)/$(title).yml
 ```
-
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.AuditLogs/Identity.AuditLogs/readme.md
+++ b/src/Beta/Identity.AuditLogs/Identity.AuditLogs/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.AzureADPIM/Identity.AzureADPIM/readme.md
+++ b/src/Beta/Identity.AzureADPIM/Identity.AzureADPIM/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.CertificateBasedAuthConfiguration/Identity.CertificateBasedAuthConfiguration/readme.md
+++ b/src/Beta/Identity.CertificateBasedAuthConfiguration/Identity.CertificateBasedAuthConfiguration/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.ConditionalAccess/Identity.ConditionalAccess/readme.md
+++ b/src/Beta/Identity.ConditionalAccess/Identity.ConditionalAccess/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.Contracts/Identity.Contracts/readme.md
+++ b/src/Beta/Identity.Contracts/Identity.Contracts/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.DataPolicyOperations/Identity.DataPolicyOperations/readme.md
+++ b/src/Beta/Identity.DataPolicyOperations/Identity.DataPolicyOperations/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.Devices/Identity.Devices/readme.md
+++ b/src/Beta/Identity.Devices/Identity.Devices/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.Directory/Identity.Directory/readme.md
+++ b/src/Beta/Identity.Directory/Identity.Directory/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.DirectoryObjects/Identity.DirectoryObjects/readme.md
+++ b/src/Beta/Identity.DirectoryObjects/Identity.DirectoryObjects/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.DirectoryRoleTemplates/Identity.DirectoryRoleTemplates/readme.md
+++ b/src/Beta/Identity.DirectoryRoleTemplates/Identity.DirectoryRoleTemplates/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.DirectoryRoles/Identity.DirectoryRoles/readme.md
+++ b/src/Beta/Identity.DirectoryRoles/Identity.DirectoryRoles/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.DirectorySettingTemplates/Identity.DirectorySettingTemplates/readme.md
+++ b/src/Beta/Identity.DirectorySettingTemplates/Identity.DirectorySettingTemplates/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.DirectorySettings/Identity.DirectorySettings/readme.md
+++ b/src/Beta/Identity.DirectorySettings/Identity.DirectorySettings/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.Domains/Identity.Domains/readme.md
+++ b/src/Beta/Identity.Domains/Identity.Domains/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.Invitations/Identity.Invitations/readme.md
+++ b/src/Beta/Identity.Invitations/Identity.Invitations/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.OAuth2PermissionGrants/Identity.OAuth2PermissionGrants/readme.md
+++ b/src/Beta/Identity.OAuth2PermissionGrants/Identity.OAuth2PermissionGrants/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.OnPremisesPublishingProfiles/Identity.OnPremisesPublishingProfiles/readme.md
+++ b/src/Beta/Identity.OnPremisesPublishingProfiles/Identity.OnPremisesPublishingProfiles/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.Organization/Identity.Organization/readme.md
+++ b/src/Beta/Identity.Organization/Identity.Organization/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.OrganizationContacts/Identity.OrganizationContacts/readme.md
+++ b/src/Beta/Identity.OrganizationContacts/Identity.OrganizationContacts/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.Policies/Identity.Policies/readme.md
+++ b/src/Beta/Identity.Policies/Identity.Policies/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.Protection/Identity.Protection/readme.md
+++ b/src/Beta/Identity.Protection/Identity.Protection/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.Providers/Identity.Providers/readme.md
+++ b/src/Beta/Identity.Providers/Identity.Providers/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.RoleManagement/Identity.RoleManagement/readme.md
+++ b/src/Beta/Identity.RoleManagement/Identity.RoleManagement/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.ServicePrincipal/Identity.ServicePrincipal/readme.md
+++ b/src/Beta/Identity.ServicePrincipal/Identity.ServicePrincipal/readme.md
@@ -31,10 +31,9 @@ title: $(service-name)
 subject-prefix: ''
 input-file: $(spec-doc-repo)/$(title).yml
 ```
-
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.SubscribedSkus/Identity.SubscribedSkus/readme.md
+++ b/src/Beta/Identity.SubscribedSkus/Identity.SubscribedSkus/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.TermsOfUse/Identity.TermsOfUse/readme.md
+++ b/src/Beta/Identity.TermsOfUse/Identity.TermsOfUse/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.TrustFramework/Identity.TrustFramework/readme.md
+++ b/src/Beta/Identity.TrustFramework/Identity.TrustFramework/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Identity.UserFlows/Identity.UserFlows/readme.md
+++ b/src/Beta/Identity.UserFlows/Identity.UserFlows/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Notification/Notification/readme.md
+++ b/src/Beta/Notification/Notification/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/OnlineMeetings/OnlineMeetings/readme.md
+++ b/src/Beta/OnlineMeetings/OnlineMeetings/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Places/Places/readme.md
+++ b/src/Beta/Places/Places/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Planner/Planner/readme.md
+++ b/src/Beta/Planner/Planner/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Reports/Reports/readme.md
+++ b/src/Beta/Reports/Reports/readme.md
@@ -43,6 +43,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/SchemaExtensions/SchemaExtensions/readme.md
+++ b/src/Beta/SchemaExtensions/SchemaExtensions/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Search/Search/readme.md
+++ b/src/Beta/Search/Search/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Security/Security/readme.md
+++ b/src/Beta/Security/Security/readme.md
@@ -66,6 +66,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Sites.Drive/Sites.Drive/readme.md
+++ b/src/Beta/Sites.Drive/Sites.Drive/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Sites.List/Sites.List/readme.md
+++ b/src/Beta/Sites.List/Sites.List/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Sites.OneNote/Sites.OneNote/readme.md
+++ b/src/Beta/Sites.OneNote/Sites.OneNote/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Sites.Pages/Sites.Pages/readme.md
+++ b/src/Beta/Sites.Pages/Sites.Pages/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Sites.Site/Sites.Site/readme.md
+++ b/src/Beta/Sites.Site/Sites.Site/readme.md
@@ -84,10 +84,9 @@ directive:
     set:
       subject: SubSite
 ```
-
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Subscriptions/Subscriptions/readme.md
+++ b/src/Beta/Subscriptions/Subscriptions/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Teams.AppCatalogs/Teams.AppCatalogs/readme.md
+++ b/src/Beta/Teams.AppCatalogs/Teams.AppCatalogs/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Teams.Channel/Teams.Channel/readme.md
+++ b/src/Beta/Teams.Channel/Teams.Channel/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Teams.Chats/Teams.Chats/readme.md
+++ b/src/Beta/Teams.Chats/Teams.Chats/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Teams.Team/Teams.Team/readme.md
+++ b/src/Beta/Teams.Team/Teams.Team/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Teams.Teamwork/Teams.Teamwork/readme.md
+++ b/src/Beta/Teams.Teamwork/Teams.Teamwork/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.ActivityFeed/Users.ActivityFeed/readme.md
+++ b/src/Beta/Users.ActivityFeed/Users.ActivityFeed/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.Calendar/Users.Calendar/readme.md
+++ b/src/Beta/Users.Calendar/Users.Calendar/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.Contacts/Users.Contacts/readme.md
+++ b/src/Beta/Users.Contacts/Users.Contacts/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.Devices/Users.Devices/readme.md
+++ b/src/Beta/Users.Devices/Users.Devices/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.DirectoryObject/Users.DirectoryObject/readme.md
+++ b/src/Beta/Users.DirectoryObject/Users.DirectoryObject/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.Drive/Users.Drive/readme.md
+++ b/src/Beta/Users.Drive/Users.Drive/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.Extensions/Users.Extensions/readme.md
+++ b/src/Beta/Users.Extensions/Users.Extensions/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.FollowedSites/Users.FollowedSites/readme.md
+++ b/src/Beta/Users.FollowedSites/Users.FollowedSites/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.Functions/Users.Functions/readme.md
+++ b/src/Beta/Users.Functions/Users.Functions/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.Groups/Users.Groups/readme.md
+++ b/src/Beta/Users.Groups/Users.Groups/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.InformationProtection/Users.InformationProtection/readme.md
+++ b/src/Beta/Users.InformationProtection/Users.InformationProtection/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.LicenseDetails/Users.LicenseDetails/readme.md
+++ b/src/Beta/Users.LicenseDetails/Users.LicenseDetails/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.Mail/Users.Mail/readme.md
+++ b/src/Beta/Users.Mail/Users.Mail/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.OneNote/Users.OneNote/readme.md
+++ b/src/Beta/Users.OneNote/Users.OneNote/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.OutlookUser/Users.OutlookUser/readme.md
+++ b/src/Beta/Users.OutlookUser/Users.OutlookUser/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.People/Users.People/readme.md
+++ b/src/Beta/Users.People/Users.People/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.Planner/Users.Planner/readme.md
+++ b/src/Beta/Users.Planner/Users.Planner/readme.md
@@ -38,10 +38,9 @@ directive:
     set:
       subject: AllUserPlanner
 ```
-
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.ProfilePhoto/Users.ProfilePhoto/readme.md
+++ b/src/Beta/Users.ProfilePhoto/Users.ProfilePhoto/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.User/Users.User/readme.md
+++ b/src/Beta/Users.User/Users.User/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Beta/Users.UserSettings/Users.UserSettings/readme.md
+++ b/src/Beta/Users.UserSettings/Users.UserSettings/readme.md
@@ -34,6 +34,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/tools/BuildModule.ps1
+++ b/tools/BuildModule.ps1
@@ -60,7 +60,6 @@ if ($LASTEXITCODE) {
 
 [HashTable]$ModuleManifestSettings = @{
     Path              = $ModuleManifest
-    FunctionsToExport = "*"
     ModuleVersion     = $ModuleVersion
     IconUri           = $NuspecMetadata["iconUri"]
     ReleaseNotes      = $ReleaseNotes

--- a/tools/Templates/Microsoft.Graph.nuspec
+++ b/tools/Templates/Microsoft.Graph.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.Graph</id>
-    <version>0.1.1</version>
+    <version>0.2.1</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>https://aka.ms/devservicesagreement</licenseUrl>

--- a/tools/Templates/readme.md
+++ b/tools/Templates/readme.md
@@ -14,6 +14,6 @@ input-file: $(spec-doc-repo)/$(title).yml
 ### Versioning
 
 ``` yaml
-module-version: 0.2.0
+module-version: 0.2.1
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```


### PR DESCRIPTION
We initially had a wildcard set on `FunctionsToExport` since the previous version AutoREST beta was not setting the correct value. This seems to have been recently [fixed](https://github.com/Azure/autorest.powershell/pull/583), and we no longer need the wildcard.

0.2.0 modules have the wildcard set on `FunctionsToExport` which results in PowerShell command completion not working.

Closes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/76

