### PR TITLE
Rename OData query parameters to comply with PS vocabulary

### DIFF
--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -58,19 +58,23 @@ directive:
   - where:
       parameter-name: OrderBy
     set:
-      alias: Sort
+      parameter-name: Sort
+      alias: OrderBy
   - where:
       parameter-name: Top
     set:
-      alias: PageSize
+      parameter-name: PageSize
+      alias: Top
   - where:
       parameter-name: Select
     set:
-      alias: Property
+      parameter-name: Property
+      alias: Select
   - where:
       parameter-name: Expand
     set:
-      alias: ExpandProperty
+      parameter-name: ExpandProperty
+      alias: Expand
   # Format cmdlet response.
   - where:
       model-name: MicrosoftGraphUser

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -54,6 +54,23 @@ directive:
     - microsoft.graph.team
     - microsoft.graph.recipient
 
+  # Set parameter alias
+  - where:
+      parameter-name: OrderBy
+    set:
+      alias: Sort
+  - where:
+      parameter-name: Top
+    set:
+      alias: PageSize
+  - where:
+      parameter-name: Select
+    set:
+      alias: Property
+  - where:
+      parameter-name: Expand
+    set:
+      alias: ExpandProperty
   # Format cmdlet response.
   - where:
       model-name: MicrosoftGraphUser


### PR DESCRIPTION
This PR implements suggestions made in https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/97 by renaming the following query parameters and aliasing them with their OData name:
| Current Parameter Name  | New Parameter Name  | Alias  |
|---|---|---|
| OrderBy  | Sort  | OrderBy  |
| Top  | PageSize  | Top  |
| Select  | Property  | Select |
| Expand | ExpandProperty | Expand |

`Get-MGUser` signature:
![image](https://user-images.githubusercontent.com/7061532/77215616-44502180-6ad2-11ea-9f39-72cc3fe69ef6.png)


Closes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/97