### PR TITLE
PowerShell 5.1 hard dependency fix

### DIFF
--- a/.azure-pipelines/generate-beta-modules.yml
+++ b/.azure-pipelines/generate-beta-modules.yml
@@ -36,13 +36,13 @@ jobs:
     displayName: 'Install AutoRest'
     inputs:
       command: 'custom'
-      customCommand: 'install -g @autorest/autorest@3.0.6114'
+      customCommand: 'install -g @autorest/autorest'
   
   - task: PowerShell@2
     displayName: 'Build Auth Modules'
     inputs:
-      filePath: '$(System.DefaultWorkingDirectory)/tools/BuildModule.ps1'
-      arguments: '-Module "Authentication" -ModulePrefix $(MODULE_PREFIX) -ModuleVersion $(Module_Version) -EnableSigning -ReleaseNotes $(Release_Notes)'
+      filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1'
+      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory) -Build -EnableSigning'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
@@ -122,7 +122,7 @@ jobs:
     displayName: 'Generate and Build Graph Resource Modules'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1'
-      arguments: '-RepositoryName $(Repository_Name) -RepositoryApiKey $(Api_Key) -ModuleVersion $(Module_Version) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\ -UseLocalDoc -BetaGraphVersion -Build -EnableSigning'
+      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\ -UseLocalDoc -BetaGraphVersion -Build -EnableSigning'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1

--- a/.azure-pipelines/generate-beta-rollup-module.yml
+++ b/.azure-pipelines/generate-beta-rollup-module.yml
@@ -29,7 +29,7 @@ jobs:
     displayName: 'Generate and Build Roll-Up Module'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateRollUpModule.ps1'
-      arguments: '-RepositoryName $(Repository_Name) -RepositoryApiKey $(Api_Key) -ModuleVersion $(Module_Version) -ArtifactsLocation $(Build.ArtifactStagingDirectory)/$(GRAPH_VERSION)/ -BetaGraphVersion'
+      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)/$(GRAPH_VERSION)/ -BetaGraphVersion'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1

--- a/.azure-pipelines/generate-v1.0-modules.yml
+++ b/.azure-pipelines/generate-v1.0-modules.yml
@@ -37,13 +37,13 @@ jobs:
     displayName: 'Install AutoRest'
     inputs:
       command: 'custom'
-      customCommand: 'install -g @autorest/autorest@3.0.6114'
+      customCommand: 'install -g @autorest/autorest'
   
   - task: PowerShell@2
     displayName: 'Build Auth Modules'
     inputs:
-      filePath: '$(System.DefaultWorkingDirectory)/tools/BuildModule.ps1'
-      arguments: '-Module "Authentication" -ModulePrefix $(MODULE_PREFIX) -ModuleVersion $(Module_Version) -EnableSigning'
+      filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1'
+      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory) -Build -EnableSigning'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
@@ -123,7 +123,7 @@ jobs:
     displayName: 'Generate and Build Graph Resource Modules'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1'
-      arguments: '-RepositoryName $(Repository_Name) -RepositoryApiKey $(Api_Key) -ModuleVersion $(Module_Version) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\ -UseLocalDoc -Build -EnableSigning'
+      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\ -UseLocalDoc -Build -EnableSigning'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1

--- a/.azure-pipelines/generate-v1.0-rollup-module.yml
+++ b/.azure-pipelines/generate-v1.0-rollup-module.yml
@@ -29,7 +29,7 @@ jobs:
     displayName: 'Generate and Build Roll-Up Module'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateRollUpModule.ps1'
-      arguments: '-RepositoryName $(Repository_Name) -RepositoryApiKey $(Api_Key) -ModuleVersion $(Module_Version) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\'
+      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1

--- a/.azure-pipelines/validate-pr-beta-modules.yml
+++ b/.azure-pipelines/validate-pr-beta-modules.yml
@@ -35,13 +35,13 @@ jobs:
     displayName: 'Install AutoRest'
     inputs:
       command: 'custom'
-      customCommand: 'install -g @autorest/autorest@3.0.6114'
+      customCommand: 'install -g @autorest/autorest'
   
   - task: PowerShell@2
     displayName: 'Generate and Build Graph Resource Modules'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1'
-      arguments: '-RepositoryName $(Repository_Name) -RepositoryApiKey $(Api_Key) -ModuleVersion $(Module_Version) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\ -UseLocalDoc -BetaGraphVersion -Build'
+      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\ -UseLocalDoc -BetaGraphVersion -Build'
       pwsh: true
   
   - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0

--- a/.azure-pipelines/validate-pr-v1.0-modules.yml
+++ b/.azure-pipelines/validate-pr-v1.0-modules.yml
@@ -35,13 +35,13 @@ jobs:
     displayName: 'Install AutoRest'
     inputs:
       command: 'custom'
-      customCommand: 'install -g @autorest/autorest@3.0.6114'
+      customCommand: 'install -g @autorest/autorest'
   
   - task: PowerShell@2
     displayName: 'Generate and Build Graph Resource Modules'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1'
-      arguments: '-RepositoryName $(Repository_Name) -RepositoryApiKey $(Api_Key) -ModuleVersion $(Module_Version) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\ -UseLocalDoc -Build'
+      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\ -UseLocalDoc -Build'
       pwsh: true
   
   - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0

--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
@@ -63,7 +63,7 @@ DotNetFrameworkVersion = '4.7.2'
 # TypesToProcess = @()
 
 # Format files (.ps1xml) to be loaded when importing this module
-FormatsToProcess = './Microsoft.Graph.Authentication.Format.ps1xml'
+FormatsToProcess = './Microsoft.Graph.Authentication.format.ps1xml'
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 # NestedModules = @()

--- a/tools/BuildModule.ps1
+++ b/tools/BuildModule.ps1
@@ -7,7 +7,7 @@ Param(
     [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()][string] $ModuleVersion,
     [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()][string[]] $ReleaseNotes,
     [int] $ModulePreviewNumber = -1,
-    [string[]] $RequiredModules,
+    [hashtable[]] $RequiredModules,
     [switch] $EnableSigning
 )
 $ErrorActionPreference = "Stop"

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -33,10 +33,9 @@ if ($BetaGraphVersion) {
 }
 $ModulePrefix = "Microsoft.Graph"
 $ModulesOutputDir = Join-Path $PSScriptRoot "..\src\$GraphVersion\"
-$AuthenticationModule = "Microsoft.Graph.Authentication"
 $OpenApiDocOutput = Join-Path $OpenApiDocOutput $GraphVersion
 $ArtifactsLocation = Join-Path $PSScriptRoot "..\artifacts\$GraphVersion"
-
+$RequiredGraphModules = @()
 # PS Scripts
 $DownloadOpenApiDocPS1 = Join-Path $PSScriptRoot ".\DownloadOpenApiDoc.ps1" -Resolve
 $ManageGeneratedModulePS1 = Join-Path $PSScriptRoot ".\ManageGeneratedModule.ps1" -Resolve
@@ -53,10 +52,11 @@ if (-not (Test-Path $ArtifactsLocation)) {
 if (-not (Test-Path $ModuleMappingConfigPath)) {
     Write-Error "Module mapping file not be found: $ModuleMappingConfigPath."
 }
-
 # Install module locally in order to specify it as a dependency for other modules down the generation pipeline.
 # https://stackoverflow.com/questions/46216038/how-do-i-define-requiredmodules-in-a-powershell-module-manifest-psd1.
-Install-Module $AuthenticationModule -Repository $RepositoryName -AllowPrerelease -Force
+$ExistingAuthModule = Find-Module "Microsoft.Graph.Authentication"
+Install-Module $ExistingAuthModule.Name -Repository $RepositoryName -AllowPrerelease -Force
+$RequiredGraphModules += @{ ModuleName = $ExistingAuthModule.Name ; RequiredVersion = $ExistingAuthModule.Version }
 if ($UpdateAutoRest) {
     # Update AutoRest.
     & AutoRest-beta --reset
@@ -123,10 +123,10 @@ $ModuleMapping.Keys | ForEach-Object {
                 # Build generated module.
                 if ($EnableSigning) {
                     # Sign generated module.
-                    & $BuildModulePS1 -Module $ModuleName -ModulePrefix $ModulePrefix -GraphVersion $GraphVersion -ModuleVersion $ModuleVersion -ModulePreviewNumber $ModulePreviewNumber -RequiredModules $AuthenticationModule -ReleaseNotes $ModuleReleaseNotes -EnableSigning
+                    & $BuildModulePS1 -Module $ModuleName -ModulePrefix $ModulePrefix -GraphVersion $GraphVersion -ModuleVersion $ModuleVersion -ModulePreviewNumber $ModulePreviewNumber -RequiredModules $RequiredGraphModules -ReleaseNotes $ModuleReleaseNotes -EnableSigning
                 }
                 else {
-                    & $BuildModulePS1 -Module $ModuleName -ModulePrefix $ModulePrefix -GraphVersion $GraphVersion -ModuleVersion $ModuleVersion -ModulePreviewNumber $ModulePreviewNumber -RequiredModules $AuthenticationModule -ReleaseNotes $ModuleReleaseNotes
+                    & $BuildModulePS1 -Module $ModuleName -ModulePrefix $ModulePrefix -GraphVersion $GraphVersion -ModuleVersion $ModuleVersion -ModulePreviewNumber $ModulePreviewNumber -RequiredModules $RequiredGraphModules -ReleaseNotes $ModuleReleaseNotes
                 }
 
                 if ($LASTEXITCODE) {

--- a/tools/NuspecHelper.ps1
+++ b/tools/NuspecHelper.ps1
@@ -4,7 +4,7 @@ function Set-NuSpecValues(
     [parameter(Position=1,Mandatory=$true)][ValidateScript({Test-Path $_ -PathType Leaf})][string] $NuSpecFilePath,
     [parameter(Position=2,Mandatory=$true)][string] $VersionNumber,
     [parameter(Position=3,Mandatory=$true)][string] $IconUrl,
-    [parameter(Position=4)][string[]] $Dependencies,
+    [parameter(Position=4)][hashtable[]] $Dependencies,
     [parameter(Position=5)][string[]] $ReleaseNotes) {
     $XmlDocument = New-Object System.Xml.XmlDocument
     $XmlDocument.Load($NuSpecFilePath)
@@ -69,7 +69,7 @@ function Set-ElementValue(
 function Set-Dependencies(
     [System.Xml.XmlDocument] $XmlDocument,
     [System.Xml.XmlElement] $MetadataElement,
-    [string[]] $Dependencies) {
+    [hashtable[]] $Dependencies) {
     if(-not $MetadataElement["dependencies"]){
         $NewDependenciesElement = $XmlDocument.CreateElement("dependencies", $XmlDocument.DocumentElement.NamespaceURI)
         $MetadataElement.AppendChild($NewDependenciesElement)
@@ -79,7 +79,8 @@ function Set-Dependencies(
 
     foreach($Dependency in $Dependencies){
         $NewDependencyElement = $XmlDocument.CreateElement("dependency", $XmlDocument.DocumentElement.NamespaceURI)
-        $NewDependencyElement.SetAttribute("id", $Dependency)
+        $NewDependencyElement.SetAttribute("id", $Dependency.ModuleName)
+        $NewDependencyElement.SetAttribute("version", $Dependency.ModuleVersion ?? $Dependency.RequiredVersion)
 
         $MetadataElement["dependencies"].AppendChild($NewDependencyElement)
     }


### PR DESCRIPTION
This PR addresses issues that have been reported when running `Microsoft.Graph 0.5.0` on PowerShell 5.1.

Changes made:
- Update all ADO pipelines to use script variables instead of environment variables when generating modules.
- Specify dependency versions in module manifest.

Will fix #189, #187, #194   