### PR TITLE
Multi-thread GraphSession support

### DIFF
--- a/src/Authentication/Authentication.Test/Helpers/GraphSessionTests.cs
+++ b/src/Authentication/Authentication.Test/Helpers/GraphSessionTests.cs
@@ -38,11 +38,21 @@
             GraphSession.Initialize(() => new GraphSession());
             Guid originalSessionId = GraphSession.Instance._graphSessionId;
 
-            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => GraphSession.Initialize(() => new GraphSession()));
+            GraphSession.Initialize(() => new GraphSession());
 
-            Assert.Equal("An instance of GraphSession already exists. Call Initialize(Func<GraphSession>, bool) to overwrite it.", exception.Message);
             Assert.NotNull(GraphSession.Instance);
             Assert.Equal(originalSessionId, GraphSession.Instance._graphSessionId);
+
+            // reset static instance.
+            GraphSession.Reset();
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenSessionIsNotInitialized()
+        {
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => GraphSession.Instance);
+
+            Assert.Equal(ErrorConstants.Codes.SessionNotInitialized, exception.Message);
 
             // reset static instance.
             GraphSession.Reset();

--- a/src/Authentication/Authentication/Common/GraphSession.cs
+++ b/src/Authentication/Authentication/Common/GraphSession.cs
@@ -93,10 +93,6 @@ namespace Microsoft.Graph.PowerShell.Authentication
                         _instance = instanceCreator();
                         _initialized = true;
                     }
-                    else
-                    {
-                        throw new InvalidOperationException(string.Format(ErrorConstants.Message.InstanceExists, nameof(GraphSession), "Initialize(Func<GraphSession>, bool)"));
-                    }
                 }
                 finally
                 {

--- a/src/Authentication/Authentication/ErrorConstants.cs
+++ b/src/Authentication/Authentication/ErrorConstants.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Graph.PowerShell.Authentication
         {
             internal const string InvalidJWT = "Invalid JWT access token.";
             internal const string MissingAuthContext = "Authentication needed, call Connect-Graph.";
-            internal const string InstanceExists = "An instance of {0} already exists. Call {1} to overwrite it.";
             internal const string NullOrEmptyParameter = "Parameter '{0}' cannot be null or empty.";
             internal const string MacKeyChainFailed = "{0} failed with result code {1}.";
         }


### PR DESCRIPTION
As noted in #253, the current design of `GraphSession` only works for single-threaded scenarios, but throws an exception for multi-threaded scenarios. This PR updates authentication module by reusing the existing session object, if one is found, as opposed to throwing an exception. The session object will only be initialized once `OnImport`, and subsequent calls will reuse the previously instantiated session.