### PR TITLE
IGR Error Fixes

### DIFF
--- a/src/Authentication/Authentication/Cmdlets/InvokeGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeGraphRequest.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     {
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly InvokeGraphRequestUserAgent _graphRequestUserAgent;
+        private readonly GraphSession _graphSession;
         private string _originalFilePath;
 
         public InvokeGraphRequest()
@@ -32,6 +33,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             _cancellationTokenSource = new CancellationTokenSource();
             _graphRequestUserAgent = new InvokeGraphRequestUserAgent(this);
             Authentication = GraphRequestAuthenticationType.Default;
+            _graphSession = GraphSession.Instance;
         }
 
         /// <summary>
@@ -69,7 +71,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             ParameterSetName = Constants.UserParameterSet,
             Position = 4,
             HelpMessage = "Optional Custom Headers")]
-        public IDictionary<string, string> Headers { get; set; }
+        public IDictionary Headers { get; set; }
 
         /// <summary>
         ///     Relative or absolute path where the response body will be saved.
@@ -248,28 +250,46 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
         /// <summary>
         ///     When -Verbose is specified, print out response status
         /// </summary>
-        /// <param name="requestMessage"></param>
-        private void ReportRequestStatus(HttpRequestMessage requestMessage)
+        /// <param name="requestMessageFormatter"></param>
+        private void ReportRequestStatus(HttpMessageFormatter requestMessageFormatter)
         {
+            requestMessageFormatter.LoadIntoBufferAsync()
+                .GetAwaiter()
+                .GetResult();
+            var requestMessage = requestMessageFormatter.HttpRequestMessage;
             var requestContentLength = requestMessage.Content?.Headers.ContentLength.Value ?? 0;
-
             var reqVerboseMsg = Resources.InvokeGraphRequestVerboseMessage.FormatCurrentCulture(requestMessage.Method,
                 requestMessage.RequestUri,
                 requestContentLength);
+            // If Verbose is specified, will print out Uri and Content Length
             WriteVerbose(reqVerboseMsg);
+            var requestString = requestMessageFormatter.ReadAsStringAsync()
+                .GetAwaiter()
+                .GetResult();
+            // If Debug is Specified, will print out the Http Request as a string
+            WriteDebug(requestString);
         }
 
         /// <summary>
         ///     When -Verbose is specified, print out response status
         /// </summary>
-        /// <param name="responseMessage"></param>
-        private void ReportResponseStatus(HttpResponseMessage responseMessage)
+        /// <param name="responseMessageFormatter"></param>
+        private void ReportResponseStatus(HttpMessageFormatter responseMessageFormatter)
         {
-            var contentType = responseMessage.GetContentType();
+            responseMessageFormatter.LoadIntoBufferAsync()
+                .GetAwaiter()
+                .GetResult();
+            var contentType = responseMessageFormatter.HttpResponseMessage.GetContentType();
             var respVerboseMsg = Resources.InvokeGraphResponseVerboseMessage.FormatCurrentCulture(
-                responseMessage.Content.Headers.ContentLength,
+                responseMessageFormatter.HttpResponseMessage.Content.Headers.ContentLength,
                 contentType);
+            // If Verbose is specified, will print out Uri and Content Length
             WriteVerbose(respVerboseMsg);
+            var responseString = responseMessageFormatter.ReadAsStringAsync()
+                .GetAwaiter()
+                .GetResult();
+            // If Debug is Specified, will print out the Http Response as a string
+            WriteDebug(responseString);
         }
 
         /// <summary>
@@ -347,13 +367,14 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             if (Method == GraphRequestMethod.GET && LanguagePrimitives.TryConvertTo(Body, out IDictionary bodyAsDictionary))
             {
                 var uriBuilder = new UriBuilder(uri);
-                if (uriBuilder.Query != null && uriBuilder.Query.Length > 1)
+                var bodyQueryParameters = bodyAsDictionary?.FormatDictionary();
+                if (uriBuilder.Query != null && uriBuilder.Query.Length > 1 && !string.IsNullOrWhiteSpace(bodyQueryParameters))
                 {
-                    uriBuilder.Query = uriBuilder.Query.Substring(1) + "&" + bodyAsDictionary.FormatDictionary();
+                    uriBuilder.Query = uriBuilder.Query.Substring(1) + "&" + bodyQueryParameters;
                 }
-                else if (bodyAsDictionary != null)
+                else if (!string.IsNullOrWhiteSpace(bodyQueryParameters))
                 {
-                    uriBuilder.Query = bodyAsDictionary.FormatDictionary();
+                    uriBuilder.Query = bodyQueryParameters;
                 }
 
                 uri = uriBuilder.Uri;
@@ -411,14 +432,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
 
                     // NOTE: Tests use this verbose output to verify the encoding.
                     WriteVerbose(Resources.ContentEncodingVerboseMessage.FormatCurrentCulture(encodingVerboseName));
-                    var convertSuccess = str.TryConvert<Hashtable>(out var obj, ref ex);
-                    if (!convertSuccess)
-                    {
-                        // fallback to string
-                        obj = str;
-                    }
-
-                    WriteObject(obj);
+                    WriteObject(str.TryConvertToJson(out var obj, ref ex) ? obj : str);
                 }
             }
 
@@ -470,8 +484,17 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             {
                 return new InvokeGraphRequestAuthProvider(GraphRequestSession);
             }
-
-            return AuthenticationHelpers.GetAuthProvider(GraphSession.Instance.AuthContext);
+            // Ensure that AuthContext is present in DefaultAuth mode, otherwise demand for Connect-Graph to be called.
+            if (Authentication == GraphRequestAuthenticationType.Default && this._graphSession.AuthContext != null)
+            {
+                return AuthenticationHelpers.GetAuthProvider(_graphSession.AuthContext);
+            }
+            else
+            {
+                var error = new ArgumentNullException(Resources.MissingAuthenticationContext.FormatCurrentCulture(nameof(this._graphSession.AuthContext)),
+                    nameof(this._graphSession.AuthContext));
+                throw error;
+            }
         }
 
         /// <summary>
@@ -768,7 +791,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             // Store the other supplied headers
             if (Headers != null)
             {
-                foreach (var key in Headers.Keys)
+                foreach (string key in Headers.Keys)
                 {
                     var value = Headers[key];
 
@@ -777,7 +800,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                     if (!(value is null))
                     {
                         // add the header value (or overwrite it if already present)
-                        GraphRequestSession.Headers[key] = value;
+                        GraphRequestSession.Headers[key] = value.ToString();
                     }
                 }
             }
@@ -854,6 +877,14 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             {
                 var error = GetValidationError(
                     Resources.AuthenticationTokenConflict.FormatCurrentCulture(Authentication, nameof(Token)),
+                    Errors.InvokeGraphRequestAuthenticationTokenConflictException);
+                ThrowTerminatingError(error);
+            }
+
+            if (Authentication == GraphRequestAuthenticationType.Default && this._graphSession.AuthContext == null)
+            {
+                var error = GetValidationError(
+                    Resources.NotConnectedToGraphException.FormatCurrentCulture(Authentication, nameof(Token)),
                     Errors.InvokeGraphRequestAuthenticationTokenConflictException);
                 ThrowTerminatingError(error);
             }
@@ -1012,11 +1043,11 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                             FillRequestStream(httpRequestMessage);
                             try
                             {
-                                ReportRequestStatus(httpRequestMessageFormatter.HttpRequestMessage);
+                                ReportRequestStatus(httpRequestMessageFormatter);
                                 var httpResponseMessage = GetResponse(client, httpRequestMessage);
                                 using (var httpResponseMessageFormatter = new HttpMessageFormatter(httpResponseMessage))
                                 {
-                                    ReportResponseStatus(httpResponseMessageFormatter.HttpResponseMessage);
+                                    ReportResponseStatus(httpResponseMessageFormatter);
                                     var isSuccess = httpResponseMessage.IsSuccessStatusCode;
                                     if (ShouldCheckHttpStatus && !isSuccess)
                                     {

--- a/src/Authentication/Authentication/Cmdlets/InvokeGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeGraphRequest.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     {
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly InvokeGraphRequestUserAgent _graphRequestUserAgent;
-        private readonly GraphSession _graphSession;
         private string _originalFilePath;
 
         public InvokeGraphRequest()
@@ -33,7 +32,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             _cancellationTokenSource = new CancellationTokenSource();
             _graphRequestUserAgent = new InvokeGraphRequestUserAgent(this);
             Authentication = GraphRequestAuthenticationType.Default;
-            _graphSession = GraphSession.Instance;
         }
 
         /// <summary>
@@ -485,14 +483,14 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                 return new InvokeGraphRequestAuthProvider(GraphRequestSession);
             }
             // Ensure that AuthContext is present in DefaultAuth mode, otherwise demand for Connect-Graph to be called.
-            if (Authentication == GraphRequestAuthenticationType.Default && this._graphSession.AuthContext != null)
+            if (Authentication == GraphRequestAuthenticationType.Default && GraphSession.Instance.AuthContext != null)
             {
-                return AuthenticationHelpers.GetAuthProvider(_graphSession.AuthContext);
+                return AuthenticationHelpers.GetAuthProvider(GraphSession.Instance.AuthContext);
             }
             else
             {
-                var error = new ArgumentNullException(Resources.MissingAuthenticationContext.FormatCurrentCulture(nameof(this._graphSession.AuthContext)),
-                    nameof(this._graphSession.AuthContext));
+                var error = new ArgumentNullException(Resources.MissingAuthenticationContext.FormatCurrentCulture(nameof(GraphSession.Instance.AuthContext)),
+                    nameof(GraphSession.Instance.AuthContext));
                 throw error;
             }
         }
@@ -881,7 +879,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                 ThrowTerminatingError(error);
             }
 
-            if (Authentication == GraphRequestAuthenticationType.Default && this._graphSession.AuthContext == null)
+            if (Authentication == GraphRequestAuthenticationType.Default && GraphSession.Instance.AuthContext == null)
             {
                 var error = GetValidationError(
                     Resources.NotConnectedToGraphException.FormatCurrentCulture(Authentication, nameof(Token)),

--- a/src/Authentication/Authentication/Helpers/Errors.cs
+++ b/src/Authentication/Authentication/Helpers/Errors.cs
@@ -19,5 +19,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         public const string InvokeGraphRequestInputFileMultiplePathsResolvedException = nameof(InvokeGraphRequestInputFileMultiplePathsResolvedException);
         public const string InvokeGraphRequestInputFileNoPathResolvedException = nameof(InvokeGraphRequestInputFileNoPathResolvedException);
         public const string InvokeGraphRequestInputFileNotFilePathException = nameof(InvokeGraphRequestInputFileNotFilePathException);
+        public const string InvokeGraphRequestMissingAuthenticationContext = nameof(InvokeGraphRequestMissingAuthenticationContext);
     }
 }

--- a/src/Authentication/Authentication/Helpers/StringUtil.cs
+++ b/src/Authentication/Authentication/Helpers/StringUtil.cs
@@ -2,12 +2,13 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
-
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.Graph.PowerShell.Authentication.Properties;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -71,12 +72,12 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         /// <param name="obj"></param>
         /// <param name="exRef"></param>
         /// <returns></returns>
-        internal static bool TryConvert<T>(this string jsonString, out object obj, ref Exception exRef)
+        internal static bool TryConvertToJson(this string jsonString, out object obj, ref Exception exRef)
         {
             var converted = false;
             try
             {
-                obj = JsonConvert.DeserializeObject<T>(jsonString);
+                obj = jsonString.ConvertFromJson(exception: out exRef);
                 if (obj == null)
                 {
                     JToken.Parse(jsonString);
@@ -99,6 +100,150 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
             }
 
             return converted;
+        }
+
+        internal static object ConvertFromJson(this string jsonString, out Exception exception, int maxDepth = 1024)
+        {
+            if (jsonString == null)
+            {
+                throw new ArgumentNullException(nameof(jsonString));
+            }
+            exception = null;
+            try
+            {
+                // If input starts with '[' (ignoring white spaces).
+                if (Regex.Match(jsonString, @"^\s*\[").Success)
+                {
+                    // JArray.Parse() will throw a JsonException if the array is invalid.
+                    // This will be caught by the catch block below, and then throw an
+                    // ArgumentException - this is done to have same behavior as the JavaScriptSerializer.
+                    JArray.Parse(jsonString);
+
+                    // Please note that if the Json array is valid, we don't do anything,
+                    // we just continue the deserialization.
+                }
+                var obj = JsonConvert.DeserializeObject(jsonString,
+                    new JsonSerializerSettings
+                    {
+                        TypeNameHandling = TypeNameHandling.None,
+                        MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
+                        MaxDepth = maxDepth
+                    });
+
+                switch (obj)
+                {
+                    case JObject dictionary:
+                        // JObject is a IDictionary
+                        return PopulateHashTableFromJDictionary(dictionary, out exception);
+                    case JArray list:
+                        return PopulateHashTableFromJArray(list, out exception);
+                    default:
+                        return obj;
+                }
+            }
+            catch (JsonException ex)
+            {
+                var msg = Resources.JsonSerializationFailed.FormatCurrentCulture(ex.Message);
+                throw new ArgumentException(msg, ex);
+            }
+        }
+
+        private static ICollection<object> PopulateHashTableFromJArray(JArray list, out Exception exception)
+        {
+            exception = null;
+            var result = new object[list.Count];
+
+            for (var index = 0; index < list.Count; index++)
+            {
+                var element = list[index];
+
+                switch (element)
+                {
+                    case JArray array:
+                        {
+                            // Array
+                            var listResult = PopulateHashTableFromJArray(array, out exception);
+                            if (exception != null)
+                            {
+                                return null;
+                            }
+
+                            result[index] = listResult;
+                            break;
+                        }
+                    case JObject dic:
+                        {
+                            // Dictionary
+                            var dicResult = PopulateHashTableFromJDictionary(dic, out exception);
+                            if (exception != null)
+                            {
+                                return null;
+                            }
+
+                            result[index] = dicResult;
+                            break;
+                        }
+                    case JValue value:
+                        {
+                            result[index] = value.Value;
+                            break;
+                        }
+                }
+            }
+
+            return result;
+        }
+
+        private static Hashtable PopulateHashTableFromJDictionary(JObject entries, out Exception exception)
+        {
+            exception = null;
+            Hashtable result = new Hashtable(entries.Count);
+            foreach (var entry in entries)
+            {
+                // Case sensitive duplicates should normally not occur since JsonConvert.DeserializeObject
+                // does not throw when encountering duplicates and just uses the last entry.
+                if (result.ContainsKey(entry.Key))
+                {
+                    string errorMsg = Resources.DuplicateKeysInJsonString.FormatCurrentCulture(entry.Key);
+                    exception = new InvalidOperationException(errorMsg);
+                    return null;
+                }
+
+                switch (entry.Value)
+                {
+                    case JArray list:
+                        {
+                            // Array
+                            var listResult = PopulateHashTableFromJArray(list, out exception);
+                            if (exception != null)
+                            {
+                                return null;
+                            }
+
+                            result.Add(entry.Key, listResult);
+                            break;
+                        }
+                    case JObject dic:
+                        {
+                            // Dictionary
+                            var dicResult = PopulateHashTableFromJDictionary(dic, out exception);
+                            if (exception != null)
+                            {
+                                return null;
+                            }
+
+                            result.Add(entry.Key, dicResult);
+                            break;
+                        }
+                    case JValue value:
+                        {
+                            result.Add(entry.Key, value.Value);
+                            break;
+                        }
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/Authentication/Authentication/Properties/Resources.Designer.cs
+++ b/src/Authentication/Authentication/Properties/Resources.Designer.cs
@@ -133,6 +133,15 @@ namespace Microsoft.Graph.PowerShell.Authentication.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot convert the JSON string because a dictionary that was converted from the string contains the duplicated key &apos;{0}&apos;..
+        /// </summary>
+        internal static string DuplicateKeysInJsonString {
+            get {
+                return ResourceManager.GetString("DuplicateKeysInJsonString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The cmdlet cannot run because the following conflicting parameters are specified: GraphRequestSession and SessionVariable. Specify either GraphRequestSession or SessionVariable, then retry..
         /// </summary>
         internal static string GraphRequestSessionConflict {
@@ -232,6 +241,15 @@ namespace Microsoft.Graph.PowerShell.Authentication.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The cmdlet cannot run because {0} is missing and &apos;Authentication&apos; is set to &apos;Default&apos;. Please call &apos;Connect-Graph&apos; then try again..
+        /// </summary>
+        internal static string MissingAuthenticationContext {
+            get {
+                return ResourceManager.GetString("MissingAuthenticationContext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Path &apos;{0}&apos; can be resolved to multiple paths..
         /// </summary>
         internal static string MultiplePathsResolved {
@@ -246,6 +264,15 @@ namespace Microsoft.Graph.PowerShell.Authentication.Properties {
         internal static string NoPathResolved {
             get {
                 return ResourceManager.GetString("NoPathResolved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The cmdlet cannot run because Authentication is set to {0} and Connect-Graph was not called. Invoke &apos;Connect-Graph&apos; or specify Authentication to be &apos;UserProvidedToken&apos; and Provide a Token then retry.
+        /// </summary>
+        internal static string NotConnectedToGraphException {
+            get {
+                return ResourceManager.GetString("NotConnectedToGraphException", resourceCulture);
             }
         }
         

--- a/src/Authentication/Authentication/Properties/Resources.resx
+++ b/src/Authentication/Authentication/Properties/Resources.resx
@@ -196,4 +196,13 @@
   <data name="InferFileNameOutFilePathConflict" xml:space="preserve">
     <value>The cmdlet cannot run because the following conflicting parameters are specified: {0} and {1}. Specify either {0} or {1} then retry.</value>
   </data>
+  <data name="NotConnectedToGraphException" xml:space="preserve">
+    <value>The cmdlet cannot run because Authentication is set to {0} and Connect-Graph was not called. Invoke 'Connect-Graph' or specify Authentication to be 'UserProvidedToken' and Provide a Token then retry</value>
+  </data>
+  <data name="DuplicateKeysInJsonString" xml:space="preserve">
+    <value>Cannot convert the JSON string because a dictionary that was converted from the string contains the duplicated key '{0}'.</value>
+  </data>
+  <data name="MissingAuthenticationContext" xml:space="preserve">
+    <value>The cmdlet cannot run because {0} is missing and 'Authentication' is set to 'Default'. Please call 'Connect-Graph' then try again.</value>
+  </data>
 </root>


### PR DESCRIPTION
Ensure that Connect-Graph has been prior called before IGR is called.
Change Headers to non-generic Dictionary.
Traverse nested json.
Add resource messages for error messages.
Provide ability to pass relative URL as well as query params.

fixes #296