### PR TITLE
Auth Module Dependencies

### DIFF
--- a/src/Authentication/Authentication/Helpers/ContentHelper.cs
+++ b/src/Authentication/Authentication/Helpers/ContentHelper.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                          || CheckIsJson(contentType);
 
             // Further content type analysis is available on Windows
-            if (Platform.IsWindows && !isText)
+            if (OperatingSystem.IsWindows() && !isText)
             {
                 // Media types registered with Windows as having a perceived type of text, are text
                 using (var contentTypeKey = Registry.ClassesRoot.OpenSubKey(@"MIME\Database\Content Type\" + contentType))

--- a/src/Authentication/Authentication/Helpers/InvokeGraphRequestUserAgent.cs
+++ b/src/Authentication/Authentication/Helpers/InvokeGraphRequestUserAgent.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         {
             get
             {
-                if (Platform.IsWindows)
+                if (OperatingSystem.IsWindows())
                 {
                     // only generate the windows user agent once
                     if (_windowsUserAgent == null)
@@ -69,11 +69,11 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
 
                     return _windowsUserAgent;
                 }
-                else if (Platform.IsMacOS)
+                else if (OperatingSystem.IsMacOS())
                 {
                     return "Macintosh";
                 }
-                else if (Platform.IsLinux)
+                else if (OperatingSystem.IsLinux())
                 {
                     return "Linux";
                 }

--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.csproj
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.6.0" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="5.6.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.6.0" />
-    <PackageReference Include="Microsoft.PowerShell.Commands.Utility" Version="6.0.4" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />


### PR DESCRIPTION
Remove Microsoft.PowerShell.Commands.Utility  since it doesn't work in PS5. 
Remove references to Microsoft.PowerShell.Commands.Utility, and migrate to Platform helpers. 

#325