### PR TITLE
Handle Dictionaries as Json and Powershell 5.0 GET Requests shouldn't have bodies.

### DIFF
--- a/src/Authentication/Authentication/Cmdlets/InvokeGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeGraphRequest.cs
@@ -16,6 +16,8 @@ using Microsoft.Graph.PowerShell.Authentication.Models;
 using Microsoft.Graph.PowerShell.Authentication.Properties;
 using Microsoft.PowerShell.Commands;
 
+using Newtonsoft.Json;
+
 using DriveNotFoundException = System.Management.Automation.DriveNotFoundException;
 
 namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
@@ -552,7 +554,10 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
         }
 
         /// <summary>
-        ///     Set the request content
+        ///     Set the request content.
+        ///     Convert Dictionaries to Json
+        ///     Passing a dictionary to the body object should be translated to Json.
+        ///     Almost everything on Microsoft Graph works converts dictionaries and arrays to JSON.
         /// </summary>
         /// <param name="request"></param>
         /// <param name="content"></param>
@@ -568,8 +573,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             {
                 throw new ArgumentNullException(nameof(content));
             }
-
-            var body = content.FormatDictionary();
+            // Covert all dictionaries to Json
+            var body = JsonConvert.SerializeObject(content);
             return SetRequestContent(request, body);
         }
 
@@ -668,6 +673,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                 {
                     content = psBody.BaseObject;
                 }
+                // Passing a dictionary to the body object should be translated to Json.
+                // Almost everything on Microsoft Graph works converts dictionaries and arrays to JSON.
                 if (content is IDictionary dictionary && request.Method != HttpMethod.Get)
                 {
                     SetRequestContent(request, dictionary);
@@ -703,14 +710,15 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             }
 
             // Add the content headers
-            if (request.Content == null)
+            // Only Set Content Headers when its not a GET Request
+            if (request.Content == null && this.Method != GraphRequestMethod.GET)
             {
                 request.Content = new StringContent(string.Empty);
                 request.Content.Headers.Clear();
             }
 
             foreach (var entry in GraphRequestSession.ContentHeaders.Where(header =>
-                !string.IsNullOrWhiteSpace(header.Value)))
+                    !string.IsNullOrWhiteSpace(header.Value)))
             {
                 if (SkipHeaderValidation)
                 {
@@ -724,7 +732,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                     }
                     catch (FormatException ex)
                     {
-                        var outerEx = new ValidationMetadataException(Resources.ContentTypeExceptionErrorMessage, ex);
+                        var outerEx =
+                            new ValidationMetadataException(Resources.ContentTypeExceptionErrorMessage, ex);
                         var er = new ErrorRecord(outerEx, Errors.InvokeGraphContentTypeException,
                             ErrorCategory.InvalidArgument, ContentType);
                         ThrowTerminatingError(er);


### PR DESCRIPTION
Powershell 5.0 does not allow GET Requests to have bodies.
https://github.com/PowerShell/PowerShell/issues/2054
Parse HashTables as Json, to enable requests to be made in the following structure. 
![image](https://user-images.githubusercontent.com/1641829/90042264-1f538980-dcd3-11ea-8092-8861ec204bc4.png)
Correctly serialized as shown below 
![image](https://user-images.githubusercontent.com/1641829/90042755-c3d5cb80-dcd3-11ea-8253-616e759e2866.png)
