### PR TITLE
Allow content to be null for GET Requests (#332)

### DIFF
--- a/src/Authentication/Authentication/Cmdlets/InvokeGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeGraphRequest.cs
@@ -722,13 +722,13 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             {
                 if (SkipHeaderValidation)
                 {
-                    request.Content.Headers.TryAddWithoutValidation(entry.Key, entry.Value);
+                    request.Content?.Headers.TryAddWithoutValidation(entry.Key, entry.Value);
                 }
                 else
                 {
                     try
                     {
-                        request.Content.Headers.Add(entry.Key, entry.Value);
+                        request.Content?.Headers.Add(entry.Key, entry.Value);
                     }
                     catch (FormatException ex)
                     {


### PR DESCRIPTION
* Powershell 5.0 does not allow GET Requests to have bodies.
Parse HashTables as Json.

* Null check for Content during Get Requests.

Co-authored-by: George