### PR TITLE
0.9.1 Pipeline Fixes

### DIFF
--- a/.azure-pipelines/generate-auth-module.yml
+++ b/.azure-pipelines/generate-auth-module.yml
@@ -36,7 +36,7 @@ jobs:
     displayName: 'Generate and Build Auth Module'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1'
-      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory) -Build -EnableSigning'
+      arguments: '-ArtifactsLocation $(Build.ArtifactStagingDirectory) -Build -EnableSigning'
       pwsh: true
 
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1

--- a/.azure-pipelines/generate-beta-modules.yml
+++ b/.azure-pipelines/generate-beta-modules.yml
@@ -9,20 +9,19 @@ trigger:
     - master
   paths:
     include:
-    - src/Beta/*
+    - src/*
     - config/ModulesMapping.jsonc
 pr: none
 variables:
   MODULE_PREFIX: 'Microsoft.Graph'
-  WORKLOAD_MODULE_PATH: 'src\beta\'
-  GRAPH_VERSION: 'beta'
+  WORKLOAD_MODULE_PATH: 'src\'
   AUTH_MODULE_PATH: 'src\Authentication\Authentication\bin\'
   AUTH_MODULE_DLL_PATTERN: 'Microsoft.Graph.Authentication.dll'
 
 jobs:
 - job: MSGraphPSSDKGeneration
   displayName: MS Graph PS SDK Beta Generation
-  timeoutInMinutes: 600
+  timeoutInMinutes: 800
   pool:
     name: Microsoft Graph
     demands: 'Agent.Name -equals PS-Build-Agent'
@@ -132,7 +131,7 @@ jobs:
     displayName: 'Generate and Build Graph Resource Modules'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1'
-      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\ -Build -EnableSigning'
+      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\ -Build -EnableSigning'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
@@ -166,7 +165,7 @@ jobs:
     inputs:
       ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet'
       FolderPath: $(WORKLOAD_MODULE_PATH)
-      Pattern: '$(MODULE_PREFIX).*.private.dll, $(MODULE_PREFIX).*.psm1, $(MODULE_PREFIX).*.format.ps1xml, *.ps1'
+      Pattern: '$(MODULE_PREFIX).*.private.dll, $(MODULE_PREFIX).*.psm1, $(MODULE_PREFIX).*.format.ps1xml, ProxyCmdletDefinitions.ps1, load-dependency.ps1'
       signConfigType: inlineSignParams
       inlineOperation: |
        [
@@ -217,8 +216,8 @@ jobs:
         [HashTable] $ModuleMapping = Get-Content $ModuleMappingConfigPath | ConvertFrom-Json -AsHashTable
         $ModuleMapping.Keys | ForEach-Object {
             $ModuleName = $_
-            $ModuleProjectDir = "$(System.DefaultWorkingDirectory)/src/$(GRAPH_VERSION)/$ModuleName/$ModuleName"
-            & $(System.DefaultWorkingDirectory)/tools/PackModule.ps1 -Module $ModuleName -GraphVersion $(GRAPH_VERSION) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\
+            $ModuleProjectDir = "$(System.DefaultWorkingDirectory)/src/$ModuleName/$ModuleName"
+            & $(System.DefaultWorkingDirectory)/tools/PackModule.ps1 -Module $ModuleName -ArtifactsLocation $(Build.ArtifactStagingDirectory)\
         }
       pwsh: true
   
@@ -226,7 +225,7 @@ jobs:
     displayName: 'ESRP NuGet CodeSigning'
     inputs:
       ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet'
-      FolderPath: '$(Build.ArtifactStagingDirectory)\$(GRAPH_VERSION)\'
+      FolderPath: '$(Build.ArtifactStagingDirectory)\'
       Pattern: '*.nupkg'
       signConfigType: inlineSignParams
       inlineOperation: |
@@ -251,7 +250,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: Publish Artifact Beta Modules
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)/$(GRAPH_VERSION)'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)/'
       ArtifactName: 'drop'
       publishLocation: 'Container'
 

--- a/.azure-pipelines/generate-beta-modules.yml
+++ b/.azure-pipelines/generate-beta-modules.yml
@@ -6,11 +6,13 @@ name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 trigger:
   branches:
     include:
-    - master
+      - master
   paths:
     include:
-    - src/*
-    - config/ModulesMapping.jsonc
+      - src/*
+      - config/ModulesMapping.jsonc
+    exclude:
+      - src/Authentication/*
 pr: none
 variables:
   MODULE_PREFIX: 'Microsoft.Graph'
@@ -51,7 +53,7 @@ jobs:
     displayName: 'Build Auth Modules'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1'
-      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory) -Build -BuildWhenEqual -EnableSigning'
+      arguments: '-ArtifactsLocation $(Build.ArtifactStagingDirectory) -Build -BuildWhenEqual -EnableSigning'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
@@ -131,7 +133,7 @@ jobs:
     displayName: 'Generate and Build Graph Resource Modules'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1'
-      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)\ -Build -EnableSigning'
+      arguments: '-ArtifactsLocation $(Build.ArtifactStagingDirectory)\ -Build -EnableSigning'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1

--- a/.azure-pipelines/generate-beta-rollup-module.yml
+++ b/.azure-pipelines/generate-beta-rollup-module.yml
@@ -7,9 +7,8 @@ trigger: none
 pr: none
 variables:
   MODULE_PREFIX: 'Microsoft.Graph'
-  GRAPH_VERSION: 'beta'
   MODULE_NAME: 'Graph'
-  MODULE_PATH: 'src/Beta/Graph/Graph'
+  MODULE_PATH: 'src/Graph/Graph'
 
 jobs:
 - job: MSGraphPSSDKGeneration
@@ -31,7 +30,7 @@ jobs:
     displayName: 'Generate and Build Roll-Up Module'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateRollUpModule.ps1'
-      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)/$(GRAPH_VERSION)/'
+      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
@@ -87,14 +86,14 @@ jobs:
       command: 'pack'
       Configuration: Release
       packagesToPack: '$(System.DefaultWorkingDirectory)/$(MODULE_PATH)/$(MODULE_PREFIX).nuspec'
-      packDestination: '$(Build.ArtifactStagingDirectory)/$(GRAPH_VERSION)/'
+      packDestination: '$(Build.ArtifactStagingDirectory)/'
       versioningScheme: 'off'
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'ESRP NuGet CodeSigning'
     inputs:
       ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet'
-      FolderPath: '$(Build.ArtifactStagingDirectory)/$(GRAPH_VERSION)/'
+      FolderPath: '$(Build.ArtifactStagingDirectory)/'
       Pattern: 'Microsoft.Graph*.nupkg'
       signConfigType: inlineSignParams
       inlineOperation: |
@@ -119,7 +118,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: Publish Artifact Microsoft.Graph.nupkg'
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)/$(GRAPH_VERSION)'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)/'
       ArtifactName: 'drop'
       publishLocation: 'Container'
 

--- a/.azure-pipelines/generate-beta-rollup-module.yml
+++ b/.azure-pipelines/generate-beta-rollup-module.yml
@@ -30,7 +30,6 @@ jobs:
     displayName: 'Generate and Build Roll-Up Module'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateRollUpModule.ps1'
-      arguments: '-RepositoryApiKey $(Api_Key) -ArtifactsLocation $(Build.ArtifactStagingDirectory)'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1

--- a/tools/GenerateAuthenticationModule.ps1
+++ b/tools/GenerateAuthenticationModule.ps1
@@ -42,7 +42,7 @@ if ($null -eq $ManifestContent.ModuleVersion) {
 [VersionState]$VersionState = & $ValidateUpdatedModuleVersionPS1 -ModuleName "$ModulePrefix.$ModuleName" -NextVersion $ManifestContent.ModuleVersion
 
 if ($VersionState.Equals([VersionState]::Invalid)) {
-  Write-Error "The specified version in $ModulePrefix.$ModuleName module is either higher or lower than what's on $RepositoryName. Update 'ModuleVersion' in $AuthModulePath$AuthModuleManifest."
+  Write-Warning "The specified version in $ModulePrefix.$ModuleName module is either higher or lower than what's on $RepositoryName. Update 'ModuleVersion' in $AuthModulePath$AuthModuleManifest."
 }
 elseif ($VersionState.Equals([VersionState]::EqualToFeed) -and !$BuildWhenEqual) {
   Write-Warning "$ModulePrefix.$ModuleName module skipped. Version has not changed and is equal to what's on $RepositoryName."

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -82,7 +82,7 @@ $ModuleMapping.Keys | ForEach-Object -Begin { $RequestCount = 0 } -End { Write-H
     [VersionState]$VersionState = & $ValidateUpdatedModuleVersionPS1 -ModuleName "$ModulePrefix.$ModuleName" -NextVersion $ModuleVersion
 
     if ($VersionState.Equals([VersionState]::Invalid) -and !$SkipVersionCheck) {
-        Write-Error "The specified version in $ModulePrefix.$ModuleName module is either higher or lower than what's on $RepositoryName. Update the 'module-version' in $ModuleLevelReadMePath"
+        Write-Warning "The specified version in $ModulePrefix.$ModuleName module is either higher or lower than what's on $RepositoryName. Update the 'module-version' in $ModuleLevelReadMePath"
     }
     elseif ($VersionState.Equals([VersionState]::EqualToFeed) -and !$SkipVersionCheck) {
         Write-Warning "$ModulePrefix.$ModuleName module skipped. Version has not changed and is equal to what's on $RepositoryName."

--- a/tools/GenerateRollUpModule.ps1
+++ b/tools/GenerateRollUpModule.ps1
@@ -50,7 +50,7 @@ if ($null -eq $NuspecMetadata["version"]) {
 [VersionState]$VersionState = & $ValidateUpdatedModuleVersionPS1 -ModuleName $ModulePrefix -NextVersion $NuspecMetadata["version"]
 
 if ($VersionState.Equals([VersionState]::Invalid)) {
-    Write-Error "The specified version in $ModulePrefix module is either higher or lower than what's on $RepositoryName. Update 'version' in $ModuleMetadataJson."
+    Write-Warning "The specified version in $ModulePrefix module is either higher or lower than what's on $RepositoryName. Update 'version' in $ModuleMetadataJson."
 }
 elseif ($VersionState.Equals([VersionState]::EqualToFeed)) {
     Write-Warning "$ModulePrefix module skipped. Version has not changed and is equal to what's on $RepositoryName."


### PR DESCRIPTION
This PR address some of the pipeline issues that we experienced during the release on 0.9.1.
- Fixes broken paths in the pipeline scripts since we now generate each service version as a profile.
- Updates signing script to only sign the bare-minimum number of files. This reduces the current signing time from ~3+ hours to ~40 minutes.
![image](https://user-images.githubusercontent.com/7061532/90423627-a73de880-e071-11ea-9314-fd8605a088e8.png)
