### PR TITLE
0.9.1 bug fixes

### DIFF
--- a/src/Financials/Financials/readme.md
+++ b/src/Financials/Financials/readme.md
@@ -58,6 +58,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 0.9.0
+module-version: 0.9.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Financials/Financials/readme.md
+++ b/src/Financials/Financials/readme.md
@@ -32,6 +32,29 @@ title: $(service-name)
 subject-prefix: ''
 
 ```
+
+### Directives
+
+> see https://github.com/Azure/autorest/blob/master/docs/powershell/directives.md
+
+``` yaml
+directive:
+# Modify generated .dictionary.cs model classes in Financials module.
+  - from: source-file-csharp
+    where: $
+    transform: >
+      if (!$documentPath.match(/generated%5Capi%5CModels%5CMicrosoftGraph\w*\d*.dictionary.cs/gm))
+      {
+        return $;
+      } else {
+        // Rename additionalProperties indexer name in Financials module from Item to EntityItem to avoid property name conflict. salesOrderLine has a property named item.
+        // See https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/indexers/using-indexers
+        let indexerRegex = /(^\s*)(public\s*global::System.Object this\[global::System.String index\]\s*{\W.*}$)/gm
+        $ = $.replace(indexerRegex, '$1[System.Runtime.CompilerServices.IndexerName("EntityItem")]\n$1$2');
+        return $;
+      }
+```
+
 ### Versioning
 
 ``` yaml

--- a/src/Identity.Organization/Identity.Organization/readme.md
+++ b/src/Identity.Organization/Identity.Organization/readme.md
@@ -44,6 +44,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 0.9.0
+module-version: 0.9.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Teams.Team/Teams.Team/readme.md
+++ b/src/Teams.Team/Teams.Team/readme.md
@@ -45,6 +45,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 0.9.0
+module-version: 0.9.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -361,7 +361,7 @@ directive:
       subject: (Application|ServicePrincipal)SynchronizationJobCredentials
       variant: Validate1|ValidateExpanded1|ValidateViaIdentity1|ValidateViaIdentityExpanded1
     remove: true
-# Add AfterToJson
+# Modify generated .json.cs model classes.
   - from: source-file-csharp
     where: $
     transform: >
@@ -369,12 +369,18 @@ directive:
       {
         return $;
       } else {
+        // Add AfterToJson
         let afterJsonDeclarationRegex = /(^\s*)(partial\s*void\s*AfterFromJson\s*\(Microsoft.Graph.PowerShell.Runtime.Json.JsonObject\s*json\s*\);$)/gm
         $ = $.replace(afterJsonDeclarationRegex, '$1$2\n$1partial void AfterToJson(ref Microsoft.Graph.PowerShell.Runtime.Json.JsonObject container, Microsoft.Graph.PowerShell.Runtime.SerializationMode serializationMode);\n');
         let afterJsonRegex = /(^\s*)(AfterToJson\(ref\s*container\s*\);$)/gm
         $ = $.replace(afterJsonRegex, '$1$2\n$1AfterToJson(ref container, serializationMode);\n');
+
+        // Pass exclusion properties to base classes during serialization.
+        let baseClassInitializerRegex = /(new\s*Microsoft.Graph.PowerShell.Models.MicrosoftGraph\w*\(\s*json\s*,\s*new\s*global::System.Collections.Generic.HashSet<string>\()(\){\W.*}\);)/gm
+        $ = $.replace(baseClassInitializerRegex, '$1(exclusions ?? new System.Collections.Generic.HashSet<string>())$2');
         return $;
       }
+# Modify generated .cs model classes.
   - from: source-file-csharp
     where: $
     transform: >
@@ -386,6 +392,24 @@ directive:
         let valuesPropertiesRegex = /(SerializedName\s*=\s*@"values".*\s*.*)(\s*)(.*Values\s*{\s*get;\s*set;\s*})/gmi
         if($.match(valuesPropertiesRegex)) {
           $ = $.replace(valuesPropertiesRegex, '$1$2 new $3');
+        }
+
+        // Add new modifier to 'additionalProperties' properties of classes that derive from an IAssociativeArray. See example https://regex101.com/r/hnX7xO/2.
+        let additionalPropertiesRegex = /(SerializedName\s*=\s*@"additionalProperties".*\s*.*)(\s*)(.*AdditionalProperties\s*{\s*get;\s*set;\s*})/gmi
+        if($.match(additionalPropertiesRegex)) {
+          $ = $.replace(additionalPropertiesRegex, '$1$2 new $3');
+        }
+
+        // Add new modifier to 'keys' properties of classes that derive from an IAssociativeArray. See example https://regex101.com/r/hnX7xO/2.
+        let keysRegex = /(SerializedName\s*=\s*@"keys".*\s*.*)(\s*)(.*Keys\s*{\s*get;\s*set;\s*})/gmi
+        if($.match(keysRegex)) {
+          $ = $.replace(keysRegex, '$1$2 new $3');
+        }
+
+        // Add new modifier to 'count' properties of classes that derive from an IAssociativeArray. See example https://regex101.com/r/hnX7xO/2.
+        let countRegex = /(SerializedName\s*=\s*@"count".*\s*.*)(\s*)(.*Count\s*{\s*get;\s*set;\s*})/gmi
+        if($.match(countRegex)) {
+          $ = $.replace(countRegex, '$1$2 new $3');
         }
 
         let regexPattern = /^\s*public\s*partial\s*class\s*MicrosoftGraph(?<EntityName>.*):$/gm;
@@ -404,7 +428,7 @@ directive:
         }
         return $;
       }
-# Override OnDefault to handle all success, 2xx responses, as success and not error.
+# Modify generated .cs cmdlets.
   - from: source-file-csharp
     where: $
     transform: >
@@ -412,6 +436,12 @@ directive:
       {
         return $;
       } else {
+        // Initialize AdditionalProperties prop to a new Hashtable by default.
+        let additionalPropertiesPropRegex = /System.Collections.Hashtable\s*AdditionalProperties\s*{\s*get;\s*set;\s*}$/gmi
+        let newAdditionalPropertiesProp = "System.Collections.Hashtable AdditionalProperties { get; set; } = new System.Collections.Hashtable();"
+        $ = $.replace(additionalPropertiesPropRegex, newAdditionalPropertiesProp);
+
+        // Override OnDefault to handle all success, 2xx responses, as success and not error.
         let overrideOnDefaultRegex = /(\s*)(partial\s*void\s*overrideOnDefault)/gmi
         let overrideOnDefaultImplementation = "$1partial void overrideOnDefault(global::System.Net.Http.HttpResponseMessage responseMessage, global::System.Threading.Tasks.Task<Microsoft.Graph.PowerShell.Models.IOdataError> response, ref global::System.Threading.Tasks.Task<bool> returnNow) => this.OverrideOnDefault(responseMessage,ref returnNow);$1$2"
         $ = $.replace(overrideOnDefaultRegex, overrideOnDefaultImplementation);
@@ -419,7 +449,7 @@ directive:
         return $;
       }
 
-# Add custom -PageSize parameter to *_List cmdlets that support Odata next link.
+# Modify generated .cs list cmdlets.
   - from: source-file-csharp
     where: $
     transform: >
@@ -427,6 +457,7 @@ directive:
       {
         return $;
       } else {
+        // Add custom -PageSize parameter to *_List cmdlets that support Odata next link.
         let odataNextLinkRegex = /(^\s*)(if\s*\(\s*result.OdataNextLink\s*!=\s*null\s*\))/gmi
         if($.match(odataNextLinkRegex)) {
           $ = $.replace(odataNextLinkRegex, '$1if (result.OdataNextLink != null && this.ShouldIteratePages(this.InvocationInformation.BoundParameters, result.Value.Length))\n$1');
@@ -440,6 +471,23 @@ directive:
           let odataNextLinkCallRegex = /(^\s*)(await\s*this\.Client\.UsersUserListUser_Call\(requestMessage\,\s*onOk\,\s*onDefault\,\s*this\,\s*Pipeline\)\;)/gmi
           $ = $.replace(odataNextLinkCallRegex, '$1requestMessage.RequestUri = GetOverflowItemsNextLinkUri(requestMessage.RequestUri);\n$1$2');
         }
+        return $;
+      }
+
+# Modify generated runtime TypeConverterExtensions class.
+  - from: source-file-csharp
+    where: $
+    transform: >
+      if (!$documentPath.match(/generated%5Cruntime%5CTypeConverterExtensions.cs/gm))
+      {
+        return $;
+      } else {
+        // Use a case-insensitive contains search.
+        let keyValueContainsRegex = /(exclusions|inclusions)(\?.Contains\(key\?.ToString\(\))(\)\))/gm
+        $ = $.replace(keyValueContainsRegex, '$1$2, System.StringComparer.OrdinalIgnoreCase$3');
+
+        let propertyContainsRegex = /(exclusions|inclusions)(\?.Contains\(property.Name)(\)\))/gm
+        $ = $.replace(propertyContainsRegex, '$1$2, System.StringComparer.OrdinalIgnoreCase$3');
         return $;
       }
 ```

--- a/tools/Custom/ListCmdlet.cs
+++ b/tools/Custom/ListCmdlet.cs
@@ -98,9 +98,12 @@ namespace Microsoft.Graph.PowerShell.Cmdlets.Custom
             {
                 currentPageSize = limit;
             }
-            // Explicitly set `-Top` parameter to currentPageSize in order for the generated cmdlets to construct a URL with a `$top` query parameter.
-            invocationInfo.BoundParameters["Top"] = currentPageSize;
-            top = currentPageSize;
+
+            if (invocationInfo.BoundParameters.ContainsKey("PageSize") || invocationInfo.BoundParameters.ContainsKey("Top") || invocationInfo.BoundParameters.ContainsKey("All")){
+                // Explicitly set `-Top` parameter to currentPageSize in order for the generated cmdlets to construct a URL with a `$top` query parameter.
+                invocationInfo.BoundParameters["Top"] = currentPageSize;
+                top = currentPageSize;
+            }
 
             if (limit != default)
             {

--- a/tools/Custom/Module.cs
+++ b/tools/Custom/Module.cs
@@ -56,19 +56,25 @@ namespace Microsoft.Graph.PowerShell
         /// </returns>
         public async Task EventHandler(string id, CancellationToken cancellationToken, Func<EventArgs> getEventData, Func<string, CancellationToken, Func<EventArgs>, Task> signal, InvocationInfo invocationInfo, string parameterSetName, System.Exception exception)
         {
-            switch (id)
+            if (invocationInfo.BoundParameters.ContainsKey("Debug"))
             {
-                case Events.Finally:
-                    await Finally(id, cancellationToken, getEventData, signal);
-                    break;
-                default:
-                    getEventData.Print(signal, cancellationToken, Events.Information, id);
-                    break;
+                switch (id)
+                {
+                    case Events.BeforeCall:
+                        await BeforeCall(id, cancellationToken, getEventData, signal);
+                        break;
+                    case Events.Finally:
+                        await Finally(id, cancellationToken, getEventData, signal);
+                        break;
+                    default:
+                        getEventData.Print(signal, cancellationToken, Events.Information, id);
+                        break;
+                }
             }
         }
 
         /// <summary>
-        /// Handles the Finally event, which is called just before Request and Response are disposed.
+        /// Handles the Finally event, which is called just after a response is received.
         /// </summary>
         /// <param name="id">The ID of the event</param>
         /// <param name="cancellationToken">The cancellation token for the event</param>
@@ -82,13 +88,33 @@ namespace Microsoft.Graph.PowerShell
             using (Extensions.NoSynchronizationContext)
             {
                 var eventData = EventDataConverter.ConvertFrom(getEventData());
-                using (var requestFormatter = new HttpMessageFormatter(eventData.RequestMessage as HttpRequestMessage))
                 using (var responseFormatter = new HttpMessageFormatter(eventData.ResponseMessage as HttpResponseMessage))
                 {
-                    var requestString = await requestFormatter.ReadAsStringAsync();
                     var responseString = await responseFormatter.ReadAsStringAsync();
-                    await signal(Events.Debug, cancellationToken, () => EventFactory.CreateLogEvent(requestString));
                     await signal(Events.Debug, cancellationToken, () => EventFactory.CreateLogEvent(responseString));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles the BeforeCall event, which is called just before Request is sent.
+        /// </summary>
+        /// <param name="id">The ID of the event</param>
+        /// <param name="cancellationToken">The cancellation token for the event</param>
+        /// <param name="getEventData">A delegate to get the detailed event data</param>
+        /// <param name="signal">The callback for the event dispatcher</param>
+        /// <returns>
+        /// A <see cref="global::System.Threading.Tasks.Task" /> that will be complete when handling of the event is completed.
+        /// </returns>
+        private async Task BeforeCall(string id, CancellationToken cancellationToken, Func<EventArgs> getEventData, Func<string, CancellationToken, Func<EventArgs>, Task> signal)
+        {
+            using (Extensions.NoSynchronizationContext)
+            {
+                var eventData = EventDataConverter.ConvertFrom(getEventData());
+                using (var requestFormatter = new HttpMessageFormatter(eventData.RequestMessage as HttpRequestMessage))
+                {
+                    var requestString = await requestFormatter.ReadAsStringAsync();
+                    await signal(Events.Debug, cancellationToken, () => EventFactory.CreateLogEvent(requestString));
                 }
             }
         }

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -136,6 +136,15 @@ $ModuleMapping.Keys | ForEach-Object -Begin { $RequestCount = 0 } -End { Write-H
                     }
                 } | Set-Content $ModulePsm1
 
+                # Address AutoREST bug where it looks for exports in the wrong directory.
+                $InternalModulePsm1 = Join-Path $ModuleProjectDir "/internal/$ModulePrefix.$ModuleName.internal.psm1"
+                (Get-Content -Path $InternalModulePsm1) | ForEach-Object{
+                    $_
+                    if ($_ -match '\$exportsPath = \$PSScriptRoot') {
+                        '  $exportsPath = Join-Path $PSScriptRoot "../exports"'
+                    }
+                } | Set-Content $InternalModulePsm1
+                
                 if ($LASTEXITCODE) {
                     Write-Error "Failed to build '$ModuleName' module."
                 }


### PR DESCRIPTION
This PR contains bug fixes that have noted with the release of 0.9.1. Most of the bugs are caused by how AutoREST handles serialization and deserialization of additionalProperties. This PR applies directives to fix these issues in the interim, but we will also open corresponding issues in AutoREST's repo for a long-term fix. The following changes are proposed in the PR  :
- Adds a directive that excludes known properties of an entity from being serialized as key-value pairs in additionalProperties. This wasn't properly handled by AutoREST and would lead to duplicate key exception since a key would be serialized in two places, as entity property and in additionalProperties. This only happened when an entity and its base class both had an additionalProperties. Closes #339 .
Exclusions HashSet wasn't being passed to the base class during serialization.
![image](https://user-images.githubusercontent.com/7061532/90566503-72a75b00-e15d-11ea-9266-4bae2fef5c5a.png)

- Adds a new modifier to `additionalProperties`, `keys` and `count` OData entity properties.
- Adds a directive that Initializes `AdditionalProperties` prop to a new `HashTable` by default to avoid null reference exception. Closes #337.
- Adds a directive that adds a case-insensitive contains search to AutoREST's `TypeConverterExtensions` class. This led to known derived entity/model class properties being deserialized as additionalProperties in their base classes. The Exclusions and Inclusions HashSets are in PascalCase yet the keys are in camelCase.
![image](https://user-images.githubusercontent.com/7061532/90566148-d54c2700-e15c-11ea-881d-30e32c4b8c38.png)
Before:
![image](https://user-images.githubusercontent.com/7061532/90565776-4ccd8680-e15c-11ea-84a3-abaeba8e9d34.png)
After:
![image](https://user-images.githubusercontent.com/7061532/90565807-53f49480-e15c-11ea-93a5-0a61e07a62e1.png)

- Updates Paging to ensure $top is only set when `PageSize`, `Top` or `All` parameters are bound to a cmdlet. Not all APIs support $top.
- Change how `-debug` events are handled by only reacting to signals when `-Debug` parameter is set. The change also ensures we only read the request content when `BeforeCall` event is raised. Closes #338 .

- Renames additionalProperties indexer name in Financials module to avoid property name conflict with `item` property in `salesOrderLine`, `salesQuoteLine`, `purchaseInvoiceLine`, `salesInvoiceLine` and `salesCreditMemoLine` entities. See https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/indexers/using-indexers.
