### PR TITLE
Add -AccessToken parameter to Connect-Graph

### DIFF
--- a/src/Authentication/Authentication.Test/Helpers/AuthenticationHelpersTests.cs
+++ b/src/Authentication/Authentication.Test/Helpers/AuthenticationHelpersTests.cs
@@ -1,0 +1,130 @@
+﻿namespace Microsoft.Graph.Authentication.Test.Helpers
+{
+    using Microsoft.Graph.Auth;
+    using Microsoft.Graph.PowerShell.Authentication;
+    using Microsoft.Graph.PowerShell.Authentication.Helpers;
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Security.Cryptography;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Threading.Tasks;
+    using Xunit;
+    public class AuthenticationHelpersTests
+    {
+        public AuthenticationHelpersTests()
+        {
+            GraphSession.Initialize(() => new GraphSession());
+        }
+
+        [Fact]
+        public async Task ShouldUseDelegateAuthProviderWhenUserAccessTokenIsProvidedAsync()
+        {
+            // Arrange
+            string accessToken = "ACCESS_TOKEN_VIA_DELEGATE_PROVIDER";
+            GraphSession.Instance.UserProvidedToken = new NetworkCredential(string.Empty, accessToken).SecurePassword;
+            AuthContext userProvidedAuthContext = new AuthContext
+            {
+                AuthType = AuthenticationType.UserProvidedAccessToken,
+                ContextScope = ContextScope.Process
+            };
+
+            IAuthenticationProvider authProvider = AuthenticationHelpers.GetAuthProvider(userProvidedAuthContext);
+            HttpRequestMessage requestMessage = new HttpRequestMessage();
+
+            // Act
+            await authProvider.AuthenticateRequestAsync(requestMessage);
+
+            // Assert
+            Assert.IsType<DelegateAuthenticationProvider>(authProvider);
+            Assert.Equal("Bearer", requestMessage.Headers.Authorization.Scheme);
+            Assert.Equal(accessToken, requestMessage.Headers.Authorization.Parameter);
+
+            // reset static instance.
+            GraphSession.Reset();
+        }
+
+        [Fact]
+        public void ShouldUseDeviceCodeProviderWhenDelegatedContextIsProvided()
+        {
+            // Arrange
+            AuthContext delegatedAuthContext = new AuthContext
+            {
+                AuthType = AuthenticationType.Delegated,
+                Scopes = new string[] { "User.Read" },
+                ContextScope = ContextScope.Process
+            };
+
+            // Act
+            IAuthenticationProvider authProvider = AuthenticationHelpers.GetAuthProvider(delegatedAuthContext);
+
+            // Assert
+            Assert.IsType<DeviceCodeProvider>(authProvider);
+
+            // reset static instance.
+            GraphSession.Reset();
+        }
+
+        [Fact]
+        public void ShouldUseClientCredentialProviderWhenAppOnlyContextIsProvided()
+        {
+            // Arrange
+            AuthContext appOnlyAuthContext = new AuthContext
+            {
+                AuthType = AuthenticationType.AppOnly,
+                ClientId = Guid.NewGuid().ToString(),
+                CertificateName = "cn=dummyCert",
+                ContextScope = ContextScope.Process
+            };
+            CreateSelfSignedCert(appOnlyAuthContext.CertificateName);
+
+            // Act
+            IAuthenticationProvider authProvider = AuthenticationHelpers.GetAuthProvider(appOnlyAuthContext);
+
+            // Assert
+            Assert.IsType<ClientCredentialProvider>(authProvider);
+
+            // reset
+            DeleteSelfSignedCert(appOnlyAuthContext.CertificateName);
+            GraphSession.Reset();
+            
+        }
+
+        private void CreateSelfSignedCert(string certName)
+        {
+            ECDsa ecdsaKey = ECDsa.Create();
+            CertificateRequest certificateRequest = new CertificateRequest(certName, ecdsaKey, HashAlgorithmName.SHA256);
+            // We have to export cert to dummy cert since `CreateSelfSigned` creates a cert without a private key.
+            X509Certificate2 cert = certificateRequest.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(5));
+            X509Certificate2 dummyCert = new X509Certificate2(cert.Export(X509ContentType.Pfx, "P@55w0rd"), "P@55w0rd", X509KeyStorageFlags.PersistKeySet);
+            using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                store.Open(OpenFlags.ReadWrite);
+
+                store.Add(dummyCert);
+            }
+        }
+
+        private void DeleteSelfSignedCert(string certificateName)
+        {
+            using (X509Store xStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                xStore.Open(OpenFlags.ReadWrite);
+
+                X509Certificate2Collection unexpiredCerts = xStore.Certificates
+                   .Find(X509FindType.FindByTimeValid, DateTime.Now, false)
+                   .Find(X509FindType.FindBySubjectDistinguishedName, certificateName, false);
+
+                // Only return current cert.
+                var xCertificate = unexpiredCerts
+                    .OfType<X509Certificate2>()
+                    .OrderByDescending(c => c.NotBefore)
+                    .FirstOrDefault();
+
+                xStore.Remove(xCertificate);
+            }
+        }
+
+    }
+}

--- a/src/Authentication/Authentication.Test/Helpers/AuthenticationHelpersTests.cs
+++ b/src/Authentication/Authentication.Test/Helpers/AuthenticationHelpersTests.cs
@@ -97,11 +97,19 @@
             CertificateRequest certificateRequest = new CertificateRequest(certName, ecdsaKey, HashAlgorithmName.SHA256);
             // We have to export cert to dummy cert since `CreateSelfSigned` creates a cert without a private key.
             X509Certificate2 cert = certificateRequest.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(5));
-            X509Certificate2 dummyCert = new X509Certificate2(cert.Export(X509ContentType.Pfx, "P@55w0rd"), "P@55w0rd", X509KeyStorageFlags.PersistKeySet);
+
+            X509Certificate2 dummyCert = null;
+            if (PowerShell.Authentication.Helpers.OperatingSystem.IsMacOS())
+            {
+                dummyCert = new X509Certificate2(cert.Export(X509ContentType.Pfx, "P@55w0rd"), "P@55w0rd", X509KeyStorageFlags.Exportable);
+            }
+            else
+            {
+                dummyCert = new X509Certificate2(cert.Export(X509ContentType.Pfx, "P@55w0rd"), "P@55w0rd", X509KeyStorageFlags.PersistKeySet);
+            }
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
             {
                 store.Open(OpenFlags.ReadWrite);
-
                 store.Add(dummyCert);
             }
         }

--- a/src/Authentication/Authentication/Cmdlets/ConnectGraph.cs
+++ b/src/Authentication/Authentication/Cmdlets/ConnectGraph.cs
@@ -192,19 +192,39 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
 
         private void ValidateParameters()
         {
-            if (ParameterSetName == Constants.AppParameterSet)
+            switch (ParameterSetName)
             {
-                // Client Id
-                if (string.IsNullOrEmpty(ClientId))
-                    ThrowParameterError(nameof(ClientId));
+                case Constants.AppParameterSet:
+                    {
+                        // Client Id
+                        if (string.IsNullOrEmpty(ClientId))
+                        {
+                            ThrowParameterError(nameof(ClientId));
+                        }
 
-                // Certificate Thumbprint or name
-                if (string.IsNullOrEmpty(CertificateThumbprint) && string.IsNullOrEmpty(CertificateName))
-                    ThrowParameterError($"{nameof(CertificateThumbprint)} or {nameof(CertificateName)}");
+                        // Certificate Thumbprint or name
+                        if (string.IsNullOrEmpty(CertificateThumbprint) && string.IsNullOrEmpty(CertificateName))
+                        {
+                            ThrowParameterError($"{nameof(CertificateThumbprint)} or {nameof(CertificateName)}");
+                        }
 
-                // Tenant Id
-                if (string.IsNullOrEmpty(TenantId))
-                    ThrowParameterError(nameof(TenantId));
+                        // Tenant Id
+                        if (string.IsNullOrEmpty(TenantId))
+                        {
+                            ThrowParameterError(nameof(TenantId));
+                        }
+
+                    }
+                    break;
+                case Constants.AccessTokenParameterSet:
+                    {
+                        // AccessToken
+                        if (string.IsNullOrEmpty(AccessToken))
+                        {
+                            ThrowParameterError(nameof(AccessToken));
+                        }
+                    }
+                    break;
             }
         }
 

--- a/src/Authentication/Authentication/Cmdlets/ConnectGraph.cs
+++ b/src/Authentication/Authentication/Cmdlets/ConnectGraph.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     using Microsoft.Graph.Auth;
     using Microsoft.Graph.PowerShell.Authentication.Helpers;
     using Microsoft.Graph.PowerShell.Authentication.Models;
-    using Microsoft.Graph.PowerShell.Authentication.Extensions;
     using Microsoft.Identity.Client;
     using System;
     using System.Collections.Generic;
@@ -15,30 +14,50 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Net;
+    using System.Globalization;
 
     [Cmdlet(VerbsCommunications.Connect, "Graph", DefaultParameterSetName = Constants.UserParameterSet)]
     public class ConnectGraph : PSCmdlet, IModuleAssemblyInitializer, IModuleAssemblyCleanup
     {
-        [Parameter(ParameterSetName = Constants.UserParameterSet, Position = 1, HelpMessage = "An array of delegated permissions to consent to.")]
+        [Parameter(ParameterSetName = Constants.UserParameterSet,
+            Position = 1,
+            HelpMessage = "An array of delegated permissions to consent to.")]
         public string[] Scopes { get; set; }
 
-        [Parameter(ParameterSetName = Constants.AppParameterSet, Position = 1, Mandatory = true, HelpMessage = "The client id of your application.")]
+        [Parameter(ParameterSetName = Constants.AppParameterSet,
+            Position = 1,
+            Mandatory = true,
+            HelpMessage = "The client id of your application.")]
         public string ClientId { get; set; }
 
-        [Parameter(ParameterSetName = Constants.AppParameterSet, Position = 2, HelpMessage = "The name of your certificate. The Certificate will be retrieved from the current user's certificate store.")]
+        [Parameter(ParameterSetName = Constants.AppParameterSet,
+            Position = 2,
+            HelpMessage = "The name of your certificate. The Certificate will be retrieved from the current user's certificate store.")]
         public string CertificateName { get; set; }
 
-        [Parameter(ParameterSetName = Constants.AppParameterSet, Position = 3, HelpMessage = "The thumbprint of your certificate. The Certificate will be retrieved from the current user's certificate store.")]
+        [Parameter(ParameterSetName = Constants.AppParameterSet,
+            Position = 3,
+            HelpMessage = "The thumbprint of your certificate. The Certificate will be retrieved from the current user's certificate store.")]
         public string CertificateThumbprint { get; set; }
+        
+        [Parameter(ParameterSetName = Constants.AccessTokenParameterSet,
+            Position = 1,
+            HelpMessage = "Specifies a bearer token for Microsoft Graph service. Access tokens do timeout and you'll have to handle their refresh.")]
+        public string AccessToken { get; set; }
 
-        [Parameter(Position = 4, HelpMessage = "The id of the tenant to connect to.")]
+        [Parameter(Position = 4,
+            HelpMessage = "The id of the tenant to connect to.")]
         public string TenantId { get; set; }
 
-        [Parameter(Position = 5, HelpMessage = "Forces the command to get a new access token silently.")]
+        [Parameter(Position = 5,
+            HelpMessage = "Forces the command to get a new access token silently.")]
         public SwitchParameter ForceRefresh { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Determines the scope of authentication context. This accepts `Process` for the current process, or `CurrentUser` for all sessions started by user.")]
+        [Parameter(Mandatory = false,
+            HelpMessage = "Determines the scope of authentication context. This accepts `Process` for the current process, or `CurrentUser` for all sessions started by user.")]
         public ContextScope ContextScope { get; set; }
+
         private CancellationTokenSource cancellationTokenSource;
 
         protected override void BeginProcessing()
@@ -55,28 +74,40 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
         protected override void ProcessRecord()
         {
             base.ProcessRecord();
+            IAuthContext authContext = new AuthContext { TenantId = TenantId };
+            cancellationTokenSource = new CancellationTokenSource();
 
-            IAuthContext authConfig = new AuthContext { TenantId = TenantId };
-
-            if (ParameterSetName == Constants.UserParameterSet)
+            switch (ParameterSetName)
             {
-                // 2 mins timeout. 1 min < HTTP timeout.
-                TimeSpan authTimeout = new TimeSpan(0, 0, Constants.MaxDeviceCodeTimeOut);
-                cancellationTokenSource = new CancellationTokenSource(authTimeout);
-                authConfig.AuthType = AuthenticationType.Delegated;
-                authConfig.Scopes = Scopes ?? new string[] { "User.Read" };
-                // Default to CurrentUser but allow the customer to change this via `ContextScope` param.
-                authConfig.ContextScope = this.IsParameterBound(nameof(ContextScope)) ? ContextScope : ContextScope.CurrentUser;
-            }
-            else
-            {
-                cancellationTokenSource = new CancellationTokenSource();
-                authConfig.AuthType = AuthenticationType.AppOnly;
-                authConfig.ClientId = ClientId;
-                authConfig.CertificateThumbprint = CertificateThumbprint;
-                authConfig.CertificateName = CertificateName;
-                // Default to Process but allow the customer to change this via `ContextScope` param.
-                authConfig.ContextScope = this.IsParameterBound(nameof(ContextScope)) ? ContextScope : ContextScope.Process;
+                case Constants.UserParameterSet:
+                    {
+                        // 2 mins timeout. 1 min < HTTP timeout.
+                        TimeSpan authTimeout = new TimeSpan(0, 0, Constants.MaxDeviceCodeTimeOut);
+                        cancellationTokenSource = new CancellationTokenSource(authTimeout);
+                        authContext.AuthType = AuthenticationType.Delegated;
+                        authContext.Scopes = Scopes ?? new string[] { "User.Read" };
+                        // Default to CurrentUser but allow the customer to change this via `ContextScope` param.
+                        authContext.ContextScope = this.IsParameterBound(nameof(ContextScope)) ? ContextScope : ContextScope.CurrentUser;
+                    }
+                    break;
+                case Constants.AppParameterSet:
+                    {
+                        authContext.AuthType = AuthenticationType.AppOnly;
+                        authContext.ClientId = ClientId;
+                        authContext.CertificateThumbprint = CertificateThumbprint;
+                        authContext.CertificateName = CertificateName;
+                        // Default to Process but allow the customer to change this via `ContextScope` param.
+                        authContext.ContextScope = this.IsParameterBound(nameof(ContextScope)) ? ContextScope : ContextScope.Process;
+                    }
+                    break;
+                case Constants.AccessTokenParameterSet:
+                    {
+                        authContext.AuthType = AuthenticationType.UserProvidedAccessToken;
+                        authContext.ContextScope = ContextScope.Process;
+                        // Store user provided access token to a session object.
+                        GraphSession.Instance.UserProvidedToken = new NetworkCredential(string.Empty, AccessToken).SecurePassword;
+                    }
+                    break;
             }
 
             CancellationToken cancellationToken = cancellationTokenSource.Token;
@@ -84,12 +115,16 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             try
             {
                 // Gets a static instance of IAuthenticationProvider when the client app hasn't changed. 
-                IAuthenticationProvider authProvider = AuthenticationHelpers.GetAuthProvider(authConfig);
+                IAuthenticationProvider authProvider = AuthenticationHelpers.GetAuthProvider(authContext);
                 IClientApplicationBase clientApplication = null;
                 if (ParameterSetName == Constants.UserParameterSet)
+                {
                     clientApplication = (authProvider as DeviceCodeProvider).ClientApplication;
-                else
+                }
+                else if (ParameterSetName == Constants.AppParameterSet)
+                {
                     clientApplication = (authProvider as ClientCredentialProvider).ClientApplication;
+                }
 
                 // Incremental scope consent without re-instantiating the auth provider. We will use a static instance.
                 GraphRequestContext graphRequestContext = new GraphRequestContext();
@@ -102,7 +137,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                         {
                             AuthenticationProviderOption = new AuthenticationProviderOption
                             {
-                                Scopes = authConfig.Scopes,
+                                Scopes = authContext.Scopes,
                                 ForceRefresh = ForceRefresh
                             }
                         }
@@ -114,24 +149,32 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                 httpRequestMessage.Properties.Add(typeof(GraphRequestContext).ToString(), graphRequestContext);
                 authProvider.AuthenticateRequestAsync(httpRequestMessage).GetAwaiter().GetResult();
 
-                var accounts = clientApplication.GetAccountsAsync().GetAwaiter().GetResult();
-                var account = accounts.FirstOrDefault();
-
-                JwtPayload jwtPayload = JwtHelpers.DecodeToObject<JwtPayload>(httpRequestMessage.Headers.Authorization?.Parameter);
-                authConfig.Scopes = jwtPayload?.Scp?.Split(' ') ?? jwtPayload?.Roles;
-                authConfig.TenantId = jwtPayload?.Tid ?? account?.HomeAccountId?.TenantId;
-                authConfig.AppName = jwtPayload?.AppDisplayname;
-                authConfig.Account = jwtPayload?.Upn ?? account?.Username;
+                IAccount account = null;
+                if (clientApplication != null)
+                {
+                    // Only get accounts when we are using MSAL to get an access token.
+                    IEnumerable<IAccount> accounts = clientApplication.GetAccountsAsync().GetAwaiter().GetResult();
+                    account = accounts.FirstOrDefault();
+                }
+                DecodeJWT(httpRequestMessage.Headers.Authorization?.Parameter, account, ref authContext);
 
                 // Save auth context to session state.
-                GraphSession.Instance.AuthContext = authConfig;
+                GraphSession.Instance.AuthContext = authContext;
             }
             catch (AuthenticationException authEx)
             {
                 if ((authEx.InnerException is TaskCanceledException) && cancellationToken.IsCancellationRequested)
-                    throw new Exception($"Device code terminal timed-out after {Constants.MaxDeviceCodeTimeOut} seconds. Please try again.");
+                {
+                    // DeviceCodeTimeout
+                    throw new Exception(string.Format(
+                            CultureInfo.CurrentCulture,
+                            ErrorConstants.Message.DeviceCodeTimeout,
+                            Constants.MaxDeviceCodeTimeOut));
+                }
                 else
+                {
                     throw authEx.InnerException ?? authEx;
+                }
             }
             catch (Exception ex)
             {
@@ -171,6 +214,24 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                 new ErrorRecord(
                     new ArgumentException($"Must specify {parameterName}"), Guid.NewGuid().ToString(), ErrorCategory.InvalidArgument, null)
                 );
+        }
+
+        private void DecodeJWT(string token, IAccount account, ref IAuthContext authContext)
+        {
+            JwtPayload jwtPayload = JwtHelpers.DecodeToObject<JwtPayload>(token);
+            if (jwtPayload == null && authContext.AuthType == AuthenticationType.UserProvidedAccessToken)
+            {
+                throw new Exception(string.Format(
+                        CultureInfo.CurrentCulture,
+                        ErrorConstants.Message.InvalidUserProvidedToken,
+                        nameof(AccessToken)));
+            }
+
+            authContext.ClientId = jwtPayload?.Appid ?? authContext.ClientId;
+            authContext.Scopes = jwtPayload?.Scp?.Split(' ') ?? jwtPayload?.Roles;
+            authContext.TenantId = jwtPayload?.Tid ?? account?.HomeAccountId?.TenantId;
+            authContext.AppName = jwtPayload?.AppDisplayname;
+            authContext.Account = jwtPayload?.Upn ?? account?.Username;
         }
 
         /// <summary>

--- a/src/Authentication/Authentication/Common/GraphSession.cs
+++ b/src/Authentication/Authentication/Common/GraphSession.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Graph.PowerShell.Authentication
 {
     using System;
+    using System.Security;
     using System.Threading;
     /// <summary>
     /// Contains methods to create, modify or obtain a thread safe static instance of <see cref="GraphSession"/>.
@@ -24,18 +25,22 @@ namespace Microsoft.Graph.PowerShell.Authentication
         /// </summary>
         public IAuthContext AuthContext { get; set; }
 
-        private byte[] token;
+        private byte[] msalToken;
 
         /// <summary>
         /// Gets or Sets a session based token.
         /// This returns an empty byte[] when token is not present.
         /// </summary>
-        public byte[] Token
+        public byte[] MSALToken
         {
-            get { return token ?? new byte[0]; }
-            set { token = value; }
+            get { return msalToken ?? new byte[0]; }
+            set { msalToken = value; }
         }
 
+        /// <summary>
+        /// Gets or Sets a user provided access token for calling Microsoft Graph service.
+        /// </summary>
+        public SecureString UserProvidedToken { get; set; }
 
         /// <summary>
         /// The name of the selected Microsoft Graph profile.

--- a/src/Authentication/Authentication/Constants.cs
+++ b/src/Authentication/Authentication/Constants.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Graph.PowerShell.Authentication
         public const string SDKHeaderValue = "Graph-powershell-{0}-{1}.{2}.{3}";
         internal const string UserParameterSet = "UserParameterSet";
         internal const string AppParameterSet = "AppParameterSet";
+        internal const string AccessTokenParameterSet = "AccessTokenParameterSet";
         internal const int MaxDeviceCodeTimeOut = 120; // 2 mins timeout.
         internal static readonly string TokenCacheDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".graph");
         internal const string ProfileDescription = "A snapshot of the Microsoft Graph {0} API for {1} cloud.";

--- a/src/Authentication/Authentication/Constants.cs
+++ b/src/Authentication/Authentication/Constants.cs
@@ -18,5 +18,6 @@ namespace Microsoft.Graph.PowerShell.Authentication
         internal const string ProfileDescription = "A snapshot of the Microsoft Graph {0} API for {1} cloud.";
         internal const string TokenCacheServiceName = "com.microsoft.graph.powershell.sdkcache";
         internal const string DefaultProfile = "v1.0-beta";
+        internal const int TokenExpirationBufferInMinutes = 5;
     }
 }

--- a/src/Authentication/Authentication/ErrorConstants.cs
+++ b/src/Authentication/Authentication/ErrorConstants.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Graph.PowerShell.Authentication
             internal const string MissingAuthContext = "Authentication needed, call Connect-Graph.";
             internal const string NullOrEmptyParameter = "Parameter '{0}' cannot be null or empty.";
             internal const string MacKeyChainFailed = "{0} failed with result code {1}.";
+            internal const string DeviceCodeTimeout = "Device code terminal timed-out after {0} seconds. Please try again.";
+            internal const string InvalidUserProvidedToken = "The provided access token is invalid. Set a valid access token to `-{0}` parameter and try again.";
         }
     }
 }

--- a/src/Authentication/Authentication/ErrorConstants.cs
+++ b/src/Authentication/Authentication/ErrorConstants.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Graph.PowerShell.Authentication
             internal const string MacKeyChainFailed = "{0} failed with result code {1}.";
             internal const string DeviceCodeTimeout = "Device code terminal timed-out after {0} seconds. Please try again.";
             internal const string InvalidUserProvidedToken = "The provided access token is invalid. Set a valid access token to `-{0}` parameter and try again.";
+            internal const string ExpiredUserProvidedToken = "The provided access token has expired. Set a valid access token to `-{0}` parameter and try again.";
         }
     }
 }

--- a/src/Authentication/Authentication/Helpers/HttpHelpers.cs
+++ b/src/Authentication/Authentication/Helpers/HttpHelpers.cs
@@ -30,15 +30,17 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         /// <summary>
         /// Creates a pre-configured Microsoft Graph <see cref="HttpClient"/>.
         /// </summary>
-        /// <param name="authConfig"></param>
+        /// <param name="authContext"></param>
         /// <returns></returns>
-        public static HttpClient GetGraphHttpClient(IAuthContext authConfig = null)
+        public static HttpClient GetGraphHttpClient(IAuthContext authContext = null)
         {
-            authConfig = authConfig ?? GraphSession.Instance.AuthContext;
-            if (authConfig is null)
+            authContext = authContext ?? GraphSession.Instance.AuthContext;
+            if (authContext is null)
+            {
                 throw new AuthenticationException(ErrorConstants.Message.MissingAuthContext);
+            }
 
-            IAuthenticationProvider authProvider = AuthenticationHelpers.GetAuthProvider(authConfig);
+            IAuthenticationProvider authProvider = AuthenticationHelpers.GetAuthProvider(authContext);
             IList<DelegatingHandler> defaultHandlers = GraphClientFactory.CreateDefaultHandlers(authProvider);
 
             // Register ODataQueryOptionsHandler after AuthHandler.

--- a/src/Authentication/Authentication/Helpers/JwtHelpers.cs
+++ b/src/Authentication/Authentication/Helpers/JwtHelpers.cs
@@ -59,5 +59,17 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                         }, ex);
             }
         }
+
+        /// <summary>
+        /// Converts a DateTime to Unix timestamp in seconds past epoch.
+        /// </summary>
+        /// <param name="time">A <see cref="DateTime"/> to convert.</param>
+        /// <returns>Unix timestamp.</returns>
+        internal static long ConvertToUnixTimestamp(DateTime time)
+        {
+            DateTime epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0);
+            TimeSpan timeDiff = time - epochTime;
+            return (long)timeDiff.TotalSeconds;
+        }
     }
 }

--- a/src/Authentication/Authentication/Interfaces/IAuthContext.cs
+++ b/src/Authentication/Authentication/Interfaces/IAuthContext.cs
@@ -7,7 +7,8 @@ namespace Microsoft.Graph.PowerShell.Authentication
     public enum AuthenticationType
     {
         Delegated,
-        AppOnly
+        AppOnly,
+        UserProvidedAccessToken
     }
 
     public enum ContextScope

--- a/src/Authentication/Authentication/Models/JwtPayload.cs
+++ b/src/Authentication/Authentication/Models/JwtPayload.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Graph.PowerShell.Authentication.Models
     using Newtonsoft.Json;
     internal partial class JwtPayload
     {
+        [JsonProperty("exp")]
+        public long Exp { get; set; }
+
         [JsonProperty("aud")]
         public Uri Aud { get; set; }
 

--- a/src/Authentication/Authentication/TokenCache/TokenCacheStorage.cs
+++ b/src/Authentication/Authentication/TokenCache/TokenCacheStorage.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.TokenCache
 
             if (authContext.ContextScope == ContextScope.Process)
             {
-                return GraphSession.Instance.Token;
+                return GraphSession.Instance.MSALToken;
             }
             else
             {
@@ -69,7 +69,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.TokenCache
 
             if (authContext.ContextScope == ContextScope.Process)
             {
-                GraphSession.Instance.Token = accessToken;
+                GraphSession.Instance.MSALToken = accessToken;
             }
             else if (authContext.ContextScope == ContextScope.CurrentUser)
             {
@@ -104,7 +104,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.TokenCache
 
             if (authContext.ContextScope == ContextScope.Process)
             {
-                GraphSession.Instance.Token = null;
+                GraphSession.Instance.MSALToken = null;
             }
             else
             {


### PR DESCRIPTION
This PR adds `-accessToken` to `Connect-Graph`. The access token lives in the session object and the customer will have to handle its refresh by calling `Connect-Graph -AccessToken "NEW_TOKEN"`.

### Proposed Usage
![image](https://user-images.githubusercontent.com/7061532/93233069-81b70400-f72f-11ea-9ee7-60b269e1fc10.png)


Closes #335