### PR TITLE
Connect and Disconnect-Graph Aliases

### DIFF
--- a/src/Authentication/Authentication/Cmdlets/ConnectGraph.cs
+++ b/src/Authentication/Authentication/Cmdlets/ConnectGraph.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                         TimeSpan authTimeout = new TimeSpan(0, 0, Constants.MaxDeviceCodeTimeOut);
                         cancellationTokenSource = new CancellationTokenSource(authTimeout);
                         authContext.AuthType = AuthenticationType.Delegated;
-                        authContext.Scopes = Scopes ?? new string[] { "User.Read" };
+                        string[] processedScopes = ProcessScopes(Scopes);
+                        authContext.Scopes = processedScopes.Length == 0 ? new string[] { "User.Read" } : processedScopes;
                         // Default to CurrentUser but allow the customer to change this via `ContextScope` param.
                         authContext.ContextScope = this.IsParameterBound(nameof(ContextScope)) ? ContextScope : ContextScope.CurrentUser;
                     }
@@ -188,6 +189,31 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
         {
             cancellationTokenSource.Cancel();
             base.StopProcessing();
+        }
+
+        /// <summary>
+        /// Processes user provided scopes by removing whitespace and splitting comma separated scopes.
+        /// </summary>
+        /// <param name="scopes">An array of scopes.</param>
+        /// <returns>A formated array of scopes.</returns>
+        private string[] ProcessScopes(string[] scopes)
+        {
+            if (scopes == null)
+            {
+                return new string[0];
+            }
+
+            List<string> formatedScopes = new List<string>();
+            foreach (string scope in scopes)
+            {
+                string[] cleanScopes = scope.Split(',')
+                    .Select(s => s.Trim())
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+                    .ToArray();
+
+                formatedScopes.AddRange(cleanScopes);
+            }
+            return formatedScopes.ToArray();
         }
 
         private void ValidateParameters()

--- a/src/Authentication/Authentication/Cmdlets/ConnectMgGraph.cs
+++ b/src/Authentication/Authentication/Cmdlets/ConnectMgGraph.cs
@@ -17,8 +17,9 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     using System.Net;
     using System.Globalization;
 
-    [Cmdlet(VerbsCommunications.Connect, "Graph", DefaultParameterSetName = Constants.UserParameterSet)]
-    public class ConnectGraph : PSCmdlet, IModuleAssemblyInitializer, IModuleAssemblyCleanup
+    [Cmdlet(VerbsCommunications.Connect, "MgGraph", DefaultParameterSetName = Constants.UserParameterSet)]
+    [Alias("Connect-Graph")]
+    public class ConnectMgGraph : PSCmdlet, IModuleAssemblyInitializer, IModuleAssemblyCleanup
     {
         [Parameter(ParameterSetName = Constants.UserParameterSet,
             Position = 1,

--- a/src/Authentication/Authentication/Cmdlets/ConnectMgGraph.cs
+++ b/src/Authentication/Authentication/Cmdlets/ConnectMgGraph.cs
@@ -30,11 +30,13 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             Position = 1,
             Mandatory = true,
             HelpMessage = "The client id of your application.")]
+        [Alias("AppId")]
         public string ClientId { get; set; }
 
         [Parameter(ParameterSetName = Constants.AppParameterSet,
             Position = 2,
             HelpMessage = "The name of your certificate. The Certificate will be retrieved from the current user's certificate store.")]
+        [Alias("CertificateSubject")]
         public string CertificateName { get; set; }
 
         [Parameter(ParameterSetName = Constants.AppParameterSet,

--- a/src/Authentication/Authentication/Cmdlets/DisconnectMgGraph.cs
+++ b/src/Authentication/Authentication/Cmdlets/DisconnectMgGraph.cs
@@ -6,8 +6,9 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     using Microsoft.Graph.PowerShell.Authentication.Helpers;
     using System;
     using System.Management.Automation;
-    [Cmdlet(VerbsCommunications.Disconnect, "Graph")]
-    public class DisconnectGraph : PSCmdlet
+    [Cmdlet(VerbsCommunications.Disconnect, "MgGraph")]
+    [Alias("Disconnect-Graph")]
+    public class DisconnectMgGraph : PSCmdlet
     {
         protected override void BeginProcessing()
         {

--- a/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
@@ -22,14 +22,15 @@ using DriveNotFoundException = System.Management.Automation.DriveNotFoundExcepti
 
 namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
 {
-    [Cmdlet(VerbsLifecycle.Invoke, "GraphRequest", DefaultParameterSetName = Constants.UserParameterSet)]
-    public class InvokeGraphRequest : PSCmdlet
+    [Cmdlet(VerbsLifecycle.Invoke, "MgGraphRequest", DefaultParameterSetName = Constants.UserParameterSet)]
+    [Alias("Invoke-GraphRequest")]
+    public class InvokeMgGraphRequest : PSCmdlet
     {
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly InvokeGraphRequestUserAgent _graphRequestUserAgent;
         private string _originalFilePath;
 
-        public InvokeGraphRequest()
+        public InvokeMgGraphRequest()
         {
             _cancellationTokenSource = new CancellationTokenSource();
             _graphRequestUserAgent = new InvokeGraphRequestUserAgent(this);

--- a/src/Authentication/Authentication/Helpers/HttpHelpers.cs
+++ b/src/Authentication/Authentication/Helpers/HttpHelpers.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
     public static class HttpHelpers
     {
         /// The version for current assembly.
-        private static AssemblyName AssemblyInfo = typeof(ConnectGraph).GetTypeInfo().Assembly.GetName();
+        private static AssemblyName AssemblyInfo = typeof(ConnectMgGraph).GetTypeInfo().Assembly.GetName();
 
         /// The value for the Auth module version header.
         private static string AuthModuleVersionHeaderValue =

--- a/src/Authentication/Authentication/Helpers/PathUtils.cs
+++ b/src/Authentication/Authentication/Helpers/PathUtils.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
     /// </summary>
     internal static class PathUtils
     {
-        public static string ResolveFilePath(string filePath, InvokeGraphRequest command, bool isLiteralPath)
+        public static string ResolveFilePath(string filePath, InvokeMgGraphRequest command, bool isLiteralPath)
         {
             string path = null;
             try

--- a/src/Authentication/Authentication/Helpers/StreamHelper.cs
+++ b/src/Authentication/Authentication/Helpers/StreamHelper.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         }
 
         internal static void SaveStreamToFile(this Stream baseResponseStream, string filePath,
-            InvokeGraphRequest invokeGraphRequest, CancellationToken token)
+            InvokeMgGraphRequest invokeGraphRequest, CancellationToken token)
         {
             // If the web cmdlet should resume, append the file instead of overwriting.
             const FileMode fileMode = FileMode.Create;

--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
@@ -72,14 +72,14 @@ FormatsToProcess = './Microsoft.Graph.Authentication.format.ps1xml'
 FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = 'Connect-Graph', 'Disconnect-Graph', 'Get-MgContext', 'Get-MgProfile', 
+CmdletsToExport = 'Connect-MgGraph', 'Disconnect-MgGraph', 'Get-MgContext', 'Get-MgProfile', 
                'Select-MgProfile', 'Invoke-GraphRequest'
 
 # Variables to export from this module
 # VariablesToExport = @()
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @()
+AliasesToExport = @('Connect-Graph', 'Disconnect-Graph')
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
@@ -73,13 +73,13 @@ FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = 'Connect-MgGraph', 'Disconnect-MgGraph', 'Get-MgContext', 'Get-MgProfile', 
-               'Select-MgProfile', 'Invoke-GraphRequest'
+               'Select-MgProfile', 'Invoke-MgGraphRequest'
 
 # Variables to export from this module
 # VariablesToExport = @()
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @('Connect-Graph', 'Disconnect-Graph')
+AliasesToExport = @('Connect-Graph', 'Disconnect-Graph', 'Invoke-GraphRequest')
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()


### PR DESCRIPTION
This PR proposed the following changes:
1. Renames `Connect-Graph` and `Disconnect-Graph` to `Connect-MgGraph` and `Disconnect-MgGraph` respectively. Their old names are then use as aliases to avoid breaking change. See customer ask https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/142#issuecomment-606776307.
2. Adds support for comma separates scopes. This was previously broken. Closes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/381.

### Open Question
- Should we also alias `Invoke-GraphRequest`? If so, what name should we use.
