### PR TITLE
Stream Support Improvements

### DIFF
--- a/config/ModulesMapping.jsonc
+++ b/config/ModulesMapping.jsonc
@@ -13,7 +13,7 @@
     "Files": "^drives\\.|^shares\\.|^users.drive$|^groups.drive$",
     "Financials": "^financials\\.",
     "Groups": "^groups.group$|^groups.directoryObject$|^groups.conversation$|^groups.endpoint$|^groups.extension$|^groups.resourceSpecificPermissionGrant$|^groups.profilePhoto$|^groups.conversationThread$|^groupLifecyclePolicies\\.|^users.group$|^groups.directorySetting$|^groups.Actions$|^groups.Functions$",
-    "Identity.DirectoryManagement": "^administrativeUnits\\.|^contacts\\.|^devices\\.|^domains\\.|^directoryRoles\\.|^directoryRoleTemplates\\.|^directorySettingTemplates\\.|^settings\\.|^subscribedSkus\\.|^contracts\\.|^directory\\.|^users.scopedRoleMembership$|^organization.organization$|^organization.organizationalBranding$|^organization.organizationSettings $|^organization.Actions$|^organization.extension$",
+    "Identity.DirectoryManagement": "^administrativeUnits\\.|^contacts\\.|^devices\\.|^domains\\.|^directoryRoles\\.|^directoryRoleTemplates\\.|^directorySettingTemplates\\.|^settings\\.|^subscribedSkus\\.|^contracts\\.|^directory\\.|^users.scopedRoleMembership$|^organization.organization$|^organization.organizationalBranding$|^organization.organizationSettings$|^organization.Actions$|^organization.extension$",
     "Identity.Governance": "^accessReviews\\.|^businessFlowTemplates\\.|^programs\\.|^programControls\\.|^programControlTypes\\.|^privilegedRoles\\.|^privilegedRoleAssignments\\.|^privilegedRoleAssignmentRequests\\.|^privilegedApproval\\.|^privilegedOperationEvents\\.|^privilegedAccess\\.|^agreements\\.|^users.agreementAcceptance$|^identityGovernance.entitlementManagement$|^identityGovernance.Functions$|^identityGovernance.Actions$",
     "Identity.SignIns": "^organization.certificateBasedAuthConfiguration$|^invitations\\.|^identityProviders\\.|^oauth2PermissionGrants\\.|^riskDetections\\.|^riskyUsers\\.|^dataPolicyOperations\\.|^identity.identityUserFlow$|^trustFramework\\.|^informationProtection\\.|^policies\\.|^users.authentication$|^users.informationProtection$|^identity.conditionalAccessRoot$",
     "Mail": "^users.inferenceClassification$|^users.mailFolder$|^users.message$",
@@ -26,7 +26,7 @@
     "Search": "^search\\.|^external\\.",
     "Security": "^Security\\.",
     "Sites": "^sites.site$|^sites.itemAnalytics$|^sites.columnDefinition$|^sites.contentType$|^sites.drive$|^sites.list$|^sites.sitePage$|^users.site$|^groups.site$|^sites.Functions$|^sites.Actions$",
-    "Teams": "^teams\\.|^chats\\.|^users.chat$|^appCatalogs$|^users.userTeamwork$|^teamwork\\.|^users.team$|^users.userTeamwork$|^groups.team$",
+    "Teams": "^teams\\.|^chats\\.|^users.chat$|^appCatalogs.teamsApp$|^users.userTeamwork$|^teamwork\\.|^users.team$|^groups.team$",
     "Users": "^users.user$|^users.directoryObject$|^users.licenseDetails$|^users.notification$|^users.outlookUser$|^users.profilePhoto$|^users.userSettings$|^users.extension$|^users.oAuth2PermissionGrant$|^users.todo$",
     "Users.Actions": "^users.Actions$",
     "Users.Functions": "^users.Functions$"

--- a/src/Applications/Applications/readme.md
+++ b/src/Applications/Applications/readme.md
@@ -38,6 +38,9 @@ subject-prefix: ''
 
 ``` yaml
 directive:
+# Remove invalid paths.
+  - remove-path-by-operation: onPremisesPublishingProfiles\.(connectors\.memberOf_.*|connectors_GetMemberOf|connectorGroups\.members_.*|connectorGroups_(Get|Create|Update|Delete)Members)
+
 # Remove cmdlets
   - where:
       verb: Test
@@ -69,6 +72,11 @@ directive:
       subject: ^OnPremis(PublishingProfile.*)$
     set:
       subject: OnPremise$1
+# Fix cmdlet name
+  - where:
+      subject: (^OnPremisePublishingProfileConnectorMember$)
+    set:
+      subject: $1Of
 ```
 ### Versioning
 

--- a/src/Authentication/Authentication/Common/DiskDataStore.cs
+++ b/src/Authentication/Authentication/Common/DiskDataStore.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Common
     /// <summary>
     /// Disk data store based on System.IO APIs.
     /// </summary>
-    internal class DiskDataStore : IDataStore
+    public class DiskDataStore : IDataStore
     {
         /// <summary>
         /// Writes the given contents to the specified file.

--- a/src/Authentication/Authentication/Common/ProtectedFileProvider.cs
+++ b/src/Authentication/Authentication/Common/ProtectedFileProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Common
     /// The file can be accessed in ReadOnly or ReadWrite mode.
     /// This class MUST be disposed by the caller.
     /// </summary>
-    internal abstract class ProtectedFileProvider : IFileProvider, IDisposable
+    public abstract class ProtectedFileProvider : IFileProvider, IDisposable
     {
         protected Stream _stream;
         public const int MaxTries = 30;

--- a/src/Files/Files/readme.md
+++ b/src/Files/Files/readme.md
@@ -38,7 +38,7 @@ subject-prefix: ''
 
 ``` yaml
 directive:
-  - remove-path-by-operation: .*_(Create|Get|Update|Set|Delete)Activities$|.*\.activities.*$
+  - remove-path-by-operation: .*_(Create|Get|Update|Set|Delete)Activities$|.*\.activities.*$|shares\..*_createLink
 ```
 ### Versioning
 

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -6,7 +6,7 @@
 azure: false
 powershell: true
 version: latest
-use: "@autorest/powershell@latest"
+use: "@autorest/powershell@2.1.401"
 metadata:
     authors: Microsoft Corporation
     owners: Microsoft Corporation

--- a/tools/Custom/FileUploadCmdlet.cs
+++ b/tools/Custom/FileUploadCmdlet.cs
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+namespace Microsoft.Graph.PowerShell.Cmdlets.Custom
+{
+    using System.IO;
+    using System.Management.Automation;
+
+    public partial class FileUploadCmdlet : PSCmdlet
+    {
+        /// <summary>Backing field for <see cref="InFile" /> property.</summary>
+        private string _inFile;
+
+        /// <summary>The path to the file to upload. This SHOULD include the file name and extension.</summary>
+        [Parameter(Mandatory = true, HelpMessage = "The path to the file to upload. This should include a path and file name. If you omit the path, the current location will be used.")]
+        [Runtime.Info(
+        Required = true,
+        ReadOnly = false,
+        Description = @"The path to the file to upload. This should include a path and file name. If you omit the path, the current location will be used.",
+        PossibleTypes = new[] { typeof(string) })]
+        [ValidateNotNullOrEmpty()]
+        [Category(ParameterCategory.Runtime)]
+        public string InFile { get => this._inFile; set => this._inFile = value; }
+
+        /// <summary>
+        /// Creates a file stream from the provided input file.
+        /// </summary>
+        /// <returns>A file stream.</returns>
+        internal Stream GetFileAsStream()
+        {
+            if (MyInvocation.BoundParameters.ContainsKey(nameof(InFile)))
+            {
+                string resolvedFilePath = this.GetProviderPath(InFile, true);
+                return new FileStream(resolvedFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/tools/Custom/FileUploadCmdlet.cs
+++ b/tools/Custom/FileUploadCmdlet.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------
 namespace Microsoft.Graph.PowerShell.Cmdlets.Custom
 {
+    using Microsoft.Graph.PowerShell.Authentication.Common;
     using System.IO;
     using System.Management.Automation;
 
@@ -31,7 +32,8 @@ namespace Microsoft.Graph.PowerShell.Cmdlets.Custom
             if (MyInvocation.BoundParameters.ContainsKey(nameof(InFile)))
             {
                 string resolvedFilePath = this.GetProviderPath(InFile, true);
-                return new FileStream(resolvedFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                var fileProvider = ProtectedFileProvider.CreateFileProvider(resolvedFilePath, FileProtection.SharedRead, new DiskDataStore());
+                return fileProvider.Stream;
             }
             else
             {

--- a/tools/Custom/PSCmdletExtensions.cs
+++ b/tools/Custom/PSCmdletExtensions.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------
 namespace Microsoft.Graph.PowerShell
 {
+    using Microsoft.Graph.PowerShell.Authentication.Common;
     using System;
     using System.Collections.ObjectModel;
     using System.IO;
@@ -62,9 +63,9 @@ namespace Microsoft.Graph.PowerShell
         /// <param name="cancellationToken">A cancellation token that will be used to cancel the operation by the user.</param>
         internal static void WriteToFile(this PSCmdlet cmdlet, Stream inputStream, string filePath, CancellationToken cancellationToken)
         {
-            using (FileStream fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read))
+            using (var fileProvider = ProtectedFileProvider.CreateFileProvider(filePath, FileProtection.ExclusiveWrite, new DiskDataStore()))
             {
-                cmdlet.WriteToStream(inputStream, fileStream, cancellationToken);
+                cmdlet.WriteToStream(inputStream, fileProvider.Stream, cancellationToken);
             }
         }
 

--- a/tools/Custom/PSCmdletExtensions.cs
+++ b/tools/Custom/PSCmdletExtensions.cs
@@ -1,0 +1,103 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+namespace Microsoft.Graph.PowerShell
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.IO;
+    using System.Management.Automation;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal static class PSCmdletExtensions
+    {
+        /// <summary>
+        /// Gets a resolved or unresolved path from PSPath.
+        /// </summary>
+        /// <param name="cmdlet">The calling <see cref="PSCmdlet"/>.</param>
+        /// <param name="filePath">The file path to get a provider path for.</param>
+        /// <param name="isResolvedPath">Determines whether get a resolved or unresolved provider path.</param>
+        /// <returns>The provider path from PSPath.</returns>
+        internal static string GetProviderPath(this PSCmdlet cmdlet, string filePath, bool isResolvedPath)
+        {
+            string providerPath = null;
+            ProviderInfo provider;
+            try
+            {
+                var paths = new Collection<string>();
+                if (isResolvedPath)
+                {
+                    paths = cmdlet.SessionState.Path.GetResolvedProviderPathFromPSPath(filePath, out provider);
+                }
+                else
+                {
+                    paths.Add(cmdlet.SessionState.Path.GetUnresolvedProviderPathFromPSPath(filePath, out provider, out _));
+                }
+
+                if (provider.Name != "FileSystem" || paths.Count == 0)
+                {
+                    cmdlet.ThrowTerminatingError(new ErrorRecord(new Exception("Invalid path."), string.Empty, ErrorCategory.InvalidArgument, filePath));
+                }
+                if (paths.Count > 1)
+                {
+                    cmdlet.ThrowTerminatingError(new ErrorRecord(new Exception("Multiple paths not allowed."), string.Empty, ErrorCategory.InvalidArgument, filePath));
+                }
+                providerPath = paths[0];
+            }
+            catch (Exception)
+            {
+                providerPath = filePath;
+            }
+
+            return providerPath;
+        }
+
+        /// <summary>
+        /// Saves a stream to a file on disk.
+        /// </summary>
+        /// <param name="cmdlet">The calling <see cref="PSCmdlet"/>.</param>
+        /// <param name="inputStream">The stream to write to file.</param>
+        /// <param name="filePath">The path to write the file to. This should include the file name and extension.</param>
+        /// <param name="cancellationToken">A cancellation token that will be used to cancel the operation by the user.</param>
+        internal static void WriteToFile(this PSCmdlet cmdlet, Stream inputStream, string filePath, CancellationToken cancellationToken)
+        {
+            using (FileStream fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read))
+            {
+                cmdlet.WriteToStream(inputStream, fileStream, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Write an input stream to an output stream.
+        /// </summary>
+        /// <param name="cmdlet">The calling <see cref="PSCmdlet"/>.</param>
+        /// <param name="inputStream">The stream to write to an output stream.</param>
+        /// <param name="outputStream">The stream to write the input stream to.</param>
+        /// <param name="cancellationToken">A cancellation token that will be used to cancel the operation by the user.</param>
+        private static void WriteToStream(this PSCmdlet cmdlet, Stream inputStream, Stream outputStream, CancellationToken cancellationToken)
+        {
+            var copyTask = inputStream.CopyToAsync(outputStream);
+            var record = new ProgressRecord(000000000, "WriteRequestProgressActivity", "WriteRequestProgressStatus");
+            try
+            {
+                do
+                {
+                    record.StatusDescription = string.Format("Number of bytes processed {0}", outputStream.Position);
+                    cmdlet.WriteProgress(record);
+
+                    Task.Delay(1000, cancellationToken).Wait(cancellationToken);
+                } while (!copyTask.IsCompleted && !cancellationToken.IsCancellationRequested);
+
+                if (copyTask.IsCompleted)
+                {
+                    record.StatusDescription = string.Format("Number of bytes processed {0}", outputStream.Position);
+                    cmdlet.WriteProgress(record);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+}

--- a/tools/Custom/PSCmdletExtensions.cs
+++ b/tools/Custom/PSCmdletExtensions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Graph.PowerShell
     using System.Collections.ObjectModel;
     using System.IO;
     using System.Management.Automation;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -58,47 +59,63 @@ namespace Microsoft.Graph.PowerShell
         /// Saves a stream to a file on disk.
         /// </summary>
         /// <param name="cmdlet">The calling <see cref="PSCmdlet"/>.</param>
+        /// <param name="response">The HTTP response from the service.</param>
         /// <param name="inputStream">The stream to write to file.</param>
         /// <param name="filePath">The path to write the file to. This should include the file name and extension.</param>
         /// <param name="cancellationToken">A cancellation token that will be used to cancel the operation by the user.</param>
-        internal static void WriteToFile(this PSCmdlet cmdlet, Stream inputStream, string filePath, CancellationToken cancellationToken)
+        internal static void WriteToFile(this PSCmdlet cmdlet, HttpResponseMessage response, Stream inputStream, string filePath, CancellationToken cancellationToken)
         {
             using (var fileProvider = ProtectedFileProvider.CreateFileProvider(filePath, FileProtection.ExclusiveWrite, new DiskDataStore()))
             {
-                cmdlet.WriteToStream(inputStream, fileProvider.Stream, cancellationToken);
+                string downloadUrl = response?.RequestMessage?.RequestUri.ToString();
+                cmdlet.WriteToStream(inputStream, fileProvider.Stream, downloadUrl, cancellationToken);
             }
         }
 
         /// <summary>
-        /// Write an input stream to an output stream.
+        /// Writes an input stream to an output stream.
         /// </summary>
         /// <param name="cmdlet">The calling <see cref="PSCmdlet"/>.</param>
         /// <param name="inputStream">The stream to write to an output stream.</param>
         /// <param name="outputStream">The stream to write the input stream to.</param>
         /// <param name="cancellationToken">A cancellation token that will be used to cancel the operation by the user.</param>
-        private static void WriteToStream(this PSCmdlet cmdlet, Stream inputStream, Stream outputStream, CancellationToken cancellationToken)
+        private static void WriteToStream(this PSCmdlet cmdlet, Stream inputStream, Stream outputStream, string downloadUrl, CancellationToken cancellationToken)
         {
-            var copyTask = inputStream.CopyToAsync(outputStream);
-            var record = new ProgressRecord(000000000, "WriteRequestProgressActivity", "WriteRequestProgressStatus");
+            Task copyTask = inputStream.CopyToAsync(outputStream);
+            ProgressRecord record = new ProgressRecord(
+                activityId: 0,
+                activity: $"Downloading {downloadUrl ?? "file"}",
+                statusDescription: $"{outputStream.Position} of {outputStream.Length} bytes downloaded.");
             try
             {
                 do
                 {
-                    record.StatusDescription = string.Format("Number of bytes processed {0}", outputStream.Position);
-                    cmdlet.WriteProgress(record);
+                    cmdlet.WriteProgress(GetProgress(record, outputStream));
 
                     Task.Delay(1000, cancellationToken).Wait(cancellationToken);
                 } while (!copyTask.IsCompleted && !cancellationToken.IsCancellationRequested);
 
                 if (copyTask.IsCompleted)
                 {
-                    record.StatusDescription = string.Format("Number of bytes processed {0}", outputStream.Position);
-                    cmdlet.WriteProgress(record);
+                    cmdlet.WriteProgress(GetProgress(record, outputStream));
                 }
             }
             catch (OperationCanceledException)
             {
             }
+        }
+
+        /// <summary>
+        /// Calculates and updates the progress record of the provided stream.
+        /// </summary>
+        /// <param name="currentProgressRecord">The <see cref="ProgressRecord"/> to update.</param>
+        /// <param name="stream">The stream to calculate its progress.</param>
+        /// <returns>An updated <see cref="ProgressRecord"/>.</returns>
+        private static ProgressRecord GetProgress(ProgressRecord currentProgressRecord, Stream stream)
+        {
+            currentProgressRecord.StatusDescription = $"{stream.Position} of {stream.Length} bytes downloaded.";
+            currentProgressRecord.PercentComplete = (int)Math.Round((double)(100 * stream.Position) / stream.Length);
+            return currentProgressRecord;
         }
     }
 }


### PR DESCRIPTION
This PR proposes the following changes to properly handle file upload and download with the generated commands.

1. Adds `FileUploadCmdlet` class. This will be the base class for all cmdlets that upload files i.e. `-BodyParameter` is of type `Stream` and name starts with `Set-*`. `FileUploadCmdlet` class performs the following :
   - Adds a mandatory `-InFile` parameter to all cmdlets that derive from `FileUploadCmdlet`.
   - `GetFileAsStream` handles getting a resolved path to the file and returns a thread safe stream.
2. Adds `PSCmdletExtensions` class. This class provides helper methods that handle retrieval of valid paths and writing of streams to a file on disk.
3. Adds directives to replace broken file upload and download logic in generated cmdlets. 
    For file download, the directive:
      - Add logic that handles writing of response streams by calling `WriteToFile` in `PSCmdletExtensions`.
  
    For file upload, the directive:
      - Replaces generated base class with `FileUploadCmdlet`.
      - Makes `bodyParameter` optional since `FileUploadCmdlet` adds a mandatory `-InFile` parameter.
      -  Adds logic handles creation of thread safe file upload stream by calling `GetFileAsStream` in `FileUploadCmdlet.
4. Updates modules mapping tags and onpremisespublishingprofile [directives](https://docs.microsoft.com/en-us/graph/api/resources/onpremisespublishingprofile-root?view=graph-rest-beta).

#### Proposed Usage
``` powershell
# Download user profile photo.
Get-MgUserPhotoContent -UserId $userId -OutFile "c:\tmp\profile.png"

# Upload user profile photo.
Set-MgUserPhotoContent -UserId $userId -InFile "c:\tmp\newProfile.png"

# Download drive item content.
Get-MgDriveItemContent -DriveId $driveId -DriveItemId $itemId -OutFile "c:\tmp\doc.docx"

# Upload drive item content.
Set-MgDriveItemContent -DriveId $driveId -DriveItemId $itemId -InFile "c:\tmp\updatedDoc.docx"
```

These changes we tested against the OpenAPI docs in staging. Thanks @irvinesunday!

Closes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/54 and https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/182