### PR TITLE
Format Search Values

### DIFF
--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -551,6 +551,10 @@ directive:
           // Call OnBeforeWriteObject to deserialize '@odata.count' from the response object.
           let writeObjectRegex = /^(\s*)(WriteObject\(result\.Value,true\);)$/gm
           $ = $.replace(writeObjectRegex,'\n$1OnBeforeWriteObject(this.InvocationInformation.BoundParameters, result?.AdditionalProperties);\n$1$2');
+
+          // Format all Search values by adding quotes around them.
+          let searchQueryRegex = /this\.InvocationInformation\.BoundParameters\.ContainsKey\("Search"\)\s*\?\s*Search\s*:\s*null/gm
+          $ = $.replace(searchQueryRegex, 'this.FormatSearchValue(this.InvocationInformation.BoundParameters, Search)');
         }
         return $;
       }

--- a/tools/Custom/ListCmdlet.cs
+++ b/tools/Custom/ListCmdlet.cs
@@ -173,11 +173,12 @@ namespace Microsoft.Graph.PowerShell.Cmdlets.Custom
         }
 
         /// <summary>
-        /// Adds quote marks around $search values if non exists.
+        /// Adds quotation mark around $search values if none exists.
+        /// This is needed to support KQL e.g. "prop:value".
         /// </summary>
         /// <param name="boundParameters">The bound parameters of the calling cmdlet.</param>
         /// <param name="search">The $search value.</param>
-        /// <returns>A formated search values.</returns>
+        /// <returns>A formated search value.</returns>
         internal string FormatSearchValue(global::System.Collections.Generic.Dictionary<string, object> boundParameters, string search)
         {
             if (!boundParameters.ContainsKey("Search"))

--- a/tools/Custom/ListCmdlet.cs
+++ b/tools/Custom/ListCmdlet.cs
@@ -172,6 +172,26 @@ namespace Microsoft.Graph.PowerShell.Cmdlets.Custom
             return nextLinkUri.Uri;
         }
 
+        /// <summary>
+        /// Adds quote marks around $search values if non exists.
+        /// </summary>
+        /// <param name="boundParameters">The bound parameters of the calling cmdlet.</param>
+        /// <param name="search">The $search value.</param>
+        /// <returns>A formated search values.</returns>
+        internal string FormatSearchValue(global::System.Collections.Generic.Dictionary<string, object> boundParameters, string search)
+        {
+            if (!boundParameters.ContainsKey("Search"))
+            {
+                return null;
+            }
+            else if (!string.IsNullOrWhiteSpace(search) && !search.StartsWith("\""))
+            {
+                search = $"\"{search}\"";
+            }
+
+            return search;
+        }
+
         internal void OnBeforeWriteObject(global::System.Collections.Generic.Dictionary<string, object> boundParameters, global::System.Collections.Generic.IDictionary<string, object> additionalProperties)
         {
             // Get odata.count from the response.


### PR DESCRIPTION
In order to support KQL, `$Search` values should be surrounded by `" "`. This PR adds `FormatSearchValue` method that adds double quote marks around $search values if none exists.

#### Proposed Usage
![image](https://user-images.githubusercontent.com/7061532/97369921-1e121180-186b-11eb-9d59-1acbc434e018.png)

Closes #399 #402 #419