### PR TITLE
Information Stream Cleanup

### DIFF
--- a/.azure-pipelines/generate-beta-modules.yml
+++ b/.azure-pipelines/generate-beta-modules.yml
@@ -133,7 +133,7 @@ jobs:
     displayName: 'Generate and Build Graph Resource Modules'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1'
-      arguments: '-ArtifactsLocation $(Build.ArtifactStagingDirectory)\ -Build -EnableSigning'
+      arguments: '-ArtifactsLocation $(Build.ArtifactStagingDirectory)\ -Build -Test -EnableSigning'
       pwsh: true
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1

--- a/.azure-pipelines/generate-modules-template.yml
+++ b/.azure-pipelines/generate-modules-template.yml
@@ -142,7 +142,7 @@ jobs:
       pwsh: true
       script: |
          Write-Host $(BUILDNUMBER)
-         pwsh $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -ArtifactsLocation $(Build.ArtifactStagingDirectory)\ -Build -EnableSigning -ModulePreviewNumber $(BUILDNUMBER) -UpdateAutoRest -RepositoryName "LocalNugetFeed"
+         pwsh $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -ArtifactsLocation $(Build.ArtifactStagingDirectory)\ -Build -Test -EnableSigning -ModulePreviewNumber $(BUILDNUMBER) -UpdateAutoRest -RepositoryName "LocalNugetFeed"
   
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'ESRP DLL Strong Name (Graph Resource Modules)'

--- a/.azure-pipelines/validate-pr-beta-modules.yml
+++ b/.azure-pipelines/validate-pr-beta-modules.yml
@@ -48,7 +48,7 @@ jobs:
     displayName: 'Generate and Build Graph Resource Modules'
     inputs:
       filePath: '$(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1'
-      arguments: '-RepositoryApiKey $(Api_Key) -Build'
+      arguments: '-RepositoryApiKey $(Api_Key) -Build -Test'
       pwsh: true
   
   - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0

--- a/build.proj
+++ b/build.proj
@@ -31,7 +31,7 @@
     <UpdateAutoRest Condition ="'$(UpdateAutoRest)' == ''">$True</UpdateAutoRest>
     <!-- PS command related -->
     <PowerShellCoreCommandPrefix>pwsh -NonInteractive -NoLogo -NoProfile -Command</PowerShellCoreCommandPrefix>
-    <GenerateModules> $(PowerShellCoreCommandPrefix) &quot; $(RepoTools)/GenerateModules.ps1 -Build -SkipVersionCheck:$(SkipVersionCheck) -EnableSigning:$(EnableSigning) -UpdateAutoRest:$(UpdateAutoRest) &quot; </GenerateModules>
+    <GenerateModules> $(PowerShellCoreCommandPrefix) &quot; $(RepoTools)/GenerateModules.ps1 -Build -Test -SkipVersionCheck:$(SkipVersionCheck) -EnableSigning:$(EnableSigning) -UpdateAutoRest:$(UpdateAutoRest) &quot; </GenerateModules>
     <GenerateRollup> $(PowerShellCoreCommandPrefix) &quot; $(RepoTools)/GenerateRollUpModule.ps1 &quot; </GenerateRollup>
     <GenerateAuth> $(PowerShellCoreCommandPrefix) &quot; $(RepoTools)/GenerateAuthenticationModule.ps1 -Build -BuildWhenEqual:$(BuildWhenEqual) -EnableSigning:$(EnableSigning) &quot; </GenerateAuth>
     <GenerateProfiles> $(PowerShellCoreCommandPrefix) &quot; $(RepoTools)/GenerateProfiles.ps1 &quot; </GenerateProfiles>

--- a/src/Applications/Applications/test/Applications.Tests.ps1
+++ b/src/Applications/Applications/test/Applications.Tests.ps1
@@ -1,0 +1,41 @@
+BeforeAll {
+    $ModuleName = "Microsoft.Graph.Applications"
+    $ModulePath = Join-Path $PSScriptRoot "..\$ModuleName.psd1"
+}
+
+Describe "Applications Module" {
+    It "Module should be available when imported" {
+        $LoadedModule = Get-Module -Name $ModuleName
+
+        $LoadedModule | Should -Not -Be $null
+        $LoadedModule.ExportedCommands.Count | Should -Not -Be 0
+    }
+
+    It "Module import should not write to streams when debug preference is not set" {
+        $ps = [powershell]::Create()
+        $ps.AddScript("Import-Module $ModulePath").Invoke()
+
+        $ps.Streams.Information.Count | Should -Be 0
+        $ps.Streams.Debug.Count | Should -Be 0
+        $ps.Streams.Error.Count | Should -Be 0
+        $ps.Streams.Verbose.Count | Should -Be 0
+        $ps.Streams.Warning.Count | Should -Be 0
+        $ps.Streams.Progress.Count | Should -Be 0
+
+        $ps.Dispose()
+    }
+
+    It "Module import should write to streams when debug preference is set" {
+        $ps = [powershell]::Create()
+        $ps.AddScript("`$DebugPreference = 'Inquire'; Import-Module $ModulePath").Invoke()
+
+        $ps.Streams.Information.Count | Should -Be 0
+        $ps.Streams.Debug.Count | Should -Be 2
+        $ps.Streams.Error.Count | Should -Be 0
+        $ps.Streams.Verbose.Count | Should -Be 0
+        $ps.Streams.Warning.Count | Should -Be 0
+        $ps.Streams.Progress.Count | Should -Be 0
+
+        $ps.Dispose()
+    }
+}

--- a/src/CloudCommunications/CloudCommunications/test/CloudCommunications.Tests.ps1
+++ b/src/CloudCommunications/CloudCommunications/test/CloudCommunications.Tests.ps1
@@ -1,0 +1,41 @@
+BeforeAll {
+    $ModuleName = "Microsoft.Graph.CloudCommunications"
+    $ModulePath = Join-Path $PSScriptRoot "..\$ModuleName.psd1"
+}
+
+Describe "CloudCommunications Module" {
+    It "Module should be available when imported" {
+        $LoadedModule = Get-Module -Name $ModuleName
+
+        $LoadedModule | Should -Not -Be $null
+        $LoadedModule.ExportedCommands.Count | Should -Not -Be 0
+    }
+
+    It "Module import should not write to streams when debug preference is not set" {
+        $ps = [powershell]::Create()
+        $ps.AddScript("Import-Module $ModulePath").Invoke()
+
+        $ps.Streams.Information.Count | Should -Be 0
+        $ps.Streams.Debug.Count | Should -Be 0
+        $ps.Streams.Error.Count | Should -Be 0
+        $ps.Streams.Verbose.Count | Should -Be 0
+        $ps.Streams.Warning.Count | Should -Be 0
+        $ps.Streams.Progress.Count | Should -Be 0
+
+        $ps.Dispose()
+    }
+
+    It "Module import should write to streams when debug preference is set" {
+        $ps = [powershell]::Create()
+        $ps.AddScript("`$DebugPreference = 'Inquire'; Import-Module $ModulePath").Invoke()
+
+        $ps.Streams.Information.Count | Should -Be 0
+        $ps.Streams.Debug.Count | Should -Be 2
+        $ps.Streams.Error.Count | Should -Be 0
+        $ps.Streams.Verbose.Count | Should -Be 0
+        $ps.Streams.Warning.Count | Should -Be 0
+        $ps.Streams.Progress.Count | Should -Be 0
+
+        $ps.Dispose()
+    }
+}

--- a/src/Users/Users/test/Users.Tests.ps1
+++ b/src/Users/Users/test/Users.Tests.ps1
@@ -1,0 +1,41 @@
+BeforeAll {
+    $ModuleName = "Microsoft.Graph.Users"
+    $ModulePath = Join-Path $PSScriptRoot "..\$ModuleName.psd1"
+}
+
+Describe "Users Module" {
+    It "Module should be available when imported" {
+        $LoadedModule = Get-Module -Name $ModuleName
+
+        $LoadedModule | Should -Not -Be $null
+        $LoadedModule.ExportedCommands.Count | Should -Not -Be 0
+    }
+
+    It "Module import should not write to streams when debug preference is not set" {
+        $ps = [powershell]::Create()
+        $ps.AddScript("Import-Module $ModulePath").Invoke()
+
+        $ps.Streams.Information.Count | Should -Be 0
+        $ps.Streams.Debug.Count | Should -Be 0
+        $ps.Streams.Error.Count | Should -Be 0
+        $ps.Streams.Verbose.Count | Should -Be 0
+        $ps.Streams.Warning.Count | Should -Be 0
+        $ps.Streams.Progress.Count | Should -Be 0
+
+        $ps.Dispose()
+    }
+
+    It "Module import should write to streams when debug preference is set" {
+        $ps = [powershell]::Create()
+        $ps.AddScript("`$DebugPreference = 'Inquire'; Import-Module $ModulePath").Invoke()
+
+        $ps.Streams.Information.Count | Should -Be 0
+        $ps.Streams.Debug.Count | Should -Be 2
+        $ps.Streams.Error.Count | Should -Be 0
+        $ps.Streams.Verbose.Count | Should -Be 0
+        $ps.Streams.Warning.Count | Should -Be 0
+        $ps.Streams.Progress.Count | Should -Be 0
+
+        $ps.Dispose()
+    }
+}

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -54,8 +54,7 @@ if($ModulePreviewNumber -eq -1) {
 # Install module locally in order to specify it as a dependency for other modules down the generation pipeline.
 # https://stackoverflow.com/questions/46216038/how-do-i-define-requiredmodules-in-a-powershell-module-manifest-psd1.
 $ExistingAuthModule = Find-Module "Microsoft.Graph.Authentication" -Repository $RepositoryName -AllowPrerelease:$AllowPreRelease
-Write-Warning "Auth Module: $ExistingAuthModule.Name"
-Write-Warning "Auth Module: $ExistingAuthModule.Version"
+Write-Host -ForegroundColor Green "Auth Module: $($ExistingAuthModule.Name), $($ExistingAuthModule.Version)"
 if (!(Get-Module -Name $ExistingAuthModule.Name -ListAvailable)) {
     Install-Module $ExistingAuthModule.Name -Repository $RepositoryName -Force -AllowClobber -AllowPrerelease:$AllowPreRelease
 }
@@ -83,7 +82,8 @@ $ModuleMapping.Keys | ForEach-Object -ThrottleLimit $ModuleMapping.Keys.Count -P
     }
     
     $ModuleName = $_
-    Write-Warning "Generating $ModuleName"
+    $FullyQualifiedModuleName = "$using:ModulePrefix.$ModuleName"
+    Write-Host -ForegroundColor Green "Generating '$FullyQualifiedModuleName' module..."
     $ModuleProjectDir = Join-Path $Using:ModulesOutputDir "$ModuleName\$ModuleName"
 
     # Copy AutoRest readme.md config is none exists.
@@ -98,37 +98,36 @@ $ModuleMapping.Keys | ForEach-Object -ThrottleLimit $ModuleMapping.Keys.Count -P
     $ModuleVersion = & $Using:ReadModuleReadMePS1 -ReadMePath $ModuleLevelReadMePath -FieldToRead "module-version"
     if ($ModuleVersion -eq $null) {
         # Module version not set in readme.md.
-        Write-Error "Version number is not set on $Using:ModulePrefix.$ModuleName module. Please set 'module-version' in $ModuleLevelReadMePath."
+        Write-Error "Version number is not set on $FullyQualifiedModuleName module. Please set 'module-version' in $ModuleLevelReadMePath."
     }
 
     # Validate module version with the one on PSGallery.
-    [VersionState] $VersionState = & $Using:ValidateUpdatedModuleVersionPS1 -ModuleName "$Using:ModulePrefix.$ModuleName" -NextVersion $ModuleVersion -PSRepository RepositoryName -ModulePreviewNumber $ModulePreviewNumber
+    [VersionState] $VersionState = & $Using:ValidateUpdatedModuleVersionPS1 -ModuleName "$FullyQualifiedModuleName" -NextVersion $ModuleVersion -PSRepository RepositoryName -ModulePreviewNumber $ModulePreviewNumber
 
     if ($VersionState.Equals([VersionState]::Invalid) -and !$Using:SkipVersionCheck) {
-        Write-Warning "The specified version in $Using:ModulePrefix.$ModuleName module is either higher or lower than what's on $Using:RepositoryName. Update the 'module-version' in $ModuleLevelReadMePath"
+        Write-Warning "The specified version in $FullyQualifiedModuleName module is either higher or lower than what's on $Using:RepositoryName. Update the 'module-version' in $ModuleLevelReadMePath"
     }
     elseif ($VersionState.Equals([VersionState]::EqualToFeed) -and !$SkipVersionCheck) {
-        Write-Warning "$Using:ModulePrefix.$ModuleName module skipped. Version has not changed and is equal to what's on $Using:RepositoryName."
+        Write-Warning "$FullyQualifiedModuleName module skipped. Version has not changed and is equal to what's on $Using:RepositoryName."
     }
     elseif ($VersionState.Equals([VersionState]::Valid) -or $VersionState.Equals([VersionState]::NotOnFeed) -or $Using:SkipVersionCheck) {
         # Read release notes from readme.
         $ModuleReleaseNotes = & $Using:ReadModuleReadMePS1 -ReadMePath $ModuleLevelReadMePath -FieldToRead "release-notes"
         if ($ModuleReleaseNotes -eq $null) {
             # Release notes not set in readme.md.
-            Write-Error "Release notes not set on $Using:ModulePrefix.$ModuleName module. Please set 'release-notes' in $ModuleLevelReadMePath."
+            Write-Error "Release notes not set on $FullyQualifiedModuleName module. Please set 'release-notes' in $ModuleLevelReadMePath."
         }
 
         try {
             # Generate PowerShell modules.
-            Write-Host -ForegroundColor Green "Generating '$Using:ModulePrefix.$ModuleName' module..."
             & autorest --module-version:$ModuleVersion --service-name:$ModuleName $ModuleLevelReadMePath --verbose
             if ($LASTEXITCODE) {
                 Write-Error "Failed to generate '$ModuleName' module."
             }
-            Write-Host -ForegroundColor Green "AutoRest generated '$Using:ModulePrefix.$ModuleName' successfully."
+            Write-Host -ForegroundColor Green "AutoRest generated '$FullyQualifiedModuleName' successfully."
 
             # Manage generated module.
-            Write-Host -ForegroundColor Green "Managing '$Using:ModulePrefix.$ModuleName' module..."
+            Write-Host -ForegroundColor Green "Managing '$FullyQualifiedModuleName' module..."
             & $Using:ManageGeneratedModulePS1 -Module $ModuleName -ModulePrefix $Using:ModulePrefix
 
             if ($Using:Build) {
@@ -146,12 +145,12 @@ $ModuleMapping.Keys | ForEach-Object -ThrottleLimit $ModuleMapping.Keys.Count -P
                 $Profiles = Get-ChildItem -Path $ModuleExportsPath -Directory | %{ $_.Name}
 
                 # Update module manifest wiht profiles.
-                $ModuleManifestPath = Join-Path $ModuleProjectDir "$Using:ModulePrefix.$ModuleName.psd1"
+                $ModuleManifestPath = Join-Path $ModuleProjectDir "$FullyQualifiedModuleName.psd1"
                 [HashTable]$PrivateData = @{ Profiles = $Profiles }
                 Update-ModuleManifest -Path $ModuleManifestPath -PrivateData $PrivateData
 
                 # Update module psm1 with Graph session profile name.
-                $ModulePsm1 = Join-Path $ModuleProjectDir "/$Using:ModulePrefix.$ModuleName.psm1"
+                $ModulePsm1 = Join-Path $ModuleProjectDir "/$FullyQualifiedModuleName.psm1"
                 (Get-Content -Path $ModulePsm1) | ForEach-Object{
                     if ($_ -match '\$instance = \[Microsoft.Graph.PowerShell.Module\]::Instance') {
                         # Update main psm1 with Graph session profile name and module name.
@@ -161,13 +160,15 @@ $ModuleMapping.Keys | ForEach-Object -ThrottleLimit $ModuleMapping.Keys.Count -P
                         # Rename all Azure instances in psm1 to `Microsoft Graph`.
                         $updatedLine = $_ -replace 'Azure', 'Microsoft Graph'
                         # Replace all 'instance.Name' declarations with fully qualified module name.
-                        $updatedLine = $updatedLine -replace '\$\(\$instance.Name\)', "$ModulePrefix.$ModuleName"
+                        $updatedLine = $updatedLine -replace '\$\(\$instance.Name\)', "$FullyQualifiedModuleName"
+                        # Replace Write-Information with Write-Debug
+                        $updatedLine = $updatedLine -replace 'Write\-Information', 'Write-Debug'
                         $updatedLine
                     }
                 } | Set-Content $ModulePsm1
 
                 # Address AutoREST bug where it looks for exports in the wrong directory.
-                $InternalModulePsm1 = Join-Path $ModuleProjectDir "/internal/$Using:ModulePrefix.$ModuleName.internal.psm1"
+                $InternalModulePsm1 = Join-Path $ModuleProjectDir "/internal/$FullyQualifiedModuleName.internal.psm1"
                 (Get-Content -Path $InternalModulePsm1) | ForEach-Object{
                     $updatedLine = $_
                     # Address AutoREST bug where it looks for exports in the wrong directory.

--- a/tools/TestModule.ps1
+++ b/tools/TestModule.ps1
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+param([string] $ModulePath, [string] $ModuleName, [switch]$Isolated)
+$ErrorActionPreference = 'Stop'
+
+# Install Pester
+if (!(Get-Module -Name Pester -ListAvailable)) {
+    Install-Module -Name Pester -Force -SkipPublisherCheck
+}
+
+if(-not $Isolated) {
+  Write-Host -ForegroundColor Green 'Creating isolated process...'
+  $pwsh = [System.Diagnostics.Process]::GetCurrentProcess().Path
+  & "$pwsh" -NonInteractive -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path @PSBoundParameters -Isolated
+  return
+}
+
+$modulePsd1 = Get-Item -Path (Join-Path $ModulePath "./$ModuleName.psd1")
+
+Import-Module -Name Pester
+Import-Module -Name $modulePsd1.FullName
+
+$testFolder = Join-Path $ModulePath 'test'
+Write-Host ("$testFolder")
+$PesterConfiguration = [PesterConfiguration]::Default
+$PesterConfiguration.Run.Path =  $testFolder
+$PesterConfiguration.Run.Exit =  $true
+$PesterConfiguration.TestResult.OutputPath = (Join-Path $testFolder "$moduleName-TestResults.xml")
+  
+try {
+    Invoke-Pester -Configuration $PesterConfiguration
+}
+catch {
+    throw $_
+}
+
+Write-Host -ForegroundColor Green '-------------Done-------------'

--- a/tools/TestModule.ps1
+++ b/tools/TestModule.ps1
@@ -21,7 +21,6 @@ Import-Module -Name Pester
 Import-Module -Name $modulePsd1.FullName
 
 $testFolder = Join-Path $ModulePath 'test'
-Write-Host ("$testFolder")
 $PesterConfiguration = [PesterConfiguration]::Default
 $PesterConfiguration.Run.Path =  $testFolder
 $PesterConfiguration.Run.Exit =  $true


### PR DESCRIPTION
This PR closes #373 by replacing all instances of `Write-Information` in a module (.psm1) with `Write-Debug`. This frees up the information stream since everything will be logged in the debug stream when `$DebugPreference` is set to `inquire` or `Continue`.

### Testing Instructions
#### Both information and debug streams should be empty
``` powershell
$ps = [powershell]::Create()
$ps.AddScript(@'
Connect-MgGraph -CertificateThumbprint $certificateThumbprint -ClientId $appId -TenantId $tenantNameOrId
$Users = Get-MgUser -Top 5
'@).Invoke()
$ps.Streams.Information
$ps.Streams.Debug
```

#### Information stream should be empty and debug stream should contain the logs
``` powershell
$ps = [powershell]::Create()
$ps.AddScript(@'
$DebugPreference = "Inquire"
Connect-MgGraph -CertificateThumbprint $certificateThumbprint -ClientId $appId -TenantId $tenantNameOrId
$Users = Get-MgUser -Top 5
'@).Invoke()
$ps.Streams.Information
$ps.Streams.Debug
```