### PR TITLE
Update phoneMethods property is using PUT method

### DIFF
--- a/openApiDocs/beta/Identity.SignIns.yml
+++ b/openApiDocs/beta/Identity.SignIns.yml
@@ -11422,7 +11422,7 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - users.authentication
       summary: Update the navigation property phoneMethods in users


### PR DESCRIPTION
Fix #278
According to https://docs.microsoft.com/en-us/graph/api/phoneauthenticationmethod-update?view=graph-rest-beta&tabs=http the method is PUT not PATCH.
This PR intends to fix thie behavior.
Please update PowerShell module then.