### PR TITLE
1.3.2 Pre-Releases

### DIFF
--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
@@ -12,7 +12,7 @@
 RootModule = './Microsoft.Graph.Authentication.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.3.1'
+ModuleVersion = '1.3.2'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core', 'Desktop'

--- a/src/DeviceManagement.Actions/DeviceManagement.Actions/readme.md
+++ b/src/DeviceManagement.Actions/DeviceManagement.Actions/readme.md
@@ -41,6 +41,16 @@ directive:
 # Remove invalid paths that exceed Windows file name limit.
   - remove-path-by-operation: ^deviceManagement.(deviceShellScripts.userRunStates.deviceRunStates.managedDevice_.*|windowsAutopilotDeploymentProfiles.(assignedDevices_updateDeviceProperties|assignedDevices.deploymentProfile_assign|assignedDevices.intendedDeploymentProfile_assign|assignedDevices_assignResourceAccountToDevice|assignedDevices_unassignResourceAccountFromDevice)|deviceComplianceScripts.deviceRunStates.managedDevice_.*|deviceCustomAttributeShellScripts.(deviceRunStates.managedDevice_.*|userRunStates.deviceRunStates.managedDevice_.*)|deviceManagementScripts.deviceRunStates.managedDevice(_updateWindowsDeviceAccount|_logoutSharedAppleDeviceActiveUser|_deleteUserFromSharedAppleDevice|_createDeviceLogCollectionRequest|_sendCustomNotificationToCompanyPortal|_triggerConfigurationManagerAction|_windowsDefenderUpdateSignatures)|deviceManagementScripts.userRunStates.deviceRunStates.managedDevice_.*|deviceConfigurations.groupAssignments.deviceConfiguration(_assignedAccessMultiModeProfiles|_windowsPrivacyAccessControls)|deviceHealthScripts.deviceRunStates.managedDevice(_sendCustomNotificationToCompanyPortal|_createDeviceLogCollectionRequest)|deviceShellScripts.deviceRunStates.managedDevice_sendCustomNotificationToCompanyPortal)$
 
+# Remove cmdlets.
+  - where:
+      verb: New
+      subject: ^DeviceManagementComanagedDeviceLogCollectionRequest$
+    remove: true
+  - where:
+      verb: Update
+      subject: ^DeviceManagementComanagedDevice.*
+    remove: true
+
 # Rename cmdlets.
   - where:
       verb: Get
@@ -56,6 +66,22 @@ directive:
     set:
       verb: Invoke
       subject: $1WindowsPrivacyAccessControl
+  - where:
+      verb: Update
+      subject: ^(DeviceManagementGroupPolicyConfiguration)(DefinitionValue)$
+    set:
+      subject: $1Multiple$2
+  - where:
+      verb: Update
+      subject: ^(DeviceManagementIntent)(Setting)$
+    set:
+      subject: $1Multiple$2
+  - where:
+      verb: Update
+      subject: ^(DeviceManagementManagedDevice)$
+    set:
+      verb: New
+      subject: $1WindowsDefenderUpdateSignature
 ```
 ### Versioning
 

--- a/src/DeviceManagement.Actions/DeviceManagement.Actions/readme.md
+++ b/src/DeviceManagement.Actions/DeviceManagement.Actions/readme.md
@@ -57,7 +57,6 @@ directive:
       verb: Invoke
       subject: $1WindowsPrivacyAccessControl
 ```
-
 ### Versioning
 
 ``` yaml

--- a/src/DeviceManagement.Administration/DeviceManagement.Administration/readme.md
+++ b/src/DeviceManagement.Administration/DeviceManagement.Administration/readme.md
@@ -31,6 +31,24 @@ require:
 title: $(service-name)
 subject-prefix: ''
 ```
+
+### Directives
+
+> see https://github.com/Azure/autorest/blob/master/docs/powershell/directives.md
+
+``` yaml
+directive:
+# Remove cmdlets.
+  - where:
+      verb: New
+      subject: ^DeviceManagementGroupPolicyMigrationReport$
+    remove: true
+  - where:
+      verb: Remove
+      subject: ^DeviceManagementGroupPolicyUploadedDefinitionFile$
+    remove: true
+```
+
 ### Versioning
 
 ``` yaml

--- a/src/DeviceManagement.Functions/DeviceManagement.Functions/readme.md
+++ b/src/DeviceManagement.Functions/DeviceManagement.Functions/readme.md
@@ -31,6 +31,30 @@ require:
 title: $(service-name)
 subject-prefix: ''
 ```
+
+### Directives
+
+> see https://github.com/Azure/autorest/blob/master/docs/powershell/directives.md
+
+``` yaml
+directive:
+# Rename cmdlets.
+  - where:
+      subject: ^(DeviceManagement(Condition|ConditionStatementManagementCondition|ConditionStatementManagementConditionStatement))$
+    set:
+      subject: $1ForPlatform
+  - where:
+      subject: ^(DeviceManagementRoleScopeTag)$
+      variant: ^Get$
+    set:
+      subject: $1ById
+  - where:
+      subject: ^(DeviceManagementRoleScopeTag)$
+      variant: ^Get1$|^GetViaIdentity$
+    set:
+      subject: $1ByResource
+```
+
 ### Versioning
 
 ``` yaml

--- a/src/DeviceManagement/DeviceManagement/readme.md
+++ b/src/DeviceManagement/DeviceManagement/readme.md
@@ -41,6 +41,16 @@ directive:
 # Remove invalid paths.
   - remove-path-by-operation: ^deviceManagement.(deviceManagementScripts.userRunStates.deviceRunStates_SetRefManagedDevice|groupPolicyConfigurations.definitionValues.presentationValues_SetRefDefinitionValue|groupPolicyConfigurations.definitionValues.presentationValues_SetRefPresentation|deviceShellScripts.userRunStates.deviceRunStates_SetRefManagedDevice)$
 
+# Remove cmdlets.
+  - where:
+      verb: New
+      subject: subject: ^DeviceManagement(Managed|Comanaged)DeviceLogCollectionRequest$
+    remove: true
+  - where:
+      verb: Update
+      subject: subject: ^DeviceManagementComanagedDevice$
+    remove: true
+
 # Rename cmdlets.
   - where:
       subject: ^(DeviceManagementUserExperienceAnalyticAppHealthApplicationPerformance)$

--- a/src/DeviceManagement/DeviceManagement/readme.md
+++ b/src/DeviceManagement/DeviceManagement/readme.md
@@ -44,11 +44,11 @@ directive:
 # Remove cmdlets.
   - where:
       verb: New
-      subject: subject: ^DeviceManagement(Managed|Comanaged)DeviceLogCollectionRequest$
+      subject: ^DeviceManagement(Managed|Comanaged)DeviceLogCollectionRequest$
     remove: true
   - where:
       verb: Update
-      subject: subject: ^DeviceManagementComanagedDevice$
+      subject: ^DeviceManagementComanagedDevice$
     remove: true
 
 # Rename cmdlets.

--- a/src/DeviceManagement/DeviceManagement/readme.md
+++ b/src/DeviceManagement/DeviceManagement/readme.md
@@ -64,7 +64,6 @@ directive:
     set:
       subject: $1ForWorkSetting
 ```
-
 ### Versioning
 
 ``` yaml

--- a/src/Devices.CorporateManagement/Devices.CorporateManagement/readme.md
+++ b/src/Devices.CorporateManagement/Devices.CorporateManagement/readme.md
@@ -39,7 +39,7 @@ subject-prefix: ''
 ``` yaml
 directive:
 # Remove paths that are too long.
-  - remove-path-by-operation: ^deviceAppManagement.wdacSupplementalPolicies.deviceStatuses(.policy_assign|_GetPolicy|_GetRefPolicy|_UpdateRefPolicy|_DeleteRefPolicy|_SetRefPolicy)$|^deviceManagement.deviceHealthScripts.deviceRunStates.managedDevice_deleteUserFromSharedAppleDevice$
+  - remove-path-by-operation: ^deviceAppManagement.wdacSupplementalPolicies.deviceStatuses(.policy_assign|_GetPolicy|_GetRefPolicy|_UpdateRefPolicy|_DeleteRefPolicy|_SetRefPolicy)$|^deviceManagement.deviceHealthScripts.deviceRunStates.managedDevice_deleteUserFromSharedAppleDevice|^deviceAppManagement.mobileApps.userStatuses.deviceStatuses.app.microsoft.graph.iosVppApp_.*$
 # Rename cmdlets with duplicates in their name.
   - where:
       subject: ^(DeviceAppManagement)(\1)+

--- a/src/Financials/Financials/readme.md
+++ b/src/Financials/Financials/readme.md
@@ -57,6 +57,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.3.1
+module-version: 1.3.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Notes/Notes/readme.md
+++ b/src/Notes/Notes/readme.md
@@ -44,6 +44,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.3.1
+module-version: 1.3.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```


### PR DESCRIPTION
This PR bumps the version of all modules that didn't have a change to 1.3.2 for release. This won't be necessary once we address our branching story. 

### Release notes
- Refreshes modules with latest APIs #561.
- Adds `DeviceManagement`, `DeviceManagement.Administration`, `DeviceManagement.Enrolment`, `DeviceManagement.Actions`, and `DeviceManagement.Functions` modules to the SDK #549.
- Fixes wrong count value with certain commands when a single item is returned in a collection #542.
- Fixes bug where `Connect-MgGraph` would truncate and try to use an invalid certificate thumbprint #540.
- Fixes `-AccessToken` parameter set #540,
- Removes breaking undocumented commands from Compliance module #552.
- Removes breaking undocumented commands from Devices.CorporateManagement module #565.
- Removes invalid `*-UserAuthenticationMethod` commands from `Identity.Signins` module #528.

