### PR TITLE
Fix broken commands in Sites module.

### DIFF
--- a/src/Sites/Sites/readme.md
+++ b/src/Sites/Sites/readme.md
@@ -49,7 +49,7 @@ directive:
   - where:
       verb: Get
       subject: ^Site$
-      variant: ^Get$|^GetViaIdentity$|^List$|^Get3$|^GetViaIdentity3$|^List2$
+      variant: ^Get1$|^Get4$|^GetViaIdentity1$|^GetViaIdentity4$|^List$|^List2$
     set:
       subject: SubSite
   - where:
@@ -65,9 +65,15 @@ directive:
     set:
       subject: SubSite
   - where:
+      verb: Remove
+      subject: ^Site$
+      variant: ^Delete$|^DeleteViaIdentity$|^Delete2$|^DeleteViaIdentity2$
+    set:
+      subject: SubSite
+  - where:
       verb: Get
       subject: (^Site$)
-      variant: ^Get2$|^GetViaIdentity2$|^Get5$|^GetViaIdentity5$
+      variant: ^Get$|^GetViaIdentity$|^Get3$|^GetViaIdentity3$
     set:
       subject: $1ByPath
   - where:

--- a/src/Sites/Sites/test/env.json
+++ b/src/Sites/Sites/test/env.json
@@ -1,0 +1,11 @@
+{
+    "ClientId": "56db239f-b87c-4dc0-9d9b-2ec0318e4ad9",
+    "TenantId": "61fcf17f-000c-4ab8-a4dc-9e92405fc737",
+    "Users": [
+        {
+            "Id": "85d17c69-6789-47c7-bf10-ad08ab4cd8da",
+            "DisplayName": "John Doe",
+            "Mail": "johndoe@testtenant.onmicrosoft.com"
+        }
+    ]
+}

--- a/src/Sites/Sites/test/loadEnv.ps1
+++ b/src/Sites/Sites/test/loadEnv.ps1
@@ -18,11 +18,16 @@ if ($TestMode -eq 'live') {
 
 if (Test-Path -Path (Join-Path $PSScriptRoot $envFile)) {
     $envFilePath = Join-Path $PSScriptRoot $envFile
-} else {
+}
+else {
     $envFilePath = Join-Path $PSScriptRoot '..\$envFile'
 }
 $env = @{}
 if (Test-Path -Path $envFilePath) {
-    $env = Get-Content (Join-Path $PSScriptRoot $envFile) | ConvertFrom-Json
-    $PSDefaultParameterValues=@{"*:SubscriptionId"=$env.SubscriptionId; "*:Tenant"=$env.Tenant}
+    # Load dummy configuration.
+    $env = Get-Content (Join-Path $PSScriptRoot $envFile) | ConvertFrom-Json -AsHashTable
+    [Microsoft.Graph.PowerShell.Authentication.GraphSession]::Instance.AuthContext = New-Object Microsoft.Graph.PowerShell.Authentication.AuthContext -Property @{
+        ClientId = $env.ClientId
+        TenantId = $env.TenantId
+    }
 }

--- a/src/Sites/Sites/test/v1.0-beta/Get-MgSite.Recording.json
+++ b/src/Sites/Sites/test/v1.0-beta/Get-MgSite.Recording.json
@@ -1,0 +1,101 @@
+{
+  "Get-MgSite+[NoContext]+ShouldGetACollectionOfSites+$GET+https://graph.microsoft.com/beta/sites+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/beta/sites",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 20:30:41 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "5e29db13-a2c1-46b6-ad7e-d44e41a09d73" ],
+        "client-request-id": [ "5e29db13-a2c1-46b6-ad7e-d44e41a09d73" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"MW1PEPF00006AF8\"}}" ],
+        "OData-Version": [ "4.0" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\"@odata.context\":\"https://graph.microsoft.com/beta/$metadata#sites\",\"value\":[]}"
+    }
+  },
+  "Get-MgSite+[NoContext]+ShouldGetASingleSite+$GET+https://graph.microsoft.com/beta/sites/root+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/beta/sites/root",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 20:30:41 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "5461e4e9-e1cf-4966-8171-103bd1812b00" ],
+        "client-request-id": [ "5461e4e9-e1cf-4966-8171-103bd1812b00" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"MW1PEPF00006B0E\"}}" ],
+        "OData-Version": [ "4.0" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\"@odata.context\":\"https://graph.microsoft.com/beta/$metadata#sites/$entity\",\"createdDateTime\":\"2020-02-13T19:06:48.53Z\",\"description\":\"\",\"id\":\"dummyRootId\",\"lastModifiedDateTime\":\"2021-02-26T16:43:51Z\",\"name\":\"\",\"webUrl\":\"https://dummyroot.sharepoint.com\",\"displayName\":\"Communication site\",\"root\":{},\"siteCollection\":{\"hostname\":\"dummyroot.sharepoint.com\"}}"
+    }
+  },
+  "Get-MgSite+[NoContext]+ShouldGetASingleSiteViaInputObject+$GET+https://graph.microsoft.com/beta/sites/root+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/beta/sites/root",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 20:30:42 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "93a5e3d0-23e4-44bf-9bf5-368ce6c83e5c" ],
+        "client-request-id": [ "93a5e3d0-23e4-44bf-9bf5-368ce6c83e5c" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"MW1PEPF00006AFC\"}}" ],
+        "OData-Version": [ "4.0" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\"@odata.context\":\"https://graph.microsoft.com/beta/$metadata#sites/$entity\",\"createdDateTime\":\"2020-02-13T19:06:48.53Z\",\"description\":\"\",\"id\":\"dummyRootId\",\"lastModifiedDateTime\":\"2021-02-26T16:43:51Z\",\"name\":\"\",\"webUrl\":\"https://dummyroot.sharepoint.com\",\"displayName\":\"Communication site\",\"root\":{},\"siteCollection\":{\"hostname\":\"dummyroot.sharepoint.com\"}}"
+    }
+  }
+}

--- a/src/Sites/Sites/test/v1.0-beta/Get-MgSite.Tests.ps1
+++ b/src/Sites/Sites/test/v1.0-beta/Get-MgSite.Tests.ps1
@@ -1,26 +1,62 @@
-$loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
-if (-Not (Test-Path -Path $loadEnvPath)) {
-    $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+BeforeAll {
+    $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+    if (-Not (Test-Path -Path $loadEnvPath)) {
+        $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+    }
+    . ($loadEnvPath)
+     # Set test mode to playback.
+     $TestMode = 'playback'
+     $TestRecordingFile = Join-Path $PSScriptRoot 'Get-MgSite.Recording.json'
+    $currentPath = $PSScriptRoot
+    while(-not $mockingPath) {
+        $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
+        $currentPath = Split-Path -Path $currentPath -Parent
+    }
+    . ($mockingPath | Select-Object -First 1).FullName
+
+    Select-MgProfile 'beta'
 }
-. ($loadEnvPath)
-$TestRecordingFile = Join-Path $PSScriptRoot 'Get-MgSite.Recording.json'
-$currentPath = $PSScriptRoot
-while(-not $mockingPath) {
-    $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
-    $currentPath = Split-Path -Path $currentPath -Parent
-}
-. ($mockingPath | Select-Object -First 1).FullName
 
 Describe 'Get-MgSite' {
-    It 'List3' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    BeforeAll {
+        $Mock.PushDescription('Get-MgSite')
+    }
+    
+    Context 'List3'{
+        It 'ShouldGetACollectionOfSites' {
+            $Mock.PushScenario('ShouldGetACollectionOfSites')
+
+            # The API currently returns an empy collection.
+            $Sites = Get-MgSite
+            $Sites | Should -HaveCount 0
+        } 
     }
 
-    It 'Get4' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    Context 'Get5'{
+        It 'ShouldGetASingleSite' {
+            $Mock.PushScenario('ShouldGetASingleSite')
+
+            $SiteId = 'root'
+            $Site = Get-MgSite -SiteId $SiteId
+            $Site | Should -BeOfType -ExpectedType 'Microsoft.Graph.PowerShell.Models.MicrosoftGraphSite'
+            $Site | Should -HaveCount 1
+            $Site.Id | Should -Be 'dummyRootId'
+            $Site.SiteCollection.HostName | Should -Be 'dummyroot.sharepoint.com'
+            $Site.AdditionalProperties | Should -HaveCount 1
+        }
     }
 
-    It 'GetViaIdentity4' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    Context 'GetViaIdentity5'{
+        It 'ShouldGetASingleSiteViaInputObject' {
+            $Mock.PushScenario('ShouldGetASingleSiteViaInputObject')
+
+            $SiteId = 'root'
+            $Site = Get-MgSite -InputObject @{ SiteId = $SiteId }
+            $Site | Should -BeOfType -ExpectedType 'Microsoft.Graph.PowerShell.Models.MicrosoftGraphSite'
+            $Site | Should -HaveCount 1
+            $Site.Id | Should -Be 'dummyRootId'
+            $Site.SiteCollection.HostName | Should -Be 'dummyroot.sharepoint.com'
+            $Site.AdditionalProperties | Should -HaveCount 1
+        }
     }
 }

--- a/src/Sites/Sites/test/v1.0-beta/Get-MgSiteByPath.Recording.json
+++ b/src/Sites/Sites/test/v1.0-beta/Get-MgSiteByPath.Recording.json
@@ -1,0 +1,66 @@
+{
+  "Get-MgSiteByPath+[NoContext]+ShouldFailToGetSiteByPath+$GET+https://graph.microsoft.com/beta/sites/root/microsoft.graph.getByPath(path=\u0027randomPath\u0027)+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/beta/sites/root/microsoft.graph.getByPath(path=\u0027randomPath\u0027)",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 400,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 21:12:55 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "b981dfd2-ac5e-4292-a3bc-9e1a276e0e9d" ],
+        "client-request-id": [ "b981dfd2-ac5e-4292-a3bc-9e1a276e0e9d" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"MW2PEPF000031CA\"}}" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\r\n  \"error\": {\r\n    \"code\": \"invalidRequest\",\r\n    \"message\": \"Invalid request\",\r\n    \"innerError\": {\r\n      \"date\": \"2021-03-08T21:12:55\",\r\n      \"request-id\": \"b981dfd2-ac5e-4292-a3bc-9e1a276e0e9d\",\r\n      \"client-request-id\": \"b981dfd2-ac5e-4292-a3bc-9e1a276e0e9d\"\r\n    }\r\n  }\r\n}"
+    }
+  },
+  "Get-MgSiteByPath+[NoContext]+ShouldFailToGetSiteByPathViaInputObject+$GET+https://graph.microsoft.com/beta/sites/root/microsoft.graph.getByPath(path=\u0027randomPath\u0027)+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/beta/sites/root/microsoft.graph.getByPath(path=\u0027randomPath\u0027)",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 400,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 21:12:56 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "99d67929-240d-4173-81b4-935f6dfe28b4" ],
+        "client-request-id": [ "99d67929-240d-4173-81b4-935f6dfe28b4" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"MW2PEPF000031CD\"}}" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\r\n  \"error\": {\r\n    \"code\": \"invalidRequest\",\r\n    \"message\": \"Invalid request\",\r\n    \"innerError\": {\r\n      \"date\": \"2021-03-08T21:12:56\",\r\n      \"request-id\": \"99d67929-240d-4173-81b4-935f6dfe28b4\",\r\n      \"client-request-id\": \"99d67929-240d-4173-81b4-935f6dfe28b4\"\r\n    }\r\n  }\r\n}"
+    }
+  }
+}

--- a/src/Sites/Sites/test/v1.0-beta/Get-MgSiteByPath.Tests.ps1
+++ b/src/Sites/Sites/test/v1.0-beta/Get-MgSiteByPath.Tests.ps1
@@ -1,22 +1,45 @@
-$loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
-if (-Not (Test-Path -Path $loadEnvPath)) {
-    $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
-}
-. ($loadEnvPath)
-$TestRecordingFile = Join-Path $PSScriptRoot 'Get-MgSiteByPath.Recording.json'
-$currentPath = $PSScriptRoot
-while(-not $mockingPath) {
-    $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
-    $currentPath = Split-Path -Path $currentPath -Parent
-}
-. ($mockingPath | Select-Object -First 1).FullName
+BeforeAll {
+    $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+    if (-Not (Test-Path -Path $loadEnvPath)) {
+        $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+    }
+    . ($loadEnvPath)
+    # Set test mode to playback.
+    $TestMode = 'playback'
+    $TestRecordingFile = Join-Path $PSScriptRoot 'Get-MgSiteByPath.Recording.json'
+    $currentPath = $PSScriptRoot
 
+    while(-not $mockingPath) {
+        $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
+        $currentPath = Split-Path -Path $currentPath -Parent
+    }
+    . ($mockingPath | Select-Object -First 1).FullName
+
+    Select-MgProfile 'beta'
+}
+
+# Skip because /sites/{site-id}/microsoft.graph.getByPath(path='{path}') returns a 400 and is not documented.
 Describe 'Get-MgSiteByPath' {
-    It 'Get5' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    BeforeAll {
+        $Mock.PushDescription('Get-MgSiteByPath')
     }
 
-    It 'GetViaIdentity5' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    Context 'Get' {
+        It 'ShouldFailToGetSiteByPath' {
+            $Mock.PushScenario('ShouldFailToGetSiteByPath')
+            
+            $SiteId = "root"
+            { Get-MgSiteByPath -SiteId $SiteId -Path "randomPath" -ErrorAction Stop } | Should -Throw -ErrorId 'invalidRequest,Microsoft.Graph.PowerShell.Cmdlets.GetMgSiteByPath_Get' -ExpectedMessage 'Invalid request' -ExceptionType 'Microsoft.Graph.PowerShell.Runtime.RestException<Microsoft.Graph.PowerShell.Models.IOdataError>'
+        }
+    }
+
+    Context 'GetViaIdentity' {
+        It 'ShouldFailToGetSiteByPathViaInputObject' {
+            $Mock.PushScenario('ShouldFailToGetSiteByPathViaInputObject')
+            
+            $SiteId = "root"
+            { Get-MgSiteByPath -InputObject @{ SiteId = $SiteId; Path = "randomPath" } -ErrorAction Stop } | Should -Throw -ErrorId 'invalidRequest,Microsoft.Graph.PowerShell.Cmdlets.GetMgSiteByPath_GetViaIdentity' -ExpectedMessage 'Invalid request' -ExceptionType 'Microsoft.Graph.PowerShell.Runtime.RestException<Microsoft.Graph.PowerShell.Models.IOdataError>'
+
+        }
     }
 }

--- a/src/Sites/Sites/test/v1.0-beta/Get-MgSubSite.Recording.json
+++ b/src/Sites/Sites/test/v1.0-beta/Get-MgSubSite.Recording.json
@@ -1,0 +1,99 @@
+{
+  "Get-MgSubSite+[NoContext]+ShouldGetACollectionOfSubSites+$GET+https://graph.microsoft.com/beta/sites/root/sites+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/beta/sites/root/sites",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 21:13:00 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "87c418b2-7763-4225-80f9-456d8d2d06ac" ],
+        "client-request-id": [ "87c418b2-7763-4225-80f9-456d8d2d06ac" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"MW2PEPF000031D0\"}}" ],
+        "OData-Version": [ "4.0" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\"@odata.context\":\"https://graph.microsoft.com/beta/$metadata#sites\",\"value\":[\n{\n\"id\": \"randomId\",\n\"name\": \"Team A Subsite\",\n\"description\": \"\",\n\"createdDateTime\": \"2016-10-18T03:05:59Z\",\n\"lastModifiedDateTime\": \"2016-10-18T10:40:59Z\",\n\"webUrl\": \"https://contoso.sharepoint.com/sites/site/subsiteA\"\n    },\n    {\n\"id\": \"contoso.sharepoint.com,da60e844-ba1d-49bc-b4d4-d5e36bae9019,0271110f-634f-4300-a841-3a8a2e851851\",\n\"name\": \"Team B Subsite\",\n\"description\": \"\",\n\"createdDateTime\": \"2016-10-18T03:05:59Z\",\n\"lastModifiedDateTime\": \"2016-10-18T10:40:59Z\",\n\"webUrl\": \"https://contoso.sharepoint.com/sites/site/subsiteB\"\n }\n ]}"
+    }
+  },
+  "Get-MgSubSite+[NoContext]+ShouldGetASingleSubSite+$GET+https://graph.microsoft.com/beta/sites/root/sites/randomId+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/beta/sites/root/sites/randomId",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 21:13:01 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "fb0cc495-e6cb-455f-a3ac-4b53016a3ec0" ],
+        "client-request-id": [ "fb0cc495-e6cb-455f-a3ac-4b53016a3ec0" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"MW2PEPF000039FD\"}}" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\n \"id\": \"randomId\",\n \"name\": \"Team A Subsite\",\n \"description\": \"\",\n \"createdDateTime\": \"2016-10-18T03:05:59Z\",\n \"lastModifiedDateTime\": \"2016-10-18T10:40:59Z\",\n \"webUrl\": \"https://contoso.sharepoint.com/sites/site/subsiteA\"\n }"
+    }
+  },
+  "Get-MgSubSite+[NoContext]+ShouldGetASingleSubSiteViaInputObject+$GET+https://graph.microsoft.com/beta/sites/root/sites/randomId+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/beta/sites/root/sites/randomId",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 21:13:01 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "f9d5ad8f-11d8-46f3-9086-e4eeafdc60bc" ],
+        "client-request-id": [ "f9d5ad8f-11d8-46f3-9086-e4eeafdc60bc" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"MW2PEPF000031CF\"}}" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\n \"id\": \"randomId\",\n \"name\": \"Team A Subsite\",\n \"description\": \"\",\n \"createdDateTime\": \"2016-10-18T03:05:59Z\",\n \"lastModifiedDateTime\": \"2016-10-18T10:40:59Z\",\n \"webUrl\": \"https://contoso.sharepoint.com/sites/site/subsiteA\"\n }"
+    }
+  }
+}

--- a/src/Sites/Sites/test/v1.0/Get-MgSite.Recording.json
+++ b/src/Sites/Sites/test/v1.0/Get-MgSite.Recording.json
@@ -1,0 +1,101 @@
+{
+  "Get-MgSite+[NoContext]+ShouldGetACollectionOfSites+$GET+https://graph.microsoft.com/v1.0/sites+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/v1.0/sites",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 19:55:17 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "c95dbb94-0cbe-43cd-96c6-0c0b56a878de" ],
+        "client-request-id": [ "7dff06cf-cffe-1d6a-c372-a4751276871b" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"002\",\"RoleInstance\":\"MWH0EPF00032D51\"}}" ],
+        "OData-Version": [ "4.0" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\"@odata.context\":\"https://graph.microsoft.com/beta/$metadata#sites\",\"value\":[]}"
+    }
+  },
+  "Get-MgSite+[NoContext]+ShouldGetASingleSite+$GET+https://graph.microsoft.com/v1.0/sites/root+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/v1.0/sites/root",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 19:55:17 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "2dfa830f-08fd-45d4-99f5-c59f1dab8b05" ],
+        "client-request-id": [ "2dfa830f-08fd-45d4-99f5-c59f1dab8b05" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"002\",\"RoleInstance\":\"MWH0EPF00032D51\"}}" ],
+        "OData-Version": [ "4.0" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#sites/$entity\",\"createdDateTime\":\"2020-02-13T19:06:48.53Z\",\"description\":\"\",\"id\":\"dummyRootId\",\"lastModifiedDateTime\":\"2021-02-26T16:43:51Z\",\"name\":\"\",\"webUrl\":\"https://dummyroot.sharepoint.com\",\"displayName\":\"Communication site\",\"root\":{},\"siteCollection\":{\"hostname\":\"dummyroot.sharepoint.com\"}}"
+    }
+  },
+  "Get-MgSite+[NoContext]+ShouldGetASingleSiteViaInputObject+$GET+https://graph.microsoft.com/v1.0/sites/root+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/v1.0/sites/root",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 19:55:17 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "2dfa830f-08fd-45d4-99f5-c59f1dab8b05" ],
+        "client-request-id": [ "2dfa830f-08fd-45d4-99f5-c59f1dab8b05" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"002\",\"RoleInstance\":\"MWH0EPF00032D51\"}}" ],
+        "OData-Version": [ "4.0" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#sites/$entity\",\"createdDateTime\":\"2020-02-13T19:06:48.53Z\",\"description\":\"\",\"id\":\"dummyRootId\",\"lastModifiedDateTime\":\"2021-02-26T16:43:51Z\",\"name\":\"\",\"webUrl\":\"https://dummyroot.sharepoint.com\",\"displayName\":\"Communication site\",\"root\":{},\"siteCollection\":{\"hostname\":\"dummyroot.sharepoint.com\"}}"
+    }
+  }
+}

--- a/src/Sites/Sites/test/v1.0/Get-MgSite.Tests.ps1
+++ b/src/Sites/Sites/test/v1.0/Get-MgSite.Tests.ps1
@@ -1,26 +1,62 @@
-$loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
-if (-Not (Test-Path -Path $loadEnvPath)) {
-    $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+BeforeAll {
+    $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+    if (-Not (Test-Path -Path $loadEnvPath)) {
+        $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+    }
+    . ($loadEnvPath)
+    # Set test mode to playback.
+    $TestMode = 'playback'
+    $TestRecordingFile = Join-Path $PSScriptRoot 'Get-MgSite.Recording.json'
+    $currentPath = $PSScriptRoot
+    while(-not $mockingPath) {
+        $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
+        $currentPath = Split-Path -Path $currentPath -Parent
+    }
+    . ($mockingPath | Select-Object -First 1).FullName
+
+    Select-MgProfile 'v1.0'
 }
-. ($loadEnvPath)
-$TestRecordingFile = Join-Path $PSScriptRoot 'Get-MgSite.Recording.json'
-$currentPath = $PSScriptRoot
-while(-not $mockingPath) {
-    $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
-    $currentPath = Split-Path -Path $currentPath -Parent
-}
-. ($mockingPath | Select-Object -First 1).FullName
 
 Describe 'Get-MgSite' {
-    It 'List1' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    BeforeAll {
+        $Mock.PushDescription('Get-MgSite')
     }
 
-    It 'Get1' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    Context 'List1' {
+        It 'ShouldGetACollectionOfSites' {
+            $Mock.PushScenario('ShouldGetACollectionOfSites')
+
+            # The API currently returns an empy collection.
+            $Sites = Get-MgSite
+            $Sites | Should -HaveCount 0
+        }    
     }
 
-    It 'GetViaIdentity1' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    Context 'Get2' {
+        It 'ShouldGetASingleSite' {
+            $Mock.PushScenario('ShouldGetASingleSite')
+
+            $SiteId = 'root'
+            $Site = Get-MgSite -SiteId $SiteId
+            $Site | Should -BeOfType -ExpectedType 'Microsoft.Graph.PowerShell.Models.MicrosoftGraphSite1'
+            $Site | Should -HaveCount 1
+            $Site.Id | Should -Be 'dummyRootId'
+            $Site.SiteCollection.HostName | Should -Be 'dummyroot.sharepoint.com'
+            $Site.AdditionalProperties | Should -HaveCount 1
+        }
+    }
+
+    Context 'GetViaIdentity2' {
+        It 'ShouldGetASingleSiteViaInputObject' {
+            $Mock.PushScenario('ShouldGetASingleSiteViaInputObject')
+
+            $SiteId = 'root'
+            $Site = Get-MgSite -InputObject @{ SiteId = $SiteId }
+            $Site | Should -BeOfType -ExpectedType 'Microsoft.Graph.PowerShell.Models.MicrosoftGraphSite1'
+            $Site | Should -HaveCount 1
+            $Site.Id | Should -Be 'dummyRootId'
+            $Site.SiteCollection.HostName | Should -Be 'dummyroot.sharepoint.com'
+            $Site.AdditionalProperties | Should -HaveCount 1
+        }
     }
 }

--- a/src/Sites/Sites/test/v1.0/Get-MgSiteByPath.Recording.json
+++ b/src/Sites/Sites/test/v1.0/Get-MgSiteByPath.Recording.json
@@ -1,0 +1,66 @@
+{
+  "Get-MgSiteByPath+[NoContext]+ShouldFailToGetSiteByPath+$GET+https://graph.microsoft.com/v1.0/sites/root/microsoft.graph.getByPath(path=\u0027randomPath\u0027)+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/v1.0/sites/root/microsoft.graph.getByPath(path=\u0027randomPath\u0027)",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 400,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 21:12:39 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "717a05c2-0a08-410a-9f2a-bf20860d9a85" ],
+        "client-request-id": [ "717a05c2-0a08-410a-9f2a-bf20860d9a85" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"MW2PEPF000031CF\"}}" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\r\n  \"error\": {\r\n    \"code\": \"invalidRequest\",\r\n    \"message\": \"Invalid request\",\r\n    \"innerError\": {\r\n      \"date\": \"2021-03-08T21:12:39\",\r\n      \"request-id\": \"717a05c2-0a08-410a-9f2a-bf20860d9a85\",\r\n      \"client-request-id\": \"717a05c2-0a08-410a-9f2a-bf20860d9a85\"\r\n    }\r\n  }\r\n}"
+    }
+  },
+  "Get-MgSiteByPath+[NoContext]+ShouldFailToGetSiteByPathViaInputObject+$GET+https://graph.microsoft.com/v1.0/sites/root/microsoft.graph.getByPath(path=\u0027randomPath\u0027)+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/v1.0/sites/root/microsoft.graph.getByPath(path=\u0027randomPath\u0027)",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 400,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 21:12:39 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "9c75914e-0016-4dde-94eb-76e1ec982723" ],
+        "client-request-id": [ "9c75914e-0016-4dde-94eb-76e1ec982723" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"MW2PEPF000031CC\"}}" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\r\n  \"error\": {\r\n    \"code\": \"invalidRequest\",\r\n    \"message\": \"Invalid request\",\r\n    \"innerError\": {\r\n      \"date\": \"2021-03-08T21:12:40\",\r\n      \"request-id\": \"9c75914e-0016-4dde-94eb-76e1ec982723\",\r\n      \"client-request-id\": \"9c75914e-0016-4dde-94eb-76e1ec982723\"\r\n    }\r\n  }\r\n}"
+    }
+  }
+}

--- a/src/Sites/Sites/test/v1.0/Get-MgSiteByPath.Tests.ps1
+++ b/src/Sites/Sites/test/v1.0/Get-MgSiteByPath.Tests.ps1
@@ -1,22 +1,45 @@
-$loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
-if (-Not (Test-Path -Path $loadEnvPath)) {
-    $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
-}
-. ($loadEnvPath)
-$TestRecordingFile = Join-Path $PSScriptRoot 'Get-MgSiteByPath.Recording.json'
-$currentPath = $PSScriptRoot
-while(-not $mockingPath) {
-    $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
-    $currentPath = Split-Path -Path $currentPath -Parent
-}
-. ($mockingPath | Select-Object -First 1).FullName
+BeforeAll {
+    $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+    if (-Not (Test-Path -Path $loadEnvPath)) {
+        $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+    }
+    . ($loadEnvPath)
+    # Set test mode to playback.
+    $TestMode = 'playback'
+    $TestRecordingFile = Join-Path $PSScriptRoot 'Get-MgSiteByPath.Recording.json'
+    $currentPath = $PSScriptRoot
 
+    while(-not $mockingPath) {
+        $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
+        $currentPath = Split-Path -Path $currentPath -Parent
+    }
+    . ($mockingPath | Select-Object -First 1).FullName
+
+    Select-MgProfile 'v1.0'
+}
+
+# Skip because /sites/{site-id}/microsoft.graph.getByPath(path='{path}') returns a 400 and is not documented.
 Describe 'Get-MgSiteByPath' {
-    It 'Get2' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    BeforeAll {
+        $Mock.PushDescription('Get-MgSiteByPath')
     }
 
-    It 'GetViaIdentity2' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    Context 'Get3' {
+        It 'ShouldFailToGetSiteByPath' {
+            $Mock.PushScenario('ShouldFailToGetSiteByPath')
+
+            $SiteId = "root"
+            { Get-MgSiteByPath -SiteId $SiteId -Path "randomPath" -ErrorAction Stop } | Should -Throw -ErrorId 'invalidRequest,Microsoft.Graph.PowerShell.Cmdlets.GetMgSiteByPath_Get3' -ExpectedMessage 'Invalid request' -ExceptionType 'Microsoft.Graph.PowerShell.Runtime.RestException<Microsoft.Graph.PowerShell.Models.IOdataError>'
+        }
+    }
+
+    Context 'GetViaIdentity3' {
+        It 'ShouldFailToGetSiteByPathViaInputObject' {
+            $Mock.PushScenario('ShouldFailToGetSiteByPathViaInputObject')
+
+            $SiteId = "root"
+            { Get-MgSiteByPath -InputObject @{ SiteId = $SiteId; Path = "randomPath" } -ErrorAction Stop } | Should -Throw -ErrorId 'invalidRequest,Microsoft.Graph.PowerShell.Cmdlets.GetMgSiteByPath_GetViaIdentity3' -ExpectedMessage 'Invalid request' -ExceptionType 'Microsoft.Graph.PowerShell.Runtime.RestException<Microsoft.Graph.PowerShell.Models.IOdataError>'
+            
+        }
     }
 }

--- a/src/Sites/Sites/test/v1.0/Get-MgSubSite.Recording.json
+++ b/src/Sites/Sites/test/v1.0/Get-MgSubSite.Recording.json
@@ -1,0 +1,99 @@
+{
+  "Get-MgSubSite+[NoContext]+ShouldGetACollectionOfSubSites+$GET+https://graph.microsoft.com/v1.0/sites/root/sites+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/v1.0/sites/root/sites",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 21:12:42 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "7a5cace6-f6a5-4124-9715-a36488374d5a" ],
+        "client-request-id": [ "7a5cace6-f6a5-4124-9715-a36488374d5a" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"MW2PEPF000031D6\"}}" ],
+        "OData-Version": [ "4.0" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\"@odata.context\":\"https://graph.microsoft.com/v1.0/$metadata#sites\",\"value\":[\n{\n\"id\": \"randomId\",\n\"name\": \"Team A Subsite\",\n\"description\": \"\",\n\"createdDateTime\": \"2016-10-18T03:05:59Z\",\n\"lastModifiedDateTime\": \"2016-10-18T10:40:59Z\",\n\"webUrl\": \"https://contoso.sharepoint.com/sites/site/subsiteA\"\n    },\n    {\n\"id\": \"contoso.sharepoint.com,da60e844-ba1d-49bc-b4d4-d5e36bae9019,0271110f-634f-4300-a841-3a8a2e851851\",\n\"name\": \"Team B Subsite\",\n\"description\": \"\",\n\"createdDateTime\": \"2016-10-18T03:05:59Z\",\n\"lastModifiedDateTime\": \"2016-10-18T10:40:59Z\",\n\"webUrl\": \"https://contoso.sharepoint.com/sites/site/subsiteB\"\n }\n ]}"
+    }
+  },
+  "Get-MgSubSite+[NoContext]+ShouldGetASingleSubSite+$GET+https://graph.microsoft.com/v1.0/sites/root/sites/randomId+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/v1.0/sites/root/sites/randomId",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 21:12:43 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "2c059afc-26fd-4218-a6fd-81c78e5241c2" ],
+        "client-request-id": [ "2c059afc-26fd-4218-a6fd-81c78e5241c2" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"MW2PEPF000031C9\"}}" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\n \"id\": \"randomId\",\n \"name\": \"Team A Subsite\",\n \"description\": \"\",\n \"createdDateTime\": \"2016-10-18T03:05:59Z\",\n \"lastModifiedDateTime\": \"2016-10-18T10:40:59Z\",\n \"webUrl\": \"https://contoso.sharepoint.com/sites/site/subsiteA\"\n }"
+    }
+  },
+  "Get-MgSubSite+[NoContext]+ShouldGetASingleSubSiteViaInputObject+$GET+https://graph.microsoft.com/v1.0/sites/root/sites/randomId+1": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://graph.microsoft.com/v1.0/sites/root/sites/randomId",
+      "Content": null,
+      "Headers": {
+        "SdkVersion": [ "Graph-powershell-Microsoft.Graph.Authentication-1.4.0", "Graph-dotnet-1.20.1" ],
+        "FeatureFlag": [ "00000047" ],
+        "Cache-Control": [ "no-store, no-cache" ],
+        "Authorization": [ "[Filtered]" ],
+        "Accept-Encoding": [ "gzip" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Mon, 08 Mar 2021 21:12:43 GMT" ],
+        "Cache-Control": [ "no-cache" ],
+        "Transfer-Encoding": [ "chunked" ],
+        "Vary": [ "Accept-Encoding" ],
+        "Strict-Transport-Security": [ "max-age=31536000" ],
+        "request-id": [ "8e367acf-fbd5-4e0b-8124-6e3da4c5773c" ],
+        "client-request-id": [ "8e367acf-fbd5-4e0b-8124-6e3da4c5773c" ],
+        "x-ms-ags-diagnostic": [ "{\"ServerInfo\":{\"DataCenter\":\"West US 2\",\"Slice\":\"E\",\"Ring\":\"1\",\"ScaleUnit\":\"001\",\"RoleInstance\":\"MW2PEPF000031DA\"}}" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": "{\n \"id\": \"randomId\",\n \"name\": \"Team A Subsite\",\n \"description\": \"\",\n \"createdDateTime\": \"2016-10-18T03:05:59Z\",\n \"lastModifiedDateTime\": \"2016-10-18T10:40:59Z\",\n \"webUrl\": \"https://contoso.sharepoint.com/sites/site/subsiteA\"\n }"
+    }
+  }
+}

--- a/src/Sites/Sites/test/v1.0/Get-MgSubSite.Tests.ps1
+++ b/src/Sites/Sites/test/v1.0/Get-MgSubSite.Tests.ps1
@@ -1,26 +1,64 @@
-$loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
-if (-Not (Test-Path -Path $loadEnvPath)) {
-    $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+BeforeAll {
+    $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+    if (-Not (Test-Path -Path $loadEnvPath)) {
+        $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+    }
+    . ($loadEnvPath)
+    # Set test mode to playback.
+    $TestMode = 'playback'
+    $TestRecordingFile = Join-Path $PSScriptRoot 'Get-MgSubSite.Recording.json'
+    $currentPath = $PSScriptRoot
+    while(-not $mockingPath) {
+        $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
+        $currentPath = Split-Path -Path $currentPath -Parent
+    }
+    . ($mockingPath | Select-Object -First 1).FullName
+
+    Select-MgProfile 'v1.0'
 }
-. ($loadEnvPath)
-$TestRecordingFile = Join-Path $PSScriptRoot 'Get-MgSubSite.Recording.json'
-$currentPath = $PSScriptRoot
-while(-not $mockingPath) {
-    $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
-    $currentPath = Split-Path -Path $currentPath -Parent
-}
-. ($mockingPath | Select-Object -First 1).FullName
 
 Describe 'Get-MgSubSite' {
-    It 'List2' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    BeforeAll {
+        $Mock.PushDescription('Get-MgSubSite')
     }
 
-    It 'Get3' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    Context 'List2' {
+        It 'ShouldGetACollectionOfSubSites' {
+            $Mock.PushScenario('ShouldGetACollectionOfSubSites')
+
+            $SiteId = "root"
+            $SubSites = Get-MgSubSite -SiteId $SiteId
+            $SubSites | Should -BeOfType -ExpectedType 'Microsoft.Graph.PowerShell.Models.MicrosoftGraphSite1'
+            $SubSites | Should -HaveCount 2
+            $SubSites.AdditionalProperties | Should -HaveCount 2
+        }
     }
 
-    It 'GetViaIdentity3' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    Context 'Get4' {
+        It 'ShouldGetASingleSubSite' {
+            $Mock.PushScenario('ShouldGetASingleSubSite')
+
+            $SiteId = "root"
+            $SubSite = Get-MgSubSite -SiteId $SiteId -SiteId1 "randomId"
+            $SubSite | Should -BeOfType -ExpectedType 'Microsoft.Graph.PowerShell.Models.MicrosoftGraphSite1'
+            $SubSite | Should -HaveCount 1
+            $SubSite.Id | Should -Be 'randomId'
+            $SubSite.WebUrl | Should -Be 'https://contoso.sharepoint.com/sites/site/subsiteA'
+            $SubSite.AdditionalProperties | Should -HaveCount 1
+        }
+    }
+
+    Context 'GetViaIdentity4' {
+        It 'ShouldGetASingleSubSiteViaInputObject' {
+            $Mock.PushScenario('ShouldGetASingleSubSiteViaInputObject')
+
+            $SiteId = "root"
+            $SubSite = Get-MgSubSite -InputObject @{ SiteId = $SiteId; SiteId1 = "randomId" }
+            $SubSite | Should -BeOfType -ExpectedType 'Microsoft.Graph.PowerShell.Models.MicrosoftGraphSite1'
+            $SubSite | Should -HaveCount 1
+            $SubSite.Id | Should -Be 'randomId'
+            $SubSite.WebUrl | Should -Be 'https://contoso.sharepoint.com/sites/site/subsiteA'
+            $SubSite.AdditionalProperties | Should -HaveCount 1
+        }
     }
 }

--- a/tools/TestModule.ps1
+++ b/tools/TestModule.ps1
@@ -16,9 +16,13 @@ if(-not $Isolated) {
 }
 
 $modulePsd1 = Get-Item -Path (Join-Path $ModulePath "./$ModuleName.psd1")
+$LocalLoadEnvPS1 = Join-Path $PSScriptRoot 'Tests/loadEnv.ps1'
 
 Import-Module -Name Pester
 Import-Module -Name $modulePsd1.FullName
+
+# Replace AutoREST loadEnv.ps1 with our local scipt.
+Copy-Item -Path $LocalLoadEnvPS1 -Destination "$ModulePath/test"
 
 $testFolder = Join-Path $ModulePath 'test'
 $PesterConfiguration = [PesterConfiguration]::Default

--- a/tools/Tests/loadEnv.ps1
+++ b/tools/Tests/loadEnv.ps1
@@ -23,5 +23,10 @@ if (Test-Path -Path (Join-Path $PSScriptRoot $envFile)) {
 }
 $env = @{}
 if (Test-Path -Path $envFilePath) {
-    $env = Get-Content (Join-Path $PSScriptRoot $envFile) | ConvertFrom-Json
-    $PSDefaultParameterValues=@{"*:SubscriptionId"=$env.SubscriptionId; "*:Tenant"=$env.Tenant}
+    # Load dummy auth configuration.
+    $env = Get-Content (Join-Path $PSScriptRoot $envFile) | ConvertFrom-Json -AsHashTable
+    [Microsoft.Graph.PowerShell.Authentication.GraphSession]::Instance.AuthContext = New-Object Microsoft.Graph.PowerShell.Authentication.AuthContext -Property @{
+        ClientId = $env.ClientId
+        TenantId = $env.TenantId
+    }
+}


### PR DESCRIPTION
This PR closes #573 by updating cmdlet rename directives in Sites module to use new cmdlet variants. 

For some unknown reason, some variants in Sites module got renamed which caused #573. I'm still waiting for an answer from https://github.com/Azure/autorest.powershell/issues/752 to understand what conditions can lead to a variant name change.

In the meantime, this PR adds Pester tests that will allow us to detect variant name change in the future.