### PR TITLE
Bump SDK version to 1.4.2

### DIFF
--- a/config/ModuleMetadata.json
+++ b/config/ModuleMetadata.json
@@ -22,5 +22,5 @@
   ],
   "releaseNotes": "See https://aka.ms/GraphPowerShell-Release.",
   "assemblyOriginatorKeyFile": "35MSSharedLib1024.snk",
-  "version": "1.4.1"
+  "version": "1.4.2"
 }

--- a/src/Applications/Applications/readme.md
+++ b/src/Applications/Applications/readme.md
@@ -90,6 +90,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
@@ -12,7 +12,7 @@
 RootModule = './Microsoft.Graph.Authentication.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.4.1'
+ModuleVersion = '1.4.2'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core', 'Desktop'

--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
@@ -12,7 +12,7 @@
 RootModule = './Microsoft.Graph.Authentication.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.4.0'
+ModuleVersion = '1.4.1'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core', 'Desktop'

--- a/src/Bookings/Bookings/readme.md
+++ b/src/Bookings/Bookings/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Calendar/Calendar/readme.md
+++ b/src/Calendar/Calendar/readme.md
@@ -52,6 +52,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/ChangeNotifications/ChangeNotifications/readme.md
+++ b/src/ChangeNotifications/ChangeNotifications/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/CloudCommunications/CloudCommunications/readme.md
+++ b/src/CloudCommunications/CloudCommunications/readme.md
@@ -59,6 +59,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Compliance/Compliance/readme.md
+++ b/src/Compliance/Compliance/readme.md
@@ -47,6 +47,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/CrossDeviceExperiences/CrossDeviceExperiences/readme.md
+++ b/src/CrossDeviceExperiences/CrossDeviceExperiences/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Actions/DeviceManagement.Actions/readme.md
+++ b/src/DeviceManagement.Actions/DeviceManagement.Actions/readme.md
@@ -86,6 +86,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Administration/DeviceManagement.Administration/readme.md
+++ b/src/DeviceManagement.Administration/DeviceManagement.Administration/readme.md
@@ -51,6 +51,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/readme.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Functions/DeviceManagement.Functions/readme.md
+++ b/src/DeviceManagement.Functions/DeviceManagement.Functions/readme.md
@@ -57,6 +57,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement/DeviceManagement/readme.md
+++ b/src/DeviceManagement/DeviceManagement/readme.md
@@ -77,6 +77,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Devices.CloudPrint/Devices.CloudPrint/readme.md
+++ b/src/Devices.CloudPrint/Devices.CloudPrint/readme.md
@@ -48,6 +48,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Devices.CorporateManagement/Devices.CorporateManagement/readme.md
+++ b/src/Devices.CorporateManagement/Devices.CorporateManagement/readme.md
@@ -86,6 +86,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DirectoryObjects/DirectoryObjects/readme.md
+++ b/src/DirectoryObjects/DirectoryObjects/readme.md
@@ -54,6 +54,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Education/Education/readme.md
+++ b/src/Education/Education/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Files/Files/readme.md
+++ b/src/Files/Files/readme.md
@@ -43,6 +43,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Financials/Financials/readme.md
+++ b/src/Financials/Financials/readme.md
@@ -57,6 +57,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Groups/Groups/readme.md
+++ b/src/Groups/Groups/readme.md
@@ -137,6 +137,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Identity.DirectoryManagement/Identity.DirectoryManagement/readme.md
+++ b/src/Identity.DirectoryManagement/Identity.DirectoryManagement/readme.md
@@ -127,6 +127,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Identity.Governance/Identity.Governance/readme.md
+++ b/src/Identity.Governance/Identity.Governance/readme.md
@@ -79,6 +79,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Identity.SignIns/Identity.SignIns/readme.md
+++ b/src/Identity.SignIns/Identity.SignIns/readme.md
@@ -56,6 +56,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Mail/Mail/readme.md
+++ b/src/Mail/Mail/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Notes/Notes/readme.md
+++ b/src/Notes/Notes/readme.md
@@ -44,6 +44,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/People/People/readme.md
+++ b/src/People/People/readme.md
@@ -74,6 +74,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/PersonalContacts/PersonalContacts/readme.md
+++ b/src/PersonalContacts/PersonalContacts/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Planner/Planner/readme.md
+++ b/src/Planner/Planner/readme.md
@@ -46,6 +46,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Reports/Reports/readme.md
+++ b/src/Reports/Reports/readme.md
@@ -81,6 +81,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/SchemaExtensions/SchemaExtensions/readme.md
+++ b/src/SchemaExtensions/SchemaExtensions/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Search/Search/readme.md
+++ b/src/Search/Search/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Security/Security/readme.md
+++ b/src/Security/Security/readme.md
@@ -73,6 +73,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.0
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Sites/Sites/readme.md
+++ b/src/Sites/Sites/readme.md
@@ -110,6 +110,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Teams/Teams/readme.md
+++ b/src/Teams/Teams/readme.md
@@ -44,6 +44,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Users.Actions/Users.Actions/readme.md
+++ b/src/Users.Actions/Users.Actions/readme.md
@@ -124,6 +124,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Users.Functions/Users.Functions/readme.md
+++ b/src/Users.Functions/Users.Functions/readme.md
@@ -61,6 +61,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Users/Users/readme.md
+++ b/src/Users/Users/readme.md
@@ -53,6 +53,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.4.1
+module-version: 1.4.2
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```


### PR DESCRIPTION
### Release notes for 1.4.2 Release
- Refreshes modules with latest APIs #578 .
- Fixes broken commands in `Sites` module #574.