### PR TITLE
Resolve dependency conflict with MSOnline module

### DIFF
--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.psm1
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.psm1
@@ -8,3 +8,21 @@ if (Test-Path -Path "$PSScriptRoot\StartupScripts" -ErrorAction Ignore)
         . $_.FullName
     }
 }
+
+$DependencyPath = (Join-Path $PSScriptRoot -ChildPath "Dependencies")
+if (Test-Path $DependencyPath -ErrorAction Ignore)
+{
+    try
+    {
+        Get-ChildItem -ErrorAction Stop -Path $DependencyPath -Filter "*.dll" | ForEach-Object {
+            try
+            {
+                Add-Type -Path $_.FullName -ErrorAction Ignore | Out-Null
+            }
+            catch {
+                Write-Verbose $_
+            }
+        }
+    }
+    catch {}
+}


### PR DESCRIPTION
This PR closes #641 by loading our dependency types to the current PowerShell session when a module is imported.