### PR TITLE
Add CODEOWNERS to make PRs discoverable.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @peombwa @ddyett @georgend

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         MESSAGE_TITLE: Weekly OpenApiDocs Download
         MESSAGE_BODY: "This pull request was automatically created by the GitHub Action,\n\n Contains OpenApiDocs Updates from Graph Explorer API"
-        REVIEWERS: peombwa,ddyett,darrelmiller
-        ASSIGNEDTO: finsharp
+        REVIEWERS: peombwa,ddyett,darrelmiller,georgend
+        ASSIGNEDTO: peombwa
         LABELS: generated
         BASE: dev
         HEAD: ${{steps.create_branch.outputs.branch}}


### PR DESCRIPTION
This PR add a [CODEOWNERS](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#about-code-owners) file to make PRs discoverable.