### PR TITLE
Identity governance: suppress invoke of my() for accesspackageassignmentresourcerole

### DIFF
--- a/src/Identity.Governance/Identity.Governance/readme.md
+++ b/src/Identity.Governance/Identity.Governance/readme.md
@@ -180,7 +180,7 @@ directive:
       subject: (.*)(EntitlementManagement)AccessPackageAssignment$
     remove: true
   - where:
-      verb: New|Remove|Update
+      verb: New|Invoke|Remove|Update
       subject: (.*)(EntitlementManagement)AccessPackageAssignmentResourceRole$
     remove: true
   - where:


### PR DESCRIPTION
This particular function will not be brought forward into 1.0 Graph API, so suppress generation of PSh for it while it is in beta.

```
<Function Name="My" IsBound="true">
 <Parameter Name="bindingParameter" Type="Collection(graph.accessPackageAssignmentResourceRole)" />
 <ReturnType Type="Collection(graph.accessPackageAssignmentResourceRole)" />
</Function>
```
