### PR TITLE
Bump SDK version to 1.6.0

### DIFF
--- a/config/ModuleMetadata.json
+++ b/config/ModuleMetadata.json
@@ -22,5 +22,5 @@
   ],
   "releaseNotes": "See https://aka.ms/GraphPowerShell-Release.",
   "assemblyOriginatorKeyFile": "35MSSharedLib1024.snk",
-  "version": "1.5.1"
+  "version": "1.6.0"
 }

--- a/src/Applications/Applications/readme.md
+++ b/src/Applications/Applications/readme.md
@@ -90,6 +90,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.csproj
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.2</Version>
+    <Version>1.6.0</Version>
     <LangVersion>7.1</LangVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>

--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
@@ -12,7 +12,7 @@
 RootModule = './Microsoft.Graph.Authentication.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.5.1'
+ModuleVersion = '1.6.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core', 'Desktop'

--- a/src/Bookings/Bookings/readme.md
+++ b/src/Bookings/Bookings/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Calendar/Calendar/readme.md
+++ b/src/Calendar/Calendar/readme.md
@@ -52,6 +52,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/ChangeNotifications/ChangeNotifications/readme.md
+++ b/src/ChangeNotifications/ChangeNotifications/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/CloudCommunications/CloudCommunications/readme.md
+++ b/src/CloudCommunications/CloudCommunications/readme.md
@@ -59,6 +59,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Compliance/Compliance/readme.md
+++ b/src/Compliance/Compliance/readme.md
@@ -47,6 +47,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/CrossDeviceExperiences/CrossDeviceExperiences/readme.md
+++ b/src/CrossDeviceExperiences/CrossDeviceExperiences/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Actions/DeviceManagement.Actions/readme.md
+++ b/src/DeviceManagement.Actions/DeviceManagement.Actions/readme.md
@@ -95,6 +95,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Administration/DeviceManagement.Administration/readme.md
+++ b/src/DeviceManagement.Administration/DeviceManagement.Administration/readme.md
@@ -51,6 +51,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/readme.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/readme.md
@@ -44,6 +44,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Functions/DeviceManagement.Functions/readme.md
+++ b/src/DeviceManagement.Functions/DeviceManagement.Functions/readme.md
@@ -57,6 +57,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement/DeviceManagement/readme.md
+++ b/src/DeviceManagement/DeviceManagement/readme.md
@@ -77,6 +77,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Devices.CloudPrint/Devices.CloudPrint/readme.md
+++ b/src/Devices.CloudPrint/Devices.CloudPrint/readme.md
@@ -48,6 +48,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Devices.CorporateManagement/Devices.CorporateManagement/readme.md
+++ b/src/Devices.CorporateManagement/Devices.CorporateManagement/readme.md
@@ -86,6 +86,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DirectoryObjects/DirectoryObjects/readme.md
+++ b/src/DirectoryObjects/DirectoryObjects/readme.md
@@ -54,6 +54,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Education/Education/readme.md
+++ b/src/Education/Education/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Files/Files/readme.md
+++ b/src/Files/Files/readme.md
@@ -43,6 +43,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Financials/Financials/readme.md
+++ b/src/Financials/Financials/readme.md
@@ -57,6 +57,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Groups/Groups/readme.md
+++ b/src/Groups/Groups/readme.md
@@ -137,6 +137,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Identity.DirectoryManagement/Identity.DirectoryManagement/readme.md
+++ b/src/Identity.DirectoryManagement/Identity.DirectoryManagement/readme.md
@@ -127,6 +127,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Identity.Governance/Identity.Governance/readme.md
+++ b/src/Identity.Governance/Identity.Governance/readme.md
@@ -253,6 +253,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Identity.SignIns/Identity.SignIns/readme.md
+++ b/src/Identity.SignIns/Identity.SignIns/readme.md
@@ -63,6 +63,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Mail/Mail/readme.md
+++ b/src/Mail/Mail/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Notes/Notes/readme.md
+++ b/src/Notes/Notes/readme.md
@@ -44,6 +44,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/People/People/readme.md
+++ b/src/People/People/readme.md
@@ -74,6 +74,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/PersonalContacts/PersonalContacts/readme.md
+++ b/src/PersonalContacts/PersonalContacts/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Planner/Planner/readme.md
+++ b/src/Planner/Planner/readme.md
@@ -46,6 +46,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Reports/Reports/readme.md
+++ b/src/Reports/Reports/readme.md
@@ -81,6 +81,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/SchemaExtensions/SchemaExtensions/readme.md
+++ b/src/SchemaExtensions/SchemaExtensions/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Search/Search/readme.md
+++ b/src/Search/Search/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Security/Security/readme.md
+++ b/src/Security/Security/readme.md
@@ -73,6 +73,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Sites/Sites/readme.md
+++ b/src/Sites/Sites/readme.md
@@ -110,6 +110,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Teams/Teams/readme.md
+++ b/src/Teams/Teams/readme.md
@@ -44,6 +44,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Users.Actions/Users.Actions/readme.md
+++ b/src/Users.Actions/Users.Actions/readme.md
@@ -124,6 +124,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Users.Functions/Users.Functions/readme.md
+++ b/src/Users.Functions/Users.Functions/readme.md
@@ -61,6 +61,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Users/Users/readme.md
+++ b/src/Users/Users/readme.md
@@ -58,6 +58,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/WindowsUpdates/WindowsUpdates/readme.md
+++ b/src/WindowsUpdates/WindowsUpdates/readme.md
@@ -105,10 +105,9 @@ directive:
     set:
       subject: $1WindowsUpdate$3
 ```
-
 ### Versioning
 
 ``` yaml
-module-version: 1.5.1
+module-version: 1.6.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```


### PR DESCRIPTION
This PR bumps the version of SDK to 1.6.0 in readiness for 1.6.0 release.

#### Release notes:
- Adds interactive authentication as the default authentication mode #618. Customers can fallback to device code using `Connect-MgGraph -UseDeviceAuthentication`.
- Adds `Microsoft.Graph.WindowsUpdates` module #671.
- Adds new commands with simplified parameter sets to `Identity.Governance` module #632, #631, #627.
- Fixes dependency conflict with MSOnline module #642.
- Fixes device code authentication in PowerShell ISE #668.
- Cleans up broken/invalid commands in `Identity.Governance`, `Identity.SignIns`, `Users`, and `Users.Actions` modules #670 #666.
- Refreshes modules with latest APIs #667.

