### PR TITLE
Handle case where network is down or the endpoint is unreachable

### DIFF
--- a/tools/Custom/Module.cs
+++ b/tools/Custom/Module.cs
@@ -85,6 +85,13 @@ namespace Microsoft.Graph.PowerShell
             using (Extensions.NoSynchronizationContext)
             {
                 var eventData = EventDataConverter.ConvertFrom(getEventData());
+                //Handle case where network is down or the endpoint is unreachable
+                //making ResponseMessage null
+                //https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/700
+                if (eventData.ResponseMessage == null)
+                {
+                    return;
+                }
                 var responseFormatter = new HttpMessageFormatter(eventData.ResponseMessage as HttpResponseMessage);
                 var responseString = await responseFormatter.ReadAsStringAsync();
                 await signal(Events.Debug, cancellationToken, () => EventFactory.CreateLogEvent(responseString));


### PR DESCRIPTION
Handle case where network is down or the endpoint is unreachable making ResponseMessage null.
Earlier behavior would suppress network errors.
***Current Behavior***
Suppresses network errors throws `ArgumentNullException` in `HttpMessageFormatter`

![image](https://user-images.githubusercontent.com/1641829/122925942-01819700-d370-11eb-89ff-ab6847393718.png)

***Proposed Behavior***
When network errors occur, let them propagate to Cmdlet Error handling. 
![image](https://user-images.githubusercontent.com/1641829/122926956-0eeb5100-d371-11eb-99cc-321042924fd9.png)



