### PR TITLE
Introduce capability to Exclude .Notes Section from ProxyCmdletsDefinitions.ps1

### DIFF
--- a/.azure-pipelines/generate-modules-template.yml
+++ b/.azure-pipelines/generate-modules-template.yml
@@ -142,7 +142,7 @@ jobs:
       pwsh: true
       script: |
          Write-Host $(BUILDNUMBER)
-         pwsh $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -ArtifactsLocation $(Build.ArtifactStagingDirectory)\ -Build -Test -EnableSigning -ModulePreviewNumber $(BUILDNUMBER) -RepositoryName "LocalNugetFeed" -ExcludeExampleTemplates
+         pwsh $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -ArtifactsLocation $(Build.ArtifactStagingDirectory)\ -Build -Test -EnableSigning -ModulePreviewNumber $(BUILDNUMBER) -RepositoryName "LocalNugetFeed" -ExcludeExampleTemplates -ExcludeNotesSection
 
   - template: ./generation-templates/generate-helpdocs-template.yml
 

--- a/.azure-pipelines/generation-templates/generate-service-modules.yml
+++ b/.azure-pipelines/generation-templates/generate-service-modules.yml
@@ -142,7 +142,7 @@ jobs:
           script: |
             [bool]$EnableSigning = if ("$(EnableSigning)" -eq "true") { $true } else { $false }
             $Modules = "$(ModulesToGenerate)" -split " "
-            . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -Build -Test -UpdateAutoRest -EnableSigning:$EnableSigning -ModulesToGenerate $Modules -ExcludeExampleTemplates
+            . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -Build -Test -UpdateAutoRest -EnableSigning:$EnableSigning -ModulesToGenerate $Modules -ExcludeExampleTemplates -ExcludeNotesSection
        
       - template: ./generate-helpdocs-template.yml
         parameters:

--- a/tools/BuildModule.ps1
+++ b/tools/BuildModule.ps1
@@ -8,7 +8,8 @@ Param(
     [int] $ModulePreviewNumber = -1,
     [hashtable[]] $RequiredModules,
     [switch] $EnableSigning,
-    [switch] $ExcludeExampleTemplates
+    [switch] $ExcludeExampleTemplates,
+    [switch] $ExcludeNotesSection
 )
 $ErrorActionPreference = "Stop"
 $LASTEXITCODE = $null
@@ -43,7 +44,7 @@ else {
 
 # Build module
 Write-Host -ForegroundColor Green "Building '$Module' module..."
-& $BuildModulePS1 -Docs -Release -ExcludeExampleTemplates:$ExcludeExampleTemplates
+& $BuildModulePS1 -Docs -Release -ExcludeExampleTemplates:$ExcludeExampleTemplates -ExcludeNotesSection:$ExcludeNotesSection
 if ($LASTEXITCODE) {
     Write-Error "Failed to build '$Module' module."
 }

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -13,7 +13,8 @@ Param(
     [switch] $Publish,
     [switch] $EnableSigning,
     [switch] $SkipVersionCheck,
-    [switch] $ExcludeExampleTemplates
+    [switch] $ExcludeExampleTemplates,
+    [switch] $ExcludeNotesSection
 )
 enum VersionState {
     Invalid
@@ -157,10 +158,10 @@ $ModulesToGenerate | ForEach-Object -ThrottleLimit $ModulesToGenerate.Count -Par
                 # Build generated module.
                 if ($Using:EnableSigning) {
                     # Sign generated module.
-                    & $Using:BuildModulePS1 -Module $ModuleName -ModulePrefix $Using:ModulePrefix -ModuleVersion $ModuleVersion -ModulePreviewNumber $Using:ModulePreviewNumber -RequiredModules $Using:RequiredGraphModules -ReleaseNotes $ModuleReleaseNotes -EnableSigning -ExcludeExampleTemplates:$Using:ExcludeExampleTemplates
+                    & $Using:BuildModulePS1 -Module $ModuleName -ModulePrefix $Using:ModulePrefix -ModuleVersion $ModuleVersion -ModulePreviewNumber $Using:ModulePreviewNumber -RequiredModules $Using:RequiredGraphModules -ReleaseNotes $ModuleReleaseNotes -EnableSigning -ExcludeExampleTemplates:$Using:ExcludeExampleTemplates -ExcludeNotesSection:$Using:ExcludeNotesSection
                 }
                 else {
-                    & $Using:BuildModulePS1 -Module $ModuleName -ModulePrefix $Using:ModulePrefix -ModuleVersion $ModuleVersion -ModulePreviewNumber $Using:ModulePreviewNumber -RequiredModules $Using:RequiredGraphModules -ReleaseNotes $ModuleReleaseNotes -ExcludeExampleTemplates:$Using:ExcludeExampleTemplates
+                    & $Using:BuildModulePS1 -Module $ModuleName -ModulePrefix $Using:ModulePrefix -ModuleVersion $ModuleVersion -ModulePreviewNumber $Using:ModulePreviewNumber -RequiredModules $Using:RequiredGraphModules -ReleaseNotes $ModuleReleaseNotes -ExcludeExampleTemplates:$Using:ExcludeExampleTemplates -ExcludeNotesSection:$Using:ExcludeNotesSection
                 }
 
                 # Get profiles for generated modules.


### PR DESCRIPTION
The `.Notes` Section causes Nuget Packages and the SDK in general to bloat heavily. Excluding the `.Notes` section of the local help yields approximately **41pc** size reduction in module size reducing download and installation time. 
This PR keeps the Notes section information in the online docs, and excludes them from the local help. 

***Structure***
![New Structure on the left and Old Structure on the Right](https://user-images.githubusercontent.com/1641829/128437870-c9a3cae7-5d79-427e-baad-06be6a982ae3.png)

***Largest Reductions***

Name | Old Size | New Size | % Change | Difference
-- | -- | -- | -- | --
Microsoft.Graph.Files.1.6.1.nupkg | 31.4 MB | 5.1 MB | 83 | 26.4 MB
Microsoft.Graph.Sites.1.6.1.nupkg | 17.6 MB | 4.0 MB | 77 | 13.6 MB
Microsoft.Graph.Education.1.6.1.nupkg | 8.6 MB | 4.3 MB | 50 | 4.3 MB
Microsoft.Graph.Compliance.1.6.1.nupkg | 5.2 MB | 2.6 MB | 50 | 2.6 MB
Microsoft.Graph.DeviceManagement.1.6.1.nupkg | 15.5 MB | 8.4 MB | 46 | 7.2 MB
Microsoft.Graph.Teams.1.6.1.nupkg | 10.0 MB | 5.6 MB | 44 | 4.4 MB
Microsoft.Graph.Devices.CloudPrint.1.6.1.nupkg | 5.4 MB | 3.1 MB | 42 | 2.3 MB
Microsoft.Graph.Groups.1.6.1.nupkg | 6.6 MB | 4.6 MB | 29 | 1.9 MB
Microsoft.Graph.Users.1.6.1.nupkg | 5.3 MB | 3.7 MB | 29 | 1.6 MB

***Minor Changes***
- Update Build Scripts with new parameter.
- Update Azure Pipelines with new parameters.

cc. @maisarissi 