### PR TITLE
Additional search filters for Find-MgGraphPermission, pipeline support, docs, samples

### DIFF
--- a/samples/2-ConnectToGraph.ps1
+++ b/samples/2-ConnectToGraph.ps1
@@ -6,6 +6,9 @@ Connect-Graph
 # Try to Get-User
 Get-MgUser
 
+# Search for delegated permissions related to sites
+Find-MgGraphPermission sites
+
 # Grant more permissions
 Connect-Graph -Scopes "User.Read","User.ReadWrite.All","Mail.ReadWrite",`
             "Directory.Read.All","Chat.ReadWrite", "People.Read", `
@@ -17,3 +20,7 @@ Connect-Graph -Scopes "User.Read","User.ReadWrite.All","Mail.ReadWrite",`
 
 # Forget all access tokens
 Disconnect-Graph
+
+# Launch detailed permissions documentation
+Get-Help Find-MgGraphPermission -Online
+

--- a/samples/9-Applications.ps1
+++ b/samples/9-Applications.ps1
@@ -26,6 +26,7 @@ $app3 = New-MgApplication -displayName "ImplicitWebApp" `
         }  
 
 # Create an registration for an ASP.NET Web App
+$scopeId_UserRead = Find-MgGraphPermission User.Read -ExactMatch -PermissionType Delegated | Select-Object -ExpandProperty Id
 $app = New-MgApplication -displayName "AspNetWebApp" `
            -Web @{ 
               RedirectUris = "https://localhost:5001/signin-oidc"; `
@@ -36,7 +37,7 @@ $app = New-MgApplication -displayName "AspNetWebApp" `
              -RequiredResourceAccess @{ ResourceAppId = "00000003-0000-0000-c000-000000000000"
                                         ResourceAccess = @(
                                                 @{ 
-                                                    Id = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+                                                    Id = $scopeId_UserRead
                                                     Type = "Scope"
                                                  }
                                                  )
@@ -56,7 +57,7 @@ $createAppParams = @{
         ResourceAppId = "00000003-0000-0000-c000-000000000000"
         ResourceAccess = @(
             @{
-                Id = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+                Id = $scopeId_UserRead
                 Type = "Scope"
             }
         )
@@ -76,18 +77,36 @@ $Certificate = Get-ChildItem -Path "Cert:\CurrentUser\My\$CertificateThumbprint"
 # Graph resource Id
 $GraphResourceId = "00000003-0000-0000-c000-000000000000"
 
-# Graph permissions constants
-$UserReadAll = @{ Id = "df021288-bdef-4463-88db-98f22de89214"; Type = "Role" }
-$GroupReadAll = @{ Id = "5b567255-7703-4780-807c-7be8301ae99b"; Type = "Role" }
-$MailboxSettingsRead = @{ Id = "40f97065-369a-49f4-947c-6a255697ae91"; Type = "Role" }
-$MailSend = @{ Id = "b633e1c5-b582-4048-a93e-9f11b44c7e96"; Type = "Role" }
+# Show friendly Graph permission names given their unique identifiers
+Find-MgGraphPermission | Where-Object Id -in @(
+    'df021288-bdef-4463-88db-98f22de89214'
+    '5b567255-7703-4780-807c-7be8301ae99b'
+    '40f97065-369a-49f4-947c-6a255697ae91'
+    'b633e1c5-b582-4048-a93e-9f11b44c7e96'
+)
 
 # Create an application registration.
+$requiredPermissions = 'Group.Read.All', 'Mail.Send', 'MailboxSettings.Read', 'User.Read.All' |
+  Find-MgGraphPermission -ExactMatch -PermissionType Application
+
+$resourceAccess = foreach ( $permission in $requiredPermissions ) {
+    @{ Id = $permission.Id; Type = 'Role' }
+}
+
 $AppName = "ScriptedGraphPSApp"
 $app4 = New-MgApplication -"ClientCredentialApp" $AppName `
                     -SignInAudience "AzureADMyOrg" `
-                    -RequiredResourceAccess @{ ResourceAppId = $graphResourceId; ResourceAccess = $UserReadAll, $GroupReadAll, $MailboxSettingsRead, $MailSend } `
+                    -RequiredResourceAccess @{ ResourceAppId = $graphResourceId; ResourceAccess = $resourceAccess } `
                     -KeyCredentials @(@{ Type = "AsymmetricX509Cert"; Usage = "Verify"; Key= $Certificate.RawData })
 
 # Create corresponding service principal.
 New-MgServicePrincipal -AppId $app4.AppId
+
+# Show permissions assigned to the application in the organization
+# using friendly permission names instead of just the unique identifiers
+$servicePrincipal4 = Get-MgServicePrincipal -Filter "appId eq '$($app4.AppId)'"
+Get-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $servicePrincipal4.id |
+  Select-Object appRoleId |
+  Find-MgGraphPermission
+
+

--- a/src/Authentication/Authentication/custom/Find-MgGraphPermission.ps1
+++ b/src/Authentication/Authentication/custom/Find-MgGraphPermission.ps1
@@ -66,6 +66,9 @@ continue to use the updated list for all future invocations of the command even 
 To return all possible permissions rather than just those that match the SearchString parameter, specify the All parameter. The
 All parameter may also be used with the PermissionType to enumerate all applicaition permissions or all delegated permissions.
 
+.INPUTS
+You can pipe permission names in the form of strings to Find-MgGraphPermission.
+
 .OUTPUTS
 This command returns a collection of items with the following fields:
 * Name: The name of the permission as found in Microsoft Graph permissions reference documentation. Names will typically
@@ -149,7 +152,7 @@ result is piped to the Format-List command so that the output of the Description
 in the default table view.
 
 .LINK
-https://docs.microsoft.com/en-us/graph/permissions-reference.
+https://docs.microsoft.com/en-us/graph/permissions-reference
 #>
 function Find-MgGraphPermission {
     [cmdletbinding(positionalbinding=$false)]

--- a/src/Authentication/Authentication/custom/Find-MgGraphPermission.ps1
+++ b/src/Authentication/Authentication/custom/Find-MgGraphPermission.ps1
@@ -116,22 +116,53 @@ New-MgGraphApplication
 New-MgServicePrinicipal
 #>
 function Find-MgGraphPermission {
-    [cmdletbinding()]
+    [cmdletbinding(positionalbinding=$false)]
     [OutputType('Microsoft.Graph.Custom.Permission')]
     param (
-        [string] $SearchString,
-        [switch] $Online
+        [parameter(ParameterSetName='Search', position=0, Mandatory=$true)]
+        [String] $SearchString,
+
+        [parameter(ParameterSetName='Search')]
+        [Switch] $ExactMatch,
+
+        [parameter(ParameterSetName='Search')]
+        [ValidateSet('Any', 'Delegated', 'Application')]
+        [String] $PermissionType = 'Any',
+
+        [parameter(ParameterSetName='Search')]
+        [Switch] $Online,
+
+        [parameter(ParameterSetname='All')]
+        [Switch] $All
     )
+
+    $filter = if ( $All.IsPresent ) {
+        { $true }
+    } elseif ( $ExactMatch.IsPresent ) {
+        { $_.Name -eq $SearchString }
+    } else {
+        { $_.Name -like "*$SearchString*" }
+    }
 
     $permissionsData = Permissions_GetPermissionsData $online
 
-    # Creating a table specifically for Oauth2permissions data
-    $oauthData = @()
-    $oauthData += Permissions_GetOauthData $permissionsData | Where-Object Name -like *$SearchString*
-    $oauthData | Sort-Object -Property Name
+    $permissions = @()
 
-    # Creating a table specifically for appRoles data
-    $appRolesData = @()
-    $appRolesData += Permissions_GetAppRolesData $permissionsData | Where-Object Name -like *$SearchString*
-    $appRolesData | Sort-Object -Property Name
+    if ( $PermissionType -in 'Any', 'Delegated' ) {
+        $permissions += Permissions_GetOauthData $permissionsData |
+          Where-Object $filter |
+          Sort-Object Name
+    }
+
+    if ( $PermissionType -in 'Any', 'Application' ) {
+        $permissions += Permissions_GetAppRolesData $permissionsData |
+          Where-Object $filter |
+          Sort-Object Name
+    }
+
+    if ( ! $permissions -and $ExactMatch.IsPresent ) {
+        Write-Error "No results were found that exactly matched the specified permission '$SearchString'"
+    }
+
+    $permissions
 }

--- a/src/Authentication/Authentication/test/Find-MgGraphPermission.Tests.ps1
+++ b/src/Authentication/Authentication/test/Find-MgGraphPermission.Tests.ps1
@@ -22,11 +22,11 @@ Describe "The Find-MgGraphPermission Command" {
             }
         }
 
-        It 'Executes successfully with no parameters' {
-            { Find-MgGraphPermission | Out-Null } | Should -Not -Throw
+        It 'Executes successfully with the All parameter' {
+            { Find-MgGraphPermission -All | Out-Null } | Should -Not -Throw
             (_Permissions_State).isFromInvokeMgGraphRequest | Should -Be $true
             Assert-MockCalled Invoke-MgGraphRequest
-            { Find-MgGraphPermission -Online | Out-Null } | Should -Not -Throw
+            { Find-MgGraphPermission -All -Online | Out-Null } | Should -Not -Throw
         }
     }
 
@@ -36,15 +36,31 @@ Describe "The Find-MgGraphPermission Command" {
             Mock Invoke-MgGraphRequest {$permissionData}
         }
 
-        It 'Executes successfully with no parameters' {
-            { Find-MgGraphPermission | Out-Null } | Should -Not -Throw
+        It 'Executes successfully with the All parameter' {
+            { Find-MgGraphPermission -All | Out-Null } | Should -Not -Throw
             Assert-MockCalled Invoke-MgGraphRequest
             (_Permissions_State).msGraphServicePrincipal | Should -Not -Be $null
             (_Permissions_State).isFromInvokeMgGraphRequest | Should -Be $true
             { Find-MgGraphPermission -Online | Out-Null } | Should -Not -Throw
         }
 
-        It 'Only calls Invoke-MgGraph request once' {
+        It 'Executes successfully when the Any parameter is specified for some search criteria' {
+            $result = Find-MgGraphPermission ReadWrite -PermissionType Any
+
+            $result.length | Should -Be 4
+        }
+
+        It 'Should accept input from the pipeline as the SearchString parameter and find matches for each element in the pipeline' -Tag testing {
+            { 'People.Read.All' | Find-MgGraphPermission -ErrorAction Stop } | Should -Not -Throw
+
+            $pipelineMatches = 'People.Read.All', 'User.Read.Basic' | Find-MgGraphPermission
+
+            $pipelineMatches.length | Should -Be 2
+            $pipelineMatches[0].Name | Should -Be 'People.Read.All'
+            $pipelineMatches[1].Name | Should -Be 'User.Read.Basic'
+        }
+
+        It 'Only calls Invoke-MgGraph request for the first invocation of Find-MgGraphPermission and is not called for subsequent invocations' {
             { Find-MgGraphPermission 'ReadWrite' | Out-Null } | Should -Not -Throw
             Assert-MockCalled Invoke-MgGraphRequest -Exactly 1
             { Find-MgGraphPermission 'Email' | Out-Null }
@@ -74,6 +90,121 @@ Describe "The Find-MgGraphPermission Command" {
             $testOnline.length | Should -Be 4
         }
 
+        It "Retrieves only delegated permissions even the PermissionType parameter is specified as Delegated when application permissions would also match the search string" {
+            $allMatches = Find-MgGraphPermission ReadWrite
+
+            $index = 0
+
+            $delegatedPermissions = , 'RoleAssignmentSchedule.ReadWrite.Directory'
+            $applicationPermissions = 'Directory.ReadWrite.All', 'Group.ReadWrite.All', 'WorkforceIntegration.ReadWrite.All'
+
+            $allPermissions = @()
+            $allPermissions += $delegatedPermissions
+            $allPermissions += $applicationPermissions
+
+            $allPermissions | foreach {
+                $allMatches[$index++].Name | Should -Be $_
+            }
+
+            $delegatedMatches = Find-MgGraphPermission ReadWrite -PermissionType Delegated
+
+            $delegatedIndex = 0
+
+            $delegatedPermissions | foreach {
+                $delegatedMatches[$delegatedIndex++].Name | Should -Be $_
+            }
+        }
+
+        It "Should throw an exception if ExactMatch is specified and the specified SearchString cannot be found even when there is a partial match" -Tag Testing {
+            $result = Find-MgGraphPermission Group
+
+            $result.length | Should -Be 2
+
+            $result | foreach {
+                $_.Name | Should -BeLike '*group*'
+            }
+
+            { Find-MgGraphPermission -ExactMatch user | out-null } | Should -Throw
+
+        }
+
+        It "Should return exactly the permission specified" -Tag testing {
+            Find-MgGraphPermission Group.read.basic |
+              Select-Object -ExpandProperty Name |
+              Should -Be 'Group.Read.Basic'
+        }
+
+        It "It allows the PermissionType to be specified when the All parameter is specified and returns the filtered results" -Tag testing {
+
+            $delegatedPermissions = 'Group.Read.Basic', 'RoleAssignmentSchedule.ReadWrite.Directory', 'User.Read.Basic'
+
+            $applicationPermissions = 'Directory.ReadWrite.All', 'Group.ReadWrite.All', 'People.Read.All', 'WorkforceIntegration.ReadWrite.All'
+
+            $allPermissions = @()
+            $allPermissions += $delegatedPermissions
+            $allPermissions += $applicationPermissions
+
+            $delegatedCount = $delegatedPermissions.Length
+            $applicationCount = $applicationPermissions.Length
+
+            $totalCount = $delegatedCount + $applicationCount
+
+            $allMatches = Find-MgGraphPermission -All
+
+            $allMatchesFromAny = Find-MgGraphPermission -All -PermissionType Any
+
+            $delegatedMatches = Find-MgGraphPermission -All -PermissionType Delegated
+
+            $applicationMatches = Find-MgGraphPermission -All -PermissionType Application
+
+            $allMatches.Length | Should -Be $totalCount
+            $allMatchesFromAny.Length | Should -Be $totalCount
+
+            $index = 0
+
+            $allPermissions | foreach {
+                $allMatches[$index].Name | Should -Be $_
+                $allMatchesFromAny[$index++].Name | Should -Be $_
+            }
+
+            $delegatedIndex = 0
+
+            $delegatedPermissions | foreach {
+                $delegatedMatches[$delegatedIndex++].Name | Should -Be $_
+            }
+
+            $applicationIndex = 0
+
+            $applicationPermissions | foreach {
+                $applicationMatches[$applicationIndex++].Name | Should -Be $_
+            }
+        }
+
+        It "Retrieves only application  permissions even the PermissionType parameter is specified as Application when delegated permissions would also match the search string" {
+            $allMatches = Find-MgGraphPermission ReadWrite
+
+            $index = 0
+
+            $delegatedPermissions = , 'RoleAssignmentSchedule.ReadWrite.Directory'
+            $applicationPermissions = 'Directory.ReadWrite.All', 'Group.ReadWrite.All', 'WorkforceIntegration.ReadWrite.All'
+
+            $allPermissions = @()
+            $allPermissions += $delegatedPermissions
+            $allPermissions += $applicationPermissions
+
+            $allPermissions | foreach {
+                $allMatches[$index++].Name | Should -Be $_
+            }
+
+            $applicationMatches = Find-MgGraphPermission ReadWrite -PermissionType Application
+
+            $applicationIndex = 0
+
+            $applicationPermissions | foreach {
+                $applicationMatches[$applicationIndex++].Name | Should -Be $_
+            }
+        }
+
         It "Returns nothing and throws no exception if a search string is specified and there is no match" {
             { Find-MgGraphPermission 'Nigeria has the best jollof' | Out-Null } | Should -Not -Throw
             Assert-MockCalled Invoke-MgGraphRequest
@@ -93,8 +224,8 @@ Describe "The Find-MgGraphPermission Command" {
             }
         }
 
-        It 'Executes successfully with no parameters' {
-            { Find-MgGraphPermission | Out-Null } | Should -Not -Throw
+        It 'Executes successfully with the All parameter' {
+            { Find-MgGraphPermission -All | Out-Null } | Should -Not -Throw
             Assert-MockCalled Invoke-MgGraphRequest
             (_Permissions_State).msGraphServicePrincipal | Should -Not -Be $null
             (_Permissions_State).isFromInvokeMgGraphRequest | Should -Be $false
@@ -134,8 +265,8 @@ Describe "The Find-MgGraphPermission Command" {
             }
         }
 
-        It 'Executes successfully with no parameters' {
-            { Find-MgGraphPermission | Out-Null } | Should -Not -Throw
+        It 'Executes successfully with the All parameter' {
+            { Find-MgGraphPermission -All | Out-Null } | Should -Not -Throw
             Assert-MockCalled Invoke-MgGraphRequest
             (_Permissions_State).msGraphServicePrincipal | Should -Not -Be $null
             (_Permissions_State).isFromInvokeMgGraphRequest | Should -Be $false
@@ -146,7 +277,7 @@ Describe "The Find-MgGraphPermission Command" {
                 $permissionData
             }
 
-            { Find-MgGraphPermission | Out-Null } | Should -Not -Throw
+            { Find-MgGraphPermission -All | Out-Null } | Should -Not -Throw
             Assert-MockCalled Invoke-MgGraphRequest
             (_Permissions_State).msGraphServicePrincipal | Should -Not -Be $null
             (_Permissions_State).isFromInvokeMgGraphRequest | Should -Be $true
@@ -209,23 +340,23 @@ Describe "The Find-MgGraphPermission Command" {
             }
         }
 
-        It 'Executes successfully with no parameters' {
-            { Find-MgGraphPermission | Out-Null } | Should -Not -Throw
+        It 'Executes successfully with the All parameter' {
+            { Find-MgGraphPermission -All | Out-Null } | Should -Not -Throw
             Assert-MockCalled Invoke-MgGraphRequest
             (_Permissions_State).msGraphServicePrincipal | Should -Not -Be $null
             (_Permissions_State).isFromInvokeMgGraphRequest | Should -Be $false
-            { Find-MgGraphPermission -Online | Out-Null } | Should -Throw 'mock authentication error message'
+            { Find-MgGraphPermission -All -Online | Out-Null } | Should -Throw 'mock authentication error message'
 
             # Restoring the connection that was set to fail in the BeforeEach
             Mock Invoke-MgGraphRequest{
                 $permissionData
             }
 
-            { Find-MgGraphPermission | Out-Null } | Should -Not -Throw
+            { Find-MgGraphPermission -All | Out-Null } | Should -Not -Throw
             Assert-MockCalled Invoke-MgGraphRequest
             (_Permissions_State).msGraphServicePrincipal | Should -Not -Be $null
             (_Permissions_State).isFromInvokeMgGraphRequest | Should -Be $true
-            { Find-MgGraphPermission -Online | Out-Null } | Should -Not -Throw
+            { Find-MgGraphPermission -All -Online | Out-Null } | Should -Not -Throw
 
         }
 


### PR DESCRIPTION
This change adds the following capabilities for `Find-MgGraphPermission`:

* New parameters for `Find-MgGraphPermission` to get more specific results and improve use in automation:
  * `ExactMatch` option is useful when you know the permission name and just want information. This could really be part of a `Get-MgGraphPermission` command, but it seems unnecessary to introduce that when `Find-MgGraphPermission` basically does this. Most common use case here will be automation where you use friendly permission names and need to convert them to unique id's for use with commands / APIs that expect unique id's.
  * `PermissionType` lets you filter on whether you want delegated or application permissions. This is useful because even in the `ExactMatch` case, permission names can map to multiple permissions because the same permission name is often used for both a delegated and application permission. By specifying both `ExactMatch` and `PermissionType` you are guaranteed to get back one unique permission, which is what is needed for automation use cases.
  * `All` lets you get all permissions and can be used with `PermissionType` to restrict it to all app permissions or all delegated permissions. This is useful for when you want to perform your own more complex filtering of permissions (e.g. not just partial or exact matches). Also useful for performing a "reverse-mapping" of permission id to permission name (just filter the results of `All` by the id)
  * Permission names may now be passed via the pipeline -- very useful when returning results from APIs that have id's such as `AppRoleAssignment` and converting those to human readable permission names
* `Get-Help Find-MgGraphPermission` now goes to the MS Graph online reference help for permissions as an easy way to redirect people to those docs. This may make it tricky for people to find docs specifically for this command though.
* Updates to docs for `Find-MgGraphPermission`
* Updated samples for `Application` and `Connect` where `Find-MgGraphPermission` adds new useful capabilities.

All new functionality has Pester unit test coverage.