### PR TITLE
Pre-populate User-Agent header for requests

### DIFF
--- a/src/Authentication/Authentication.Core/Interfaces/IAuthContext.cs
+++ b/src/Authentication/Authentication.Core/Interfaces/IAuthContext.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Graph.PowerShell.Authentication
 {
+    using System;
     using System.Security.Cryptography.X509Certificates;
 
     public enum AuthenticationType
@@ -41,5 +42,6 @@ namespace Microsoft.Graph.PowerShell.Authentication
         string AppName { get; set; }
         ContextScope ContextScope { get; set; }
         X509Certificate2 Certificate { get; set; }
+        Version PSHostVersion { get; set; }
     }
 }

--- a/src/Authentication/Authentication/Cmdlets/ConnectMgGraph.cs
+++ b/src/Authentication/Authentication/Cmdlets/ConnectMgGraph.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
         {
             using (NoSynchronizationContext)
             {
-                IAuthContext authContext = new AuthContext { TenantId = TenantId };
+                IAuthContext authContext = new AuthContext { TenantId = TenantId, PSHostVersion = this.Host.Version };
                 // Set selected environment to the session object.
                 GraphSession.Instance.Environment = environment;
                 switch (ParameterSetName)

--- a/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
@@ -31,13 +31,12 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     public class InvokeMgGraphRequest : PSCmdlet
     {
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
-        private readonly InvokeGraphRequestUserAgent _graphRequestUserAgent;
+        private RequestUserAgent _graphRequestUserAgent;
         private IGraphEnvironment _originalEnvironment;
         private string _originalFilePath;
 
         public InvokeMgGraphRequest()
         {
-            _graphRequestUserAgent = new InvokeGraphRequestUserAgent(this);
             Authentication = GraphRequestAuthenticationType.Default;
         }
 
@@ -1121,7 +1120,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             {
                 this.Break();
             }
-
+            _graphRequestUserAgent = new RequestUserAgent(this.Host.Version, this.MyInvocation);
             ValidateParameters();
             base.BeginProcessing();
         }

--- a/src/Authentication/Authentication/Helpers/RequestUserAgent.cs
+++ b/src/Authentication/Authentication/Helpers/RequestUserAgent.cs
@@ -11,14 +11,16 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Graph.PowerShell.Authentication.Helpers
 {
-    internal class InvokeGraphRequestUserAgent
+    internal class RequestUserAgent
     {
-        private readonly PSCmdlet _cmdLet;
+        private readonly InvocationInfo _invocationInfo;
+        private readonly Version _psHostVersion;
         private string _windowsUserAgent;
 
-        internal InvokeGraphRequestUserAgent(PSCmdlet cmdLet)
+        internal RequestUserAgent(Version psHostVersion, InvocationInfo invocationInfo)
         {
-            _cmdLet = cmdLet;
+            _invocationInfo = invocationInfo;
+            _psHostVersion = psHostVersion;
         }
         /// <summary>
         /// Full UserAgent which Includes the Operating System, Current Culture
@@ -46,7 +48,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
             get
             {
                 var app = string.Format(CultureInfo.InvariantCulture,
-                    "PowerShell/{0} {1}", this._cmdLet.Host.Version, this._cmdLet.MyInvocation.MyCommand.Name);
+                    "PowerShell/{0} {1}", _psHostVersion, _invocationInfo.MyCommand.Name);
                 return app;
             }
         }

--- a/src/Authentication/Authentication/Models/AuthContext.cs
+++ b/src/Authentication/Authentication/Models/AuthContext.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Graph.PowerShell.Authentication
 {
+    using System;
     using System.Security.Cryptography.X509Certificates;
     public class AuthContext: IAuthContext
     {
@@ -19,6 +20,7 @@ namespace Microsoft.Graph.PowerShell.Authentication
         public string AppName { get; set; }
         public ContextScope ContextScope { get ; set ; }
         public X509Certificate2 Certificate { get; set; }
+        public Version PSHostVersion { get; set; }
 
         public AuthContext()
         {

--- a/tools/Custom/Module.cs
+++ b/tools/Custom/Module.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Graph.PowerShell
             // Call Init to trigger any custom initialization needed after
             // module load and before pipeline is setup and used.
             Init();
-            pipeline = new Runtime.HttpPipeline(new Runtime.HttpClientFactory(HttpHelpers.GetGraphHttpClient()));
+            pipeline = new Runtime.HttpPipeline(new Runtime.HttpClientFactory(HttpHelpers.GetGraphHttpClient(invocationInfo)));
         }
 
         /// <summary>


### PR DESCRIPTION
[Certain APIs](https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/630) require a `User-Agent` header to be present in the headers when making a request. This PR pre-populates `User-Agent` header for all requests made through the SDK.

The `User-Agent` will consist of:
- OS name and version.
- PowerShell host version.
- Command name.

Closes #630 
Closes #920 