### PR TITLE
Fix missing NOTES section reference with better message. 

### DIFF
--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -6,7 +6,7 @@
 azure: false
 powershell: true
 version: latest
-use: "./assets/autorest-powershell-2.1.500.tgz"
+use: "./assets/autorest-powershell-2.1.600.tgz"
 metadata:
     authors: Microsoft Corporation
     owners: Microsoft Corporation


### PR DESCRIPTION
Use new version of autorest powershell where:-
- License text is not repeated in ProxyCmdlet definitions.
- Correct message pointing users to correct place to find help.

![MicrosoftTeams-image](https://user-images.githubusercontent.com/1641829/143895569-84d04a9a-90cc-4d30-86e3-2f7458141ebc.png)
[Autorest.PowerShell fix](https://github.com/Azure/autorest.powershell/pull/874)