### PR TITLE
Properly handle async calls when logging request/response bodies

### DIFF
--- a/src/Authentication/Authentication/Constants.cs
+++ b/src/Authentication/Authentication/Constants.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Graph.PowerShell.Authentication
     public static class Constants
     {
         public const int MaxContentLength = 10240;
-        public const string SDKHeaderValue = "Graph-powershell-{0}.{1}.{2}";
+        public const string SDKHeaderValue = "graph-powershell/{0}.{1}.{2}";
         internal const string UserParameterSet = "UserParameterSet";
         internal const string AppParameterSet = "AppParameterSet";
         internal const string AccessTokenParameterSet = "AccessTokenParameterSet";

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -534,6 +534,11 @@ directive:
         let duplicateDebugRegex = /^(\s*)(WriteDebug\(\$"{id}:.*)/gmi
         $ = $.replace(duplicateDebugRegex, "");
 
+        // catch all exceptions in ProcessRecordAsync.
+        let processAsyncFinallyRegex = /(finally\s*{\s*await \(\(Microsoft\.Graph\.PowerShell\.Runtime\.IEventListener\)this\)\.Signal\(Microsoft\.Graph\.PowerShell\.Runtime\.Events\.CmdletProcessRecordAsyncEnd\);)/gmi
+        let catchAllExceptionImplementation = '((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletException, $"{ex.GetType().Name} - {ex.Message} : {ex.StackTrace}").Wait(); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; } WriteError(new global::System.Management.Automation.ErrorRecord(ex, string.Empty, global::System.Management.Automation.ErrorCategory.NotSpecified, null));'
+        $ = $.replace(processAsyncFinallyRegex, `catch (System.Exception ex){${catchAllExceptionImplementation}}\n$1`);
+
         return $;
       }
 

--- a/tools/Custom/HttpMessageLogFormatter.cs
+++ b/tools/Custom/HttpMessageLogFormatter.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Graph.PowerShell
             string body = string.Empty;
             try
             {
-                body = (request.Content == null) ? string.Empty : FormatString(request.Content.ReadAsStringAsync().Result);
+                body = (request.Content == null) ? string.Empty : FormatString(request.Content.ReadAsStringAsync().GetAwaiter().GetResult());
             }
             catch { }
 
@@ -44,7 +44,7 @@ namespace Microsoft.Graph.PowerShell
             string body = string.Empty;
             try
             {
-                body = (response.Content == null) ? string.Empty : FormatString(response.Content.ReadAsStringAsync().Result);
+                body = (response.Content == null) ? string.Empty : FormatString(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
             }
             catch { }
 

--- a/tools/Custom/HttpMessageLogFormatter.cs
+++ b/tools/Custom/HttpMessageLogFormatter.cs
@@ -56,11 +56,11 @@ namespace Microsoft.Graph.PowerShell
             return stringBuilder.ToString();
         }
 
+        private static Regex regexPattern = new Regex("(\\s*\"access_token\"\\s*:\\s*)\"[^\"]+\"", RegexOptions.Compiled);
         private static object SanitizeBody(string body)
         {
             IList<Regex> regexList = new List<Regex>();
             // Remove access_token:*  instances in body.
-            Regex regexPattern = new Regex("(\\s*\"access_token\"\\s*:\\s*)\"[^\"]+\"");
             regexList.Add(regexPattern);
 
             foreach (Regex matcher in regexList)

--- a/tools/Custom/Module.cs
+++ b/tools/Custom/Module.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Graph.PowerShell
                 var response = eventData?.ResponseMessage as HttpResponseMessage;
                 if (response != null)
                 {
-                    if (response.Headers.Warning != null)
+                    if (response.Headers.Warning != null && response.Headers.Warning.Any())
                     {
                         string warningHeader = response.Headers.Warning.ToString();
                         await signal(Events.Warning, cancellationToken,


### PR DESCRIPTION
This PR ensures request/response bodies are always logged when `-Debug` is set.