### PR TITLE
Fixes Missing `-Debug` Request Body in PS 5.1

### DIFF
--- a/tools/Custom/HttpMessageLogFormatter.cs
+++ b/tools/Custom/HttpMessageLogFormatter.cs
@@ -12,18 +12,19 @@ namespace Microsoft.Graph.PowerShell
     using System.Net.Http.Headers;
     using System.Text;
     using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
     using System.Xml.Linq;
 
     public static class HttpMessageLogFormatter
     {
-        public static string GetHttpRequestLog(HttpRequestMessage request)
+        public static async Task<string> GetHttpRequestLogAsync(HttpRequestMessage request)
         {
             if (request == null) return string.Empty;
 
             string body = string.Empty;
             try
             {
-                body = (request.Content == null) ? string.Empty : FormatString(request.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+                body = (request.Content == null) ? string.Empty : FormatString(await request.Content.ReadAsStringAsync());
             }
             catch { }
 
@@ -36,14 +37,14 @@ namespace Microsoft.Graph.PowerShell
             return stringBuilder.ToString();
         }
 
-        public static string GetHttpResponseLog(HttpResponseMessage response)
+        public static async Task<string> GetHttpResponseLogAsync(HttpResponseMessage response)
         {
             if (response == null) return string.Empty;
 
             string body = string.Empty;
             try
             {
-                body = (response.Content == null) ? string.Empty : FormatString(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+                body = (response.Content == null) ? string.Empty : FormatString(await response.Content.ReadAsStringAsync());
             }
             catch { }
 


### PR DESCRIPTION
This PR fixes #980 by falling back to `OnBeforeCall` event handler when `-Debug` is used in PS 5.1.

#### Root cause of the bug
In PS 5.1 (NET Framework 4.x), the requestMessage content was being disposed before we could access it in the `OnResponseCreated` event handler. We need to log the request object in the `OnResponseCreated` to retrieve the request headers set via the middleware pipeline.

#### Fix
1. In PS 5.1 (.NET Framework), log the request message object in the `OnBeforeCall` event handler.
2. In PS 6+ (NET Core, NET 5+), log the request message object in the `OnResponseCreated` event handle.