### PR TITLE
Set the default page size to MaxPageSize

### DIFF
--- a/tools/Custom/ListCmdlet.cs
+++ b/tools/Custom/ListCmdlet.cs
@@ -107,7 +107,17 @@ namespace Microsoft.Graph.PowerShell.Cmdlets.Custom
                 limit = top;
             }
 
-            int currentPageSize = invocationInfo.BoundParameters.ContainsKey("PageSize") ? PageSize : DefaultPageSize;
+            int currentPageSize = DefaultPageSize;
+            if(invocationInfo.BoundParameters.ContainsKey("PageSize"))
+            {
+                currentPageSize = PageSize;
+            }
+            
+            if(invocationInfo.BoundParameters.ContainsKey("All"))
+            {
+                currentPageSize = MaxPageSize;
+            }
+
             if (invocationInfo.BoundParameters.ContainsKey("Top") && limit < currentPageSize)
             {
                 currentPageSize = limit;


### PR DESCRIPTION
The default page size has been set to the maximum value (999) as defined by the constant variable "MaxPageSize" whenever the argument "All" is provided. E.g. 
```
Get-MgServiceAnnouncementMessage -All -CountVariable 'ServiceAnnouncementMessageCount' -Debug
```
This is supposed to address issues https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/1141 and https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/1224.
The screenshot shows the result of this fix.  i.e., ```odata.nextLink``` parameter which was not there before as per the customer complaint, is now available.
![image](https://user-images.githubusercontent.com/10947120/165403533-baae482b-36b9-4c76-ae8f-d0abee2f491b.png)

