### PR TITLE
Example add mg application password

### DIFF
--- a/src/Applications/Applications/examples/v1.0-beta/Add-MgApplicationPassword.md
+++ b/src/Applications/Applications/examples/v1.0-beta/Add-MgApplicationPassword.md
@@ -60,4 +60,4 @@ AdditionalProperties : {[@odata.context,
 
 Add a password to an application that becomes valid at 12:00 am the next day and is valid for six months.
 
-Use `$secret.StartDateTime.ToLocalTime()` to convert the dates from UTC to the local timezone.
+Use `$secret.StartDateTime.ToLocalTime()` to convert the returned dates from UTC to the local timezone.

--- a/src/Applications/Applications/examples/v1.0-beta/Add-MgApplicationPassword.md
+++ b/src/Applications/Applications/examples/v1.0-beta/Add-MgApplicationPassword.md
@@ -1,18 +1,63 @@
-### Example 1: {{ Add title here }}
-```powershell
-PS C:\> {{ Add code here }}
+### Example 1: Add a password credential to an application with a six month expiry
 
-{{ Add output here }}
+```powershell
+
+Connect-MgGraph -Scopes 'Application.ReadWrite.All'
+
+$appObjectId = 'eaf1e531-0d58-4874-babe-b9a9f436e6c3'
+
+$passwordCred = @{
+   displayName = 'Created in PowerShell'
+   endDateTime = (Get-Date).AddMonths(6)
+}
+
+$secret = Add-MgApplicationPassword -applicationId $appObjectId -PasswordCredential $passwordCred
+$secret | Format-List
+
+CustomKeyIdentifier  :
+DisplayName          : Created in PowerShell
+EndDateTime          : 26/11/2022 12:03:31 pm
+Hint                 : Q_e
+KeyId                : c82bb763-741b-4575-9d9d-df7e766f6999
+SecretText           : Q_e8Q~ZDWJD.bkgajbREp-VFFUayCuEk8b1hDcr9
+StartDateTime        : 26/5/2022 1:03:31 pm
+AdditionalProperties : {[@odata.context,
+                       https://graph.microsoft.com/v1.0/$metadata#microsoft.graph.passwordCredential]}
 ```
 
-{{ Add description here }}
+Add a password to an application that expires in six months from the current date.
 
-### Example 2: {{ Add title here }}
+### Example 2: Add a password credential to an application with a start date
+
 ```powershell
-PS C:\> {{ Add code here }}
 
-{{ Add output here }}
+Connect-MgGraph -Scopes 'Application.ReadWrite.All'
+
+$appObjectId = 'eaf1e531-0d58-4874-babe-b9a9f436e6c3'
+
+$startDate = (Get-Date).AddDays(1).Date
+$endDate = $startDate.AddMonths(6)
+
+$passwordCred = @{
+   displayName = 'Created in PowerShell'
+   startDateTime = $startDate
+   endDateTime = $endDate
+}
+
+$secret = Add-MgApplicationPassword -applicationId $appObjectId -PasswordCredential $passwordCred
+$secret | Format-List
+
+CustomKeyIdentifier  :
+DisplayName          : Created in PowerShell
+EndDateTime          : 26/11/2022 1:00:00 pm
+Hint                 : TiA
+KeyId                : 082bf20f-63d6-4970-bb4e-55e504f50d8b
+SecretText           : TiA8Q~Zs7ej1cGtlW0qnmuFi~JlxXTZew_tU1bGA
+StartDateTime        : 26/5/2022 2:00:00 pm
+AdditionalProperties : {[@odata.context,
+                       https://graph.microsoft.com/v1.0/$metadata#microsoft.graph.passwordCredential]}
 ```
 
-{{ Add description here }}
+Add a password to an application that becomes valid at 12:00 am the next day and is valid for six months.
 
+Use `$secret.StartDateTime.ToLocalTime()` to convert the dates from UTC to the local timezone.

--- a/src/Applications/Applications/examples/v1.0/Add-MgApplicationPassword.md
+++ b/src/Applications/Applications/examples/v1.0/Add-MgApplicationPassword.md
@@ -1,18 +1,63 @@
-### Example 1: {{ Add title here }}
-```powershell
-PS C:\> {{ Add code here }}
+### Example 1: Add a password credential to an application with a six month expiry
 
-{{ Add output here }}
+```powershell
+
+Connect-MgGraph -Scopes 'Application.ReadWrite.All'
+
+$appObjectId = 'eaf1e531-0d58-4874-babe-b9a9f436e6c3'
+
+$passwordCred = @{
+   displayName = 'Created in PowerShell'
+   endDateTime = (Get-Date).AddMonths(6)
+}
+
+$secret = Add-MgApplicationPassword -applicationId $appObjectId -PasswordCredential $passwordCred
+$secret | Format-List
+
+CustomKeyIdentifier  :
+DisplayName          : Created in PowerShell
+EndDateTime          : 26/11/2022 12:03:31 pm
+Hint                 : Q_e
+KeyId                : c82bb763-741b-4575-9d9d-df7e766f6999
+SecretText           : Q_e8Q~ZDWJD.bkgajbREp-VFFUayCuEk8b1hDcr9
+StartDateTime        : 26/5/2022 1:03:31 pm
+AdditionalProperties : {[@odata.context,
+                       https://graph.microsoft.com/v1.0/$metadata#microsoft.graph.passwordCredential]}
 ```
 
-{{ Add description here }}
+Add a password to an application that expires in six months from the current date.
 
-### Example 2: {{ Add title here }}
+### Example 2: Add a password credential to an application with a start date
+
 ```powershell
-PS C:\> {{ Add code here }}
 
-{{ Add output here }}
+Connect-MgGraph -Scopes 'Application.ReadWrite.All'
+
+$appObjectId = 'eaf1e531-0d58-4874-babe-b9a9f436e6c3'
+
+$startDate = (Get-Date).AddDays(1).Date
+$endDate = $startDate.AddMonths(6)
+
+$passwordCred = @{
+   displayName = 'Created in PowerShell'
+   startDateTime = $startDate
+   endDateTime = $endDate
+}
+
+$secret = Add-MgApplicationPassword -applicationId $appObjectId -PasswordCredential $passwordCred
+$secret | Format-List
+
+CustomKeyIdentifier  :
+DisplayName          : Created in PowerShell
+EndDateTime          : 26/11/2022 1:00:00 pm
+Hint                 : TiA
+KeyId                : 082bf20f-63d6-4970-bb4e-55e504f50d8b
+SecretText           : TiA8Q~Zs7ej1cGtlW0qnmuFi~JlxXTZew_tU1bGA
+StartDateTime        : 26/5/2022 2:00:00 pm
+AdditionalProperties : {[@odata.context,
+                       https://graph.microsoft.com/v1.0/$metadata#microsoft.graph.passwordCredential]}
 ```
 
-{{ Add description here }}
+Add a password to an application that becomes valid at 12:00 am the next day and is valid for six months.
 
+Use `$secret.StartDateTime.ToLocalTime()` to convert the returned dates from UTC to the local timezone.


### PR DESCRIPTION
Added examples for `Add-MgApplicationPassword` cmdlet.

### Changes proposed in this pull request
- Example 1: Add a password with six month expiry
- Example 2: Add a password that has a start date