### PR TITLE
Remove unsupported commands from Identity.Governance module

### DIFF
--- a/src/Identity.Governance/Identity.Governance/readme.md
+++ b/src/Identity.Governance/Identity.Governance/readme.md
@@ -300,6 +300,10 @@ directive:
       verb: New|Remove|Update|Get|Invoke
       subject: (.*)(IdentityGovernance)AppConsent
     remove: true
+  - where:
+      verb: New|Remove|Update
+      subject: ^(.*)EntitlementManagementConnectedOrganization(Internal|External)Sponsor$
+    remove: true
 # Rename cmdlets with duplicates in their name.
   - where:
       subject: ^(BusinessFlowTemplate)(\1)+


### PR DESCRIPTION
This PR closes #1063 by removing unsupported `*externalSponsor` and `*internalSponsor` commands from Identity.Governance module.

The supported `$ref` path will be added by https://github.com/microsoftgraph/msgraph-metadata/pull/162.

See https://docs.microsoft.com/en-us/graph/api/resources/connectedorganization?view=graph-rest-1.0 for more details.