### PR TITLE
Removed null reference to Graph Instance environment after calling Invoke-MgGraph command

### DIFF
--- a/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
@@ -1090,9 +1090,13 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
 
         /// <summary>
         ///     Resets GraphSession environment back to its original state.
+        ///     Original state can remain to be the previous state defined by the user, 
+        ///     or the default global state. User defined state can be removed by calling,
+        ///     Remove-MgGraph Command
         /// </summary>
         private void ResetGraphSessionEnvironment()
         {
+            _originalEnvironment = GraphSession.Instance.Environment;
             GraphSession.Instance.Environment = _originalEnvironment;
         }
 


### PR DESCRIPTION

﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Reassign _originalEnvironment variable to the previous user defined environment instead of pointing to null. This will fix environment null reference issues on Invoke-MgGraph command such as this https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/1312

The images below show the results before and after proposed fix respectively

- **Before fix**
      
<img width="537" alt="image" src="https://user-images.githubusercontent.com/10947120/174590197-06d4ec2a-0e48-49ad-b4cf-33f75215d2fa.png">

- **After fix**
     
<img width="486" alt="image" src="https://user-images.githubusercontent.com/10947120/174590567-dd4312e8-d1d2-497e-b23a-8cfc9d0620e0.png">


