### PR TITLE
Add custom directive to download files in Reports module.

### DIFF
--- a/src/Authentication/Authentication/ErrorConstants.cs
+++ b/src/Authentication/Authentication/ErrorConstants.cs
@@ -29,13 +29,14 @@ namespace Microsoft.Graph.PowerShell.Authentication
             public const string InvokeGraphRequestCouldNotInferFileName = nameof(InvokeGraphRequestKeysWithDifferentCasingInJsonString);
         }
 
-        internal static class Message
+        public static class Message
         {
             internal const string CannotModifyBuiltInEnvironment = "Cannot {0} built-in environment {1}.";
             internal const string InvalidUrlParameter = "Parameter '{0}' has an invalid endpoint URL. Please use a valid URL with a network protocol i.e. [protocol]://[resource-name].";
             internal const string InvalidEnvironment = "Unable to find environment with name '{0}'. Use Get-MgEnvironment to list available environments.";
             internal const string CannotAccessFile = "Could not {0} file at '{1}'. Please ensure you have access to this file and try again in a few minutes..";
             internal const string InvalidCertificateThumbprint = "'{0}' must have a length of 40. Ensure you have the right certificate thumbprint then try again.";
+            public const string CannotInferFileName = "Could not infer file name from the response. Please specify the file name in -OutFile explicitly.";
         }
     }
 }

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -617,7 +617,7 @@ directive:
       } else {
         let outFileParameterRegex = /(^\s*)public\s*global::System\.String\s*OutFile\s*/gmi
         let streamResponseRegex = /global::System\.Threading\.Tasks\.Task<global::System\.IO\.Stream>\s*response/gmi
-        let octetStreamSchemaResponseRegex = /global::System\.Threading\.Tasks\.Task<.*OctetStreamSchema>\s*response/gmi
+        let octetStreamSchemaResponseRegex = /global::System\.Threading\.Tasks\.Task<.*(OctetStreamSchema|GraphReport)>\s*response/gmi
         let overrideOnOkCallRegex = /(^\s*)(overrideOnOk\(\s*responseMessage\s*,\s*response\s*,\s*ref\s*_returnNow\s*\);)/gmi
         if($.match(outFileParameterRegex) && $.match(streamResponseRegex)) {
           // Handle file download.


### PR DESCRIPTION
This PR closes #407 by adding a custom directive to download files when the response is of type `OctetStreamSchemaResponse` or `MicrosoftGraphReport`, and a command has `-OutFile` parameter.

#### Proposed Usage
``` powershell
# Download teams user activity count as CSV to the specified path using the file name in the path.
 Get-MgReportTeamUserActivityCount -Period D7 -OutFile "C:\My_PATH\FileName.csv"

# Download teams user activity count as CSV to the specified path. File name will be inferred from the content disposition header.
 Get-MgReportTeamUserActivityCount -Period D7 -OutFile "C:\My_PATH"

# Download teams user activity count as CSV to the current directory with the provided file name.
 Get-MgReportTeamUserActivityCount -Period D7 -OutFile "FileName.csv"

# Download teams user activity count as CSV to the current directory by inferring the file name from the content disposition header.
 Get-MgReportTeamUserActivityCount -Period D7 -OutFile .
```