### PR TITLE
Fixed typo in Get-MgDomain example

### DIFF
--- a/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0/Get-MgDomain.md
+++ b/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0/Get-MgDomain.md
@@ -35,7 +35,7 @@ Get entity from domains by key
 
 ## EXAMPLES
 
-### Example 1: Get a list of domaim objects
+### Example 1: Get a list of domain objects
 ```powershell
 Get-MgDomain | Format-List
 


### PR DESCRIPTION
Fixed the "domaim" typo in "[Example 1](https://docs.microsoft.com/en-us/powershell/module/microsoft.graph.identity.directorymanagement/get-mgdomain?view=graph-powershell-1.0#examples)" for the Get-MgDomain documentation. 
<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #1334 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Initial text in doc: "Example 1: Get a list of domaim objects"
- Fixed text in doc: "Example 1: Get a list of domain objects"

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links

- https://docs.microsoft.com/en-us/powershell/module/microsoft.graph.identity.directorymanagement/get-mgdomain?view=graph-powershell-1.0#examples