### PR TITLE
Enable API Version telemetry

### DIFF
--- a/src/Authentication/Authentication/Constants.cs
+++ b/src/Authentication/Authentication/Constants.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Graph.PowerShell.Authentication
     {
         public const double ClientTimeout = 300;
         public const int MaxContentLength = 10240;
-        public const string SDKHeaderValue = "graph-powershell/{0}.{1}.{2}";
+        public const string SDKHeaderValueV1 = "graph-powershell/{0}.{1}.{2}";
+        public const string SDKHeaderValueBeta = "graph-powershell-beta/{0}.{1}.{2}";
         internal const string UserParameterSet = nameof(UserParameterSet);
         internal const string AppParameterSet = nameof(AppParameterSet);
         internal const string AccessTokenParameterSet = nameof(AccessTokenParameterSet);

--- a/tools/Custom/Module.cs
+++ b/tools/Custom/Module.cs
@@ -16,10 +16,6 @@ namespace NamespacePrefixPlaceholder.PowerShell
 {
     public partial class Module
     {
-        /// <summary>
-        /// The selected Microsoft Graph profile.
-        /// </summary>
-        public string ProfileName { get; set; } = "v1.0";
         partial void BeforeCreatePipeline(System.Management.Automation.InvocationInfo invocationInfo, ref Runtime.HttpPipeline pipeline)
         {
             // Call Init to trigger any custom initialization needed after

--- a/tools/PostGeneration/CleanUpPsm1.ps1
+++ b/tools/PostGeneration/CleanUpPsm1.ps1
@@ -5,23 +5,16 @@ Param(
     [Parameter(Mandatory = $true)] [ValidateNotNullOrEmpty()][string] $FullyQualifiedModuleName
 )
 $ErrorActionPreference = "Stop"
-# Update module psm1 with Graph session profile name.
+# Update module psm1.
 $ModulePsm1 = Join-Path $ModuleProjectPath "/$FullyQualifiedModuleName.psm1"
 (Get-Content -Path $ModulePsm1) | ForEach-Object {
-    if ($_ -match '\$instance = \[Microsoft.Graph.PowerShell.Module\]::Instance') {
-        # Update main psm1 with Graph session profile name and module name.
-        $_
-        '  $instance.ProfileName = [Microsoft.Graph.PowerShell.Authentication.GraphSession]::Instance.SelectedProfile'
-    }
-    else {
-        # Rename all Azure instances in psm1 to `Microsoft Graph`.
-        $updatedLine = $_ -replace 'Azure', 'Microsoft Graph'
-        # Replace all 'instance.Name' declarations with fully qualified module name.
-        $updatedLine = $updatedLine -replace '\$\(\$instance.Name\)', "$FullyQualifiedModuleName"
-        # Replace Write-Information with Write-Debug
-        $updatedLine = $updatedLine -replace 'Write\-Information', 'Write-Debug'
-        $updatedLine
-    }
+    # Rename all Azure instances in psm1 to `Microsoft Graph`.
+    $updatedLine = $_ -replace 'Azure', 'Microsoft Graph'
+    # Replace all 'instance.Name' declarations with fully qualified module name.
+    $updatedLine = $updatedLine -replace '\$\(\$instance.Name\)', "$FullyQualifiedModuleName"
+    # Replace Write-Information with Write-Debug
+    $updatedLine = $updatedLine -replace 'Write\-Information', 'Write-Debug'
+    $updatedLine
 } | Set-Content $ModulePsm1
 
 # Address AutoREST bug where it looks for exports in the wrong directory.


### PR DESCRIPTION
This PR closes #1069 by ensuring the SdkVersion header has the right value giving the different SDKs for v1.0 and beta as described in [Telemetry Handler specification](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/middleware/TelemetryHandler.md).