### PR TITLE
Exclude features branch

### DIFF
--- a/.azure-pipelines/integrated-pipeline.yml
+++ b/.azure-pipelines/integrated-pipeline.yml
@@ -41,9 +41,9 @@ trigger:
       - dev
       - releases/*
       - bugfixes/*
-      - features/*
       exclude:
       - DocsGeneration/*
+      - features/*
 
 pr:
   branches:

--- a/.azure-pipelines/integrated-pipeline.yml
+++ b/.azure-pipelines/integrated-pipeline.yml
@@ -43,7 +43,7 @@ trigger:
       - bugfixes/*
       exclude:
       - DocsGeneration/*
-      - features/*
+      - features/2.0
 
 pr:
   branches:


### PR DESCRIPTION
This PR excludes from `features/2.0` branch from v1 integration builds as the branch has its own dedicated AzDo pipeline - https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/1435.