### PR TITLE
Manually add request bodies to ref operations

### DIFF
--- a/openApiDocs/beta/Applications.yml
+++ b/openApiDocs/beta/Applications.yml
@@ -623,6 +623,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: application
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -740,6 +749,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: application
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -2060,6 +2078,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: application
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -4339,6 +4366,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: application
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -4528,6 +4564,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: application
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -6148,6 +6193,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: onPremisesAgent
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -6701,6 +6755,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: publishedResource
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -7150,6 +7213,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: onPremisesAgent
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -8065,6 +8137,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: connectorGroup
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -8515,6 +8596,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: connector
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -8997,6 +9087,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: publishedResource
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -10324,6 +10423,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: servicePrincipal
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -11335,6 +11443,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: servicePrincipal
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -12518,6 +12635,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: servicePrincipal
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/beta/CrossDeviceExperiences.yml
+++ b/openApiDocs/beta/CrossDeviceExperiences.yml
@@ -2024,6 +2024,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: device
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/beta/Devices.CloudPrint.yml
+++ b/openApiDocs/beta/Devices.CloudPrint.yml
@@ -2340,6 +2340,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: printerShare
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -3032,6 +3041,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: printerShare
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -11015,6 +11033,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: printerShare
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -11707,6 +11734,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: printerShare
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/beta/Education.yml
+++ b/openApiDocs/beta/Education.yml
@@ -1299,6 +1299,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -1873,6 +1882,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -4037,6 +4055,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationClass
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -4579,6 +4606,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationClass
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -5238,6 +5274,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -5714,6 +5759,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -8782,6 +8836,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationSchool
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -9116,6 +9179,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationSchool
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -10768,6 +10840,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -11342,6 +11423,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/beta/Groups.yml
+++ b/openApiDocs/beta/Groups.yml
@@ -1112,6 +1112,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: group
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -19120,6 +19129,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: group
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -21322,6 +21340,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: group
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -22505,6 +22532,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: group
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/beta/Identity.DirectoryManagement.yml
+++ b/openApiDocs/beta/Identity.DirectoryManagement.yml
@@ -623,6 +623,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: administrativeUnit
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -4332,6 +4341,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: device
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -5659,6 +5677,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: administrativeUnit
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -7821,6 +7848,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: featureRolloutPolicy
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -10573,6 +10609,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: directoryRole
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/beta/Identity.Governance.yml
+++ b/openApiDocs/beta/Identity.Governance.yml
@@ -25770,6 +25770,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: accessPackageAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -26243,6 +26252,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: accessPackageAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -43303,6 +43321,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: accessPackage
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -43804,6 +43831,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: accessPackage
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -55076,6 +55112,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: accessPackage
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -55549,6 +55594,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: accessPackage
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -56060,6 +56114,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: connectedOrganization
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -56392,6 +56455,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: connectedOrganization
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/beta/Identity.SignIns.yml
+++ b/openApiDocs/beta/Identity.SignIns.yml
@@ -1159,6 +1159,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: b2cIdentityUserFlow
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -4343,6 +4352,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: b2xIdentityUserFlow
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -14539,6 +14557,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: featureRolloutPolicy
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -15649,6 +15676,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: mobilityManagementPolicy
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -16337,6 +16373,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: mobilityManagementPolicy
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -22112,6 +22157,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: microsoftAuthenticatorAuthenticationMethod
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -24321,6 +24375,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: passwordlessMicrosoftAuthenticatorAuthenticationMethod
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -27158,6 +27221,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: windowsHelloForBusinessAuthenticationMethod
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/beta/Users.yml
+++ b/openApiDocs/beta/Users.yml
@@ -1874,6 +1874,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: user
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/v1.0/Applications.yml
+++ b/openApiDocs/v1.0/Applications.yml
@@ -1698,6 +1698,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: application
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -1887,6 +1896,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: application
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -2076,6 +2094,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: application
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -3854,6 +3881,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: servicePrincipal
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -4865,6 +4901,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: servicePrincipal
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -5816,6 +5861,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: servicePrincipal
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/v1.0/Devices.CloudPrint.yml
+++ b/openApiDocs/v1.0/Devices.CloudPrint.yml
@@ -2498,6 +2498,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: printerShare
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -3107,6 +3116,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: printerShare
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/v1.0/Education.yml
+++ b/openApiDocs/v1.0/Education.yml
@@ -1289,6 +1289,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -1832,6 +1841,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -3978,6 +3996,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationClass
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -4520,6 +4547,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationClass
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -5173,6 +5209,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -5625,6 +5670,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -8607,6 +8661,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationSchool
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -8941,6 +9004,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationSchool
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -9891,6 +9963,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -10434,6 +10515,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: educationAssignment
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/v1.0/Groups.yml
+++ b/openApiDocs/v1.0/Groups.yml
@@ -1020,6 +1020,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: group
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -12147,6 +12156,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: group
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -14312,6 +14330,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: group
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -15501,6 +15528,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: group
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/v1.0/Identity.DirectoryManagement.yml
+++ b/openApiDocs/v1.0/Identity.DirectoryManagement.yml
@@ -2625,6 +2625,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: device
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -3686,6 +3695,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: administrativeUnit
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -5048,6 +5066,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: directoryRole
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/v1.0/Identity.Governance.yml
+++ b/openApiDocs/v1.0/Identity.Governance.yml
@@ -9598,6 +9598,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: connectedOrganization
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -9936,6 +9945,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: connectedOrganization
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/v1.0/Identity.SignIns.yml
+++ b/openApiDocs/v1.0/Identity.SignIns.yml
@@ -2311,6 +2311,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: b2xIdentityUserFlow
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -8047,6 +8056,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: featureRolloutPolicy
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -12357,6 +12375,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: microsoftAuthenticatorAuthenticationMethod
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success
@@ -14783,6 +14810,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: windowsHelloForBusinessAuthenticationMethod
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success

--- a/openApiDocs/v1.0/Users.yml
+++ b/openApiDocs/v1.0/Users.yml
@@ -1658,6 +1658,15 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: user
+      requestBody:
+        description: New navigation property ref value
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+        required: true
       responses:
         '204':
           description: Success


### PR DESCRIPTION
This PR closes #1440 by temporarily adding missing request bodies to affected `/$ref` operations. The complete fix will be provided by https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1082 once the bug fix is released.