### PR TITLE
Exclude v2 branch from v1 CI/CD

### DIFF
--- a/.azure-pipelines/common-templates/download-openapi-docs.yml
+++ b/.azure-pipelines/common-templates/download-openapi-docs.yml
@@ -130,7 +130,7 @@ jobs:
           script: |
             git status
             git add .
-            git commit -m 'Weekly OpenApiDocs Download. [run ci]'
+            git commit -m 'Weekly OpenApiDocs Download.'
             git status
             git push --set-upstream "https://$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git" $(ComputeBranch.WeeklyBranch)
             git status

--- a/.azure-pipelines/generation-templates/generate-service-modules.yml
+++ b/.azure-pipelines/generation-templates/generate-service-modules.yml
@@ -147,9 +147,9 @@ jobs:
             if ("${{ parameters.GenerateCommandMetadata }}" -eq "false") {
               $ModulesToGenerate = "${{ parameters.ModulesToGenerate }}"
               $Modules = $ModulesToGenerate.Split(" ", [System.StringSplitOptions]::RemoveEmptyEntries)
-              . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -Build -UpdateAutoRest -EnableSigning:$EnableSigning -ModulesToGenerate $Modules -ExcludeExampleTemplates -ExcludeNotesSection
+              . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -Build -Test -UpdateAutoRest -EnableSigning:$EnableSigning -ModulesToGenerate $Modules -ExcludeExampleTemplates -ExcludeNotesSection
             } else {
-              . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -Build -UpdateAutoRest -EnableSigning:$EnableSigning -ExcludeExampleTemplates -ExcludeNotesSection
+              . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -Build -Test -UpdateAutoRest -EnableSigning:$EnableSigning -ExcludeExampleTemplates -ExcludeNotesSection
             }
 
       - ${{ if eq(parameters.GenerateCommandMetadata, true) }}:

--- a/.azure-pipelines/integrated-pipeline.yml
+++ b/.azure-pipelines/integrated-pipeline.yml
@@ -39,17 +39,20 @@ trigger:
       include:
       - main
       - dev
-      - releases/*
-      - bugfixes/*
       exclude:
+      - WeeklyOpenApiDocsDownload/*
       - DocsGeneration/*
-      - features/2.0
+      - features/*
 
 pr:
   branches:
+    include:
+    - main
+    - dev
     exclude:
+    - WeeklyOpenApiDocsDownload/*
     - DocsGeneration/*
-    - features/2.0
+    - features/*
 
 stages:
 - stage: ComputeVersion

--- a/tools/GenerateHelp.ps1
+++ b/tools/GenerateHelp.ps1
@@ -57,8 +57,8 @@ $ModulesToGenerate | ForEach-Object {
     else {
         Write-Warning "v1.0 Docs for $ModuleName not Found"
     }
-    git status
-    git commit -m "Docs Generation for $ModuleName [run ci]"
 }
+git status
+git commit -m "Docs Generation for $(Get-Date -Format "MM-dd-yyyy") [run ci]"
 
 Write-Host -ForegroundColor Green "-------------Done-------------"


### PR DESCRIPTION
This PR excludes v2 branch from v1 CI/CD by adding an `include` for `main` and `dev` branches during PR trigger.

The PR also reduces the number of commits made during `Docs Generation` automated PR generation. See https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/1564/commits.