### PR TITLE
Mark nav properties as `readOnly`

### DIFF
--- a/tools/TweakOpenApi.ps1
+++ b/tools/TweakOpenApi.ps1
@@ -32,6 +32,13 @@ Get-ChildItem -Path $OpenAPIFilesPath | ForEach-Object {
             Write-Debug "$_ -> $operationId".Trim()
             return $operationId
         }
+
+        if ($_.contains("x-ms-navigationProperty: true")) {
+            # Mark navigation properties as readOnly.
+            $navigationPropertyExtension = ($_ -replace "x-ms-navigationProperty", "readOnly")
+            $modified = $true
+            return $navigationPropertyExtension
+        }
         return $_
     }
     if ($modified) { $updatedContent | Out-File $filePath -Force }


### PR DESCRIPTION
This PR closes #1605 by adding a pre-generation script that marks all navigation properties as readOnly. See discussion at https://github.com/microsoft/OpenAPI.NET.OData/issues/254 for more details.

The script will be executed every week after the weekly OpenAPI document refresh task is complete in https://github.com/microsoftgraph/msgraph-sdk-powershell/blob/7abf06334a79538e8b17da123ec6e8f7d8d6a866/tools/UpdateOpenApi.ps1#L62

A complete diff of changes being made can be found at https://github.com/microsoftgraph/msgraph-sdk-powershell/compare/po/ReadOnlyNavProperties...testRun/ReadOnlyNavProperties.