### PR TITLE
Fix serialization of Hashtables.

### DIFF
--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -714,6 +714,21 @@ directive:
         return $;
       }
 
+# Modify generated DictionaryExtensions.
+  - from: source-file-csharp
+    where: $
+    transform: >
+      if (!$documentPath.match(/generated%5Cruntime%5CDictionaryExtensions.cs/gm))
+      {
+        return $;
+      } else {
+        // Replace HashTableToDictionary call.
+        let hashtableRegex = /(HashTableToDictionary<V>\(nested, new System\.Collections\.Generic\.Dictionary<string, V>\(\)\);)/gm
+        $ = $.replace(hashtableRegex, 'try {dictionary[key] = (V)value;} catch {}');
+
+        return $;
+      }
+
 # Serialize all $count parameter to lowercase true or false.
   - from: source-file-csharp
     where: $


### PR DESCRIPTION
This PR closes #1538 by adding an AutoREST directive to assist in HashTable serialization.

This fix is only needed for v1 releases of the module as the issue has been fix by AutoREST in v2.