### PR TITLE
Update Find-MgGraphCommand for v2

### DIFF
--- a/src/Authentication/Authentication/custom/Find-MgGraphCommand.ps1
+++ b/src/Authentication/Authentication/custom/Find-MgGraphCommand.ps1
@@ -72,7 +72,6 @@ Function Find-MgGraphCommand {
         [Parameter(ParameterSetName = "FindByUri")]
         [Parameter(ParameterSetName = "FindByCommand")]
         [ValidateSet("v1.0", "beta")]
-        [Alias("Profile")]
         [string]$ApiVersion,
 
         [Parameter(ParameterSetName = "FindByCommand", Mandatory = $true)]

--- a/src/Authentication/Authentication/test/Find-MgGraphCommand.Tests.ps1
+++ b/src/Authentication/Authentication/test/Find-MgGraphCommand.Tests.ps1
@@ -12,12 +12,12 @@ Describe "Find-MgGraphCommand Command" {
             {
                 $MgCommand = Find-MgGraphCommand -Uri "/users"
                 $MgCommand | Should -HaveCount 4
-                $MgCommand.Command | Select-Object -Unique | should -HaveCount 2
+                $MgCommand.Command | Select-Object -Unique | should -HaveCount 4
                 $MgCommand.Method | Select-Object -Unique | should -HaveCount 2
                 $MgCommand.APIVersion | Select-Object -Unique | should -HaveCount 2
-                $MgCommand.Variants | Select-Object -Unique | should -HaveCount 6
+                $MgCommand.Variants | Select-Object -Unique | should -HaveCount 3
                 $MgCommand.URI | Select-Object -Unique | Should -Be "/users"
-                $MgCommand.Command | Select-Object -Unique | Should -BeIn @("New-MgUser", "Get-MgUser")
+                $MgCommand.Command | Select-Object -Unique | Should -BeIn @("New-MgUser", "Get-MgUser", "New-MgBetaUser", "Get-MgBetaUser")
             } | Should -Not -Throw
         }
         It 'Should find beta command using tokenized key segments' {
@@ -30,7 +30,7 @@ Describe "Find-MgGraphCommand Command" {
                 $MgCommand.APIVersion | Should -Be "beta" # -APIVersion takes precedence.
                 $MgCommand.Variants | Should -Contain "Export"
                 $MgCommand.URI | Should -Be "/users/{user-id}/exportPersonalData"
-                $MgCommand.Command | Should -Be "Export-MgUserPersonalData"
+                $MgCommand.Command | Should -Be "Export-MgBetaUserPersonalData"
             } | Should -Not -Throw
         }
         It 'Should find v1.0 command using actual id in key segments' {
@@ -43,7 +43,7 @@ Describe "Find-MgGraphCommand Command" {
                 $MgCommand.APIVersion | Should -Be "beta"
                 $MgCommand.Variants | Should -Contain "Get"
                 $MgCommand.URI | Should -Be $ExpectedResourceUri
-                $MgCommand.Command | Should -Be "Get-MgEntitlementManagementAccessPackageAssignmentResourceRole"
+                $MgCommand.Command | Should -Be "Get-MgBetaEntitlementManagementAccessPackageAssignmentResourceRole"
             } | Should -Not -Throw
         }
 
@@ -56,7 +56,7 @@ Describe "Find-MgGraphCommand Command" {
                 $MgCommand.APIVersion | Should -Be "beta"
                 $MgCommand.Variants | Should -Contain "List"
                 $MgCommand.URI | Should -Be "/users"
-                $MgCommand.Command | Should -Be "Get-MgUser"
+                $MgCommand.Command | Should -Be "Get-MgBetaUser"
             } | Should -Not -Throw
         }
         It 'Should find command using escaped URI' {
@@ -66,9 +66,9 @@ Describe "Find-MgGraphCommand Command" {
                 $MgCommand | Should -HaveCount 2
                 $MgCommand.Method | Select-Object -Unique | Should -Be "POST"
                 $MgCommand.APIVersion | Should -BeIn @("v1.0", "beta")
-                $MgCommand.Variants | Should -Contain "Create1"
+                $MgCommand.Variants | Should -Contain "Create"
                 $MgCommand.URI | Select-Object -Unique | Should -Be "/servicePrincipals/{servicePrincipal-id}/endpoints"
-                $MgCommand.Command | Select-Object -Unique | Should -Be "New-MgServicePrincipalEndpoint"
+                $MgCommand.Command | Select-Object -Unique | Should -BeIn @("New-MgServicePrincipalEndpoint", "New-MgBetaServicePrincipalEndpoint")
             } | Should -Not -Throw
         }
         It 'Should find command using regex' {
@@ -78,7 +78,7 @@ Describe "Find-MgGraphCommand Command" {
                 $MgCommand.Count | Should -BeGreaterThan 1
                 $MgCommand.Method | Select-Object -Unique | Should -Be "POST"
                 $MgCommand.APIVersion | Select-Object -Unique | Should -Be "beta"
-                $MgCommand.Command | Select-Object -Unique | Should -BeLike "*-MgUserCalendar*"
+                $MgCommand.Command | Select-Object -Unique | Should -BeLike "*-MgBetaUserCalendar*"
             } | Should -Not -Throw
         }
         It 'Should find command using action with FQNamespace.' {
@@ -87,7 +87,7 @@ Describe "Find-MgGraphCommand Command" {
                 $MgCommand = Find-MgGraphCommand -Uri $Uri -ApiVersion beta
                 $MgCommand.Method | Should -Be "POST"
                 $MgCommand.APIVersion | Should -Be "beta"
-                $MgCommand.Command | Should -Be "Update-MgSiteOnenotePageContent"
+                $MgCommand.Command | Should -Be "Update-MgBetaSiteOnenotePageContent"
                 $MgCommand.Uri | Should -Be "/sites/{site-id}/onenote/pages/{onenotePage-id}/onenotePatchContent"
             } | Should -Not -Throw
         }
@@ -97,7 +97,7 @@ Describe "Find-MgGraphCommand Command" {
                 $MgCommand = Find-MgGraphCommand -Uri $Uri -ApiVersion beta
                 $MgCommand.Method | Should -Be "POST"
                 $MgCommand.APIVersion | Should -Be "beta"
-                $MgCommand.Command | Should -Be "Update-MgWindowsUpdatesDeploymentAudience"
+                $MgCommand.Command | Should -Be "Update-MgBetaWindowsUpdatesDeploymentAudience"
                 $MgCommand.Uri | Should -Be "/admin/windows/updates/deployments/{deployment-id}/audience/updateAudience"
             } | Should -Not -Throw
         }
@@ -107,7 +107,7 @@ Describe "Find-MgGraphCommand Command" {
                 $MgCommand = Find-MgGraphCommand -Uri $Uri -ApiVersion beta
                 $MgCommand.Method | Should -Be "GET"
                 $MgCommand.APIVersion | Should -Be "beta"
-                $MgCommand.Command | Should -Be "Get-MgDeviceManagementAssignmentFilterState"
+                $MgCommand.Command | Should -Be "Get-MgBetaDeviceManagementAssignmentFilterState"
                 $MgCommand.Uri | Should -Be "/deviceManagement/assignmentFilters/getState"
             } | Should -Not -Throw
         }
@@ -117,7 +117,7 @@ Describe "Find-MgGraphCommand Command" {
                 $MgCommand.Count | Should -BeGreaterThan 1
                 $MgCommand.Method | Select-Object -Unique | Should -Be "GET"
                 $MgCommand.APIVersion | Select-Object -Unique | Should -BeIn @("v1.0", "beta")
-                $MgCommand.Command | Select-Object -Unique | Should -Be "Get-MgUser"
+                $MgCommand.Command | Select-Object -Unique | Should -BeIn @("Get-MgUser", "Get-MgBetaUser")
                 $MgCommand.Uri | Select-Object -Unique | Should -BeIn @("/users", "/users/{user-id}")
             } | Should -Not -Throw
         }
@@ -125,26 +125,39 @@ Describe "Find-MgGraphCommand Command" {
             $ExpectedErrorMessage = "*is not valid or is not currently supported by the SDK*"
             { Find-MgGraphCommand -Uri "invalidURI" -Method GET -ErrorAction Stop | Out-Null } | Should -Throw -ExpectedMessage $ExpectedErrorMessage
         }
+        It 'Should find command using actual id in key segments inside parenthesis' {
+            {
+                $ExpectedResourceUri = @("/reports/getSharePointActivityUserCounts(period='{period}')", "/reports/getSharePointActivityUserCounts(period='{period}')")
+                $Uri = "/reports/getSharePointActivityUserCounts(period='D3')"
+                $MgCommand = Find-MgGraphCommand -Uri $Uri 
+                $MgCommand | Should -HaveCount 2
+                $MgCommand.Method | Should -Be @("GET", "GET")
+                $MgCommand.APIVersion | Should -BeIn @("v1.0", "beta")
+                $MgCommand.Variants | Should -Contain "Get"
+                $MgCommand.URI | Should -Be $ExpectedResourceUri
+                $MgCommand.Command | Should -Be @("Get-MgReportSharePointActivityUserCount", "Get-MgBetaReportSharePointActivityUserCount")
+            } | Should -Not -Throw    
+        }
     }
 
     Context "FindByCommand" {
         It 'Should find command using only mandatory parameters' {
             {
                 $MgCommand = Find-MgGraphCommand -Command "Get-MgUser"
-                $MgCommand | Should -HaveCount 4 # /users and /users/{id}.
+                $MgCommand | Should -HaveCount 2 # /users and /users/{id}.
                 $MgCommand[0].Method | Select-Object -Unique | Should -Be "GET"
-                $MgCommand[0].APIVersion | Select-Object -Unique | Should -BeIn @("v1.0", "beta")
+                $MgCommand[0].APIVersion | Select-Object -Unique | Should -Be "v1.0"
                 $MgCommand[0].Command | Select-Object -Unique | Should -Be "Get-MgUser"
             } | Should -Not -Throw
         }
         Context "FindByCommand" {
             It 'Should find command using all parameters' {
                 {
-                    $MgCommand = Find-MgGraphCommand -Command "Invoke-MgAcceptGroupCalendarEvent" -Profile beta
+                    $MgCommand = Find-MgGraphCommand -Command "Invoke-MgBetaAcceptGroupCalendarEvent" -ApiVersion beta
                     $MgCommand | Should -HaveCount 1
                     $MgCommand.Method | Should -Be "POST"
                     $MgCommand.APIVersion | Should -Be "beta"
-                    $MgCommand.Command | Should -Be "Invoke-MgAcceptGroupCalendarEvent"
+                    $MgCommand.Command | Should -Be "Invoke-MgBetaAcceptGroupCalendarEvent"
                     $MgCommand.URI | Should -Be "/groups/{group-id}/calendar/events/{event-id}/accept"
                 } | Should -Not -Throw
             }
@@ -158,21 +171,9 @@ Describe "Find-MgGraphCommand Command" {
                 } | Should -Not -Throw
             }
             It 'Should throw error when command name is invalid' {
-                $ExpectedErrorMessage = "*'New-MgInvalid' is not a valid Microsoft Graph PowerShell command.*"
-                { Find-MgGraphCommand -Command "New-MgInvalid" -ErrorAction Stop | Out-Null } | Should -Throw -ExpectedMessage $ExpectedErrorMessage }
-            
-            It 'Should find command using actual id in key segments inside parenthesis' {
                 {
-                    $ExpectedResourceUri = @("/reports/getSharePointActivityUserCounts(period='{period}')", "/reports/getSharePointActivityUserCounts(period='{period}')")
-                    $Uri = "/reports/getSharePointActivityUserCounts(period='D3')"
-                    $MgCommand = Find-MgGraphCommand -Uri $Uri 
-                    $MgCommand | Should -HaveCount 2
-                    $MgCommand.Method | Should -Be @("GET", "GET")
-                    $MgCommand.APIVersion | Should -BeIn @("v1.0", "beta")
-                    $MgCommand.Variants | Should -Contain "Get"
-                    $MgCommand.URI | Should -Be $ExpectedResourceUri
-                    $MgCommand.Command | Should -Be @("Get-MgReportSharePointActivityUserCount", "Get-MgReportSharePointActivityUserCount")
-                } | Should -Not -Throw    
+                    Find-MgGraphCommand -Command "New-MgInvalid" -ErrorAction Stop | Out-Null
+                } | Should -Throw -ExpectedMessage "*'New-MgInvalid' is not a valid Microsoft Graph PowerShell command.*"
             }
         }
     }

--- a/src/Authentication/Authentication/test/Find-MgGraphCommand.Tests.ps1
+++ b/src/Authentication/Authentication/test/Find-MgGraphCommand.Tests.ps1
@@ -163,7 +163,7 @@ Describe "Find-MgGraphCommand Command" {
             
             It 'Should find command using actual id in key segments inside parenthesis' {
                 {
-                    $ExpectedResourceUri =  @("/reports/getSharePointActivityUserCounts(period='{period}')", "/reports/getSharePointActivityUserCounts(period='{period}')")
+                    $ExpectedResourceUri = @("/reports/getSharePointActivityUserCounts(period='{period}')", "/reports/getSharePointActivityUserCounts(period='{period}')")
                     $Uri = "/reports/getSharePointActivityUserCounts(period='D3')"
                     $MgCommand = Find-MgGraphCommand -Uri $Uri 
                     $MgCommand | Should -HaveCount 2

--- a/tools/ManageGeneratedModule.ps1
+++ b/tools/ManageGeneratedModule.ps1
@@ -47,7 +47,7 @@ foreach ($Package in $NugetPackagesToRemove) {
 # Add nuget packages from generate modules.
 foreach ($Package in $NugetPackagesToAdd) {
     Write-Debug "Executing: dotnet add $ModuleCsProj package $Package"
-    dotnet add $ModuleCsProj package $Package | Out-Null
+    dotnet add $ModuleCsProj package $Package -s https://api.nuget.org/v3/index.json | Out-Null
     if ($LastExitCode) {
         Write-Error "Failed to execute: dotnet add $ModuleCsProj package $Package"
     }


### PR DESCRIPTION
This PR closes #1568 by updating `Find-MgGraphCommand` to cover v2 commands.

The PR updates `MgCommandMetadata.json` file to:
``` json
[
  {
    "Uri": "/applications/{application-id}",
    "ApiVersion": "v1.0",
    "Variants": ["Get", "GetViaIdentity"],
    "OutputType": "IMicrosoftGraphApplication",
    "Command": "Get-MgApplication",
    "Permissions": [
      {
        "Name": "Application.ReadWrite.All",
        "Description": "Read and write applications",
        "FullDescription": "Allows the app to create, read, update and delete applications and service principals on your behalf. Does not allow management of consent grants.",
        "IsAdmin": true
      }
    ],
    "Method": "GET",
    "Module": "Applications"
  },
  {
    "Uri": "/applications/{application-id}",
    "ApiVersion": "beta",
    "Variants": ["Get", "GetViaIdentity"],
    "OutputType": "IMicrosoftGraphApplication",
    "Command": "Get-MgBetaApplication",
    "Permissions": [
      {
        "Name": "Application.ReadWrite.All",
        "Description": "Read and write applications",
        "FullDescription": "Allows the app to create, read, update and delete applications and service principals on your behalf. Does not allow management of consent grants.",
        "IsAdmin": true
      }
    ],
    "Method": "GET",
    "Module": "Beta.Applications"
  }
]


```