### PR TITLE
Sign all module artifacts

### DIFF
--- a/.azure-pipelines/generation-templates/authentication-module.yml
+++ b/.azure-pipelines/generation-templates/authentication-module.yml
@@ -39,7 +39,18 @@ steps:
       - template: ../common-templates/esrp/codesign.yml
         parameters:
           FolderPath: "$(System.DefaultWorkingDirectory)/src/Authentication/Authentication"
-          Pattern: "Microsoft.Graph.Authentication.dll, Microsoft.Graph.Authentication.Core.dll, *.ps1"
+          Pattern: "Microsoft.Graph.Authentication.dll, Microsoft.Graph.Authentication.Core.dll, *.psm1, *.psd1, *.format.ps1xml, *.ps1"
+
+      - task: PowerShell@2
+        displayName: "Validate Authenticode Signature"
+        inputs:
+          targetType: "inline"
+          pwsh: true
+          script: |
+            $ModulePsd1 = "$(System.DefaultWorkingDirectory)/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1"
+            $ModulePsm1 = "$(System.DefaultWorkingDirectory)/src/Authentication/Authentication/Microsoft.Graph.Authentication.psm1"
+            ($ModulePsd1 | Get-AuthenticodeSignature).Status | Should -Be "Valid"
+            ($ModulePsm1 | Get-AuthenticodeSignature).Status | Should -Be "Valid"
 
   - ${{ if eq(parameters.Pack, true) }}:
       - task: PowerShell@2

--- a/.azure-pipelines/generation-templates/meta-module.yml
+++ b/.azure-pipelines/generation-templates/meta-module.yml
@@ -26,7 +26,19 @@ steps:
       - template: ../common-templates/esrp/codesign.yml
         parameters:
           FolderPath: "$(System.DefaultWorkingDirectory)/src/Graph"
-          Pattern: "Microsoft.Graph.psm1, Microsoft.Graph.*.format.ps1xml, *.ps1"
+          Pattern: "Microsoft.Graph.*.psd1"
+
+      - task: PowerShell@2
+        displayName: "Validate Authenticode Signature"
+        inputs:
+          targetType: "inline"
+          pwsh: true
+          script: |
+            @("v1.0", "beta") | ForEach-Object {
+              $ApiVersion = $_
+              $ModulePsd1 = Join-Path $(System.DefaultWorkingDirectory) "/src/Graph/$ApiVersion/Microsoft.Graph*.psd1" -Resolve
+              ($ModulePsd1 | Get-AuthenticodeSignature).Status | Should -Be "Valid"
+            }
 
   - ${{ if eq(parameters.Pack, true) }}:
       - task: PowerShell@2

--- a/.azure-pipelines/generation-templates/meta-module.yml
+++ b/.azure-pipelines/generation-templates/meta-module.yml
@@ -26,7 +26,7 @@ steps:
       - template: ../common-templates/esrp/codesign.yml
         parameters:
           FolderPath: "$(System.DefaultWorkingDirectory)/src/Graph"
-          Pattern: "Microsoft.Graph.*.psd1"
+          Pattern: "*.psd1"
 
       - task: PowerShell@2
         displayName: "Validate Authenticode Signature"

--- a/.azure-pipelines/generation-templates/workload-modules.yml
+++ b/.azure-pipelines/generation-templates/workload-modules.yml
@@ -39,7 +39,29 @@ steps:
       - template: ../common-templates/esrp/codesign.yml
         parameters:
           FolderPath: "$(System.DefaultWorkingDirectory)/src"
-          Pattern: "Microsoft.Graph.*.private.dll, Microsoft.Graph.*.psm1, Microsoft.Graph.*.format.ps1xml, ProxyCmdletDefinitions.ps1, load-dependency.ps1"
+          Pattern: "Microsoft.Graph.*.private.dll, Microsoft.Graph.*.psm1, Microsoft.Graph.*.psd1, Microsoft.Graph.*.format.ps1xml, ProxyCmdletDefinitions.ps1, load-dependency.ps1"
+
+      - task: PowerShell@2
+        displayName: "Validate Authenticode Signature"
+        inputs:
+          targetType: "inline"
+          pwsh: true
+          script: |
+            $ModuleMappingConfigPath = '$(System.DefaultWorkingDirectory)/config/ModulesMapping.jsonc'
+            [HashTable] $ModuleMapping = Get-Content $ModuleMappingConfigPath | ConvertFrom-Json -AsHashTable
+            @("v1.0", "beta") | ForEach-Object {
+              $ApiVersion = $_
+              $ModuleMapping.Keys | ForEach-Object {
+                  $ModuleName = $_
+                  $ModulePath = "$(System.DefaultWorkingDirectory)/src/$ModuleName/$ApiVersion"
+                  if (Test-Path $ModulePath) {
+                    $ModulePsd1 = Join-Path $ModulePath "Microsoft.Graph*.$ModuleName.psd1" -Resolve
+                    $ModulePsm1 = Join-Path $ModulePath "Microsoft.Graph*.$ModuleName.psm1" -Resolve
+                    ($ModulePsd1 | Get-AuthenticodeSignature).Status | Should -Be "Valid"
+                    ($ModulePsm1 | Get-AuthenticodeSignature).Status | Should -Be "Valid"
+                  }
+              }
+            }
 
   - ${{ if eq(parameters.Pack, true) }}:
       - task: PowerShell@2


### PR DESCRIPTION
Fixes #1612 by ensuring we sign all module artifacts. The PR also adds a validation task to for all modules to ensure we've signed all `.psm1` and `psd1` files.