### PR TITLE
Remove misplaced `\n` literals in markdown docs

### DIFF
--- a/src/Applications/Applications/docs/v1.0-beta/Add-MgServicePrincipalTokenSigningCertificate.md
+++ b/src/Applications/Applications/docs/v1.0-beta/Add-MgServicePrincipalTokenSigningCertificate.md
@@ -9,7 +9,11 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Creates a self-signed signing certificate and returns a selfSignedCertificate object, which is the public part of the generated certificate.
-The self-signed signing certificate is composed of the following objects which are added to the servicePrincipal: \n+ The keyCredentials object with the following objects:\n    + A private key object with **usage** set to `Sign`.\n    + A public key object with **usage** set to `Verify`.\n+ The passwordCredentials object.
+The self-signed signing certificate is composed of the following objects which are added to the servicePrincipal: 
++ The keyCredentials object with the following objects:
+    + A private key object with **usage** set to `Sign`.
+    + A public key object with **usage** set to `Verify`.
++ The passwordCredentials object.
 All the objects have the same value of **customKeyIdentifier**.
 The **passwordCredential** is used to open the PFX file (private key).
 It and the associated private key object have the same value of **keyId**.
@@ -48,7 +52,11 @@ Add-MgServicePrincipalTokenSigningCertificate -InputObject <IApplicationsIdentit
 
 ## DESCRIPTION
 Creates a self-signed signing certificate and returns a selfSignedCertificate object, which is the public part of the generated certificate.
-The self-signed signing certificate is composed of the following objects which are added to the servicePrincipal: \n+ The keyCredentials object with the following objects:\n    + A private key object with **usage** set to `Sign`.\n    + A public key object with **usage** set to `Verify`.\n+ The passwordCredentials object.
+The self-signed signing certificate is composed of the following objects which are added to the servicePrincipal: 
++ The keyCredentials object with the following objects:
+    + A private key object with **usage** set to `Sign`.
+    + A public key object with **usage** set to `Verify`.
++ The passwordCredentials object.
 All the objects have the same value of **customKeyIdentifier**.
 The **passwordCredential** is used to open the PFX file (private key).
 It and the associated private key object have the same value of **keyId**.

--- a/src/Applications/Applications/docs/v1.0-beta/Microsoft.Graph.Applications.md
+++ b/src/Applications/Applications/docs/v1.0-beta/Microsoft.Graph.Applications.md
@@ -23,7 +23,11 @@ Adds a strong password to an application.
 
 ### [Add-MgServicePrincipalTokenSigningCertificate](Add-MgServicePrincipalTokenSigningCertificate.md)
 Creates a self-signed signing certificate and returns a selfSignedCertificate object, which is the public part of the generated certificate.
-The self-signed signing certificate is composed of the following objects which are added to the servicePrincipal: \n+ The keyCredentials object with the following objects:\n    + A private key object with **usage** set to `Sign`.\n    + A public key object with **usage** set to `Verify`.\n+ The passwordCredentials object.
+The self-signed signing certificate is composed of the following objects which are added to the servicePrincipal: 
++ The keyCredentials object with the following objects:
+    + A private key object with **usage** set to `Sign`.
+    + A public key object with **usage** set to `Verify`.
++ The passwordCredentials object.
 All the objects have the same value of **customKeyIdentifier**.
 The **passwordCredential** is used to open the PFX file (private key).
 It and the associated private key object have the same value of **keyId**.

--- a/src/Applications/Applications/docs/v1.0/Add-MgServicePrincipalTokenSigningCertificate.md
+++ b/src/Applications/Applications/docs/v1.0/Add-MgServicePrincipalTokenSigningCertificate.md
@@ -9,7 +9,11 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a self-signed signing certificate and return a selfSignedCertificate object, which is the public part of the generated certificate.
-The self-signed signing certificate is composed of the following objects, which are added to the servicePrincipal: \n+ The keyCredentials object with the following objects:\n    + A private key object with **usage** set to `Sign`.\n    + A public key object with **usage** set to `Verify`.\n+ The passwordCredentials object.
+The self-signed signing certificate is composed of the following objects, which are added to the servicePrincipal: 
++ The keyCredentials object with the following objects:
+    + A private key object with **usage** set to `Sign`.
+    + A public key object with **usage** set to `Verify`.
++ The passwordCredentials object.
 All the objects have the same value of **customKeyIdentifier**.
 The **passwordCredential** is used to open the PFX file (private key).
 It and the associated private key object have the same value of **keyId**.
@@ -48,7 +52,11 @@ Add-MgServicePrincipalTokenSigningCertificate -InputObject <IApplicationsIdentit
 
 ## DESCRIPTION
 Create a self-signed signing certificate and return a selfSignedCertificate object, which is the public part of the generated certificate.
-The self-signed signing certificate is composed of the following objects, which are added to the servicePrincipal: \n+ The keyCredentials object with the following objects:\n    + A private key object with **usage** set to `Sign`.\n    + A public key object with **usage** set to `Verify`.\n+ The passwordCredentials object.
+The self-signed signing certificate is composed of the following objects, which are added to the servicePrincipal: 
++ The keyCredentials object with the following objects:
+    + A private key object with **usage** set to `Sign`.
+    + A public key object with **usage** set to `Verify`.
++ The passwordCredentials object.
 All the objects have the same value of **customKeyIdentifier**.
 The **passwordCredential** is used to open the PFX file (private key).
 It and the associated private key object have the same value of **keyId**.

--- a/src/Applications/Applications/docs/v1.0/Microsoft.Graph.Applications.md
+++ b/src/Applications/Applications/docs/v1.0/Microsoft.Graph.Applications.md
@@ -33,7 +33,11 @@ Add a strong password or secret to a servicePrincipal object.
 
 ### [Add-MgServicePrincipalTokenSigningCertificate](Add-MgServicePrincipalTokenSigningCertificate.md)
 Create a self-signed signing certificate and return a selfSignedCertificate object, which is the public part of the generated certificate.
-The self-signed signing certificate is composed of the following objects, which are added to the servicePrincipal: \n+ The keyCredentials object with the following objects:\n    + A private key object with **usage** set to `Sign`.\n    + A public key object with **usage** set to `Verify`.\n+ The passwordCredentials object.
+The self-signed signing certificate is composed of the following objects, which are added to the servicePrincipal: 
++ The keyCredentials object with the following objects:
+    + A private key object with **usage** set to `Sign`.
+    + A public key object with **usage** set to `Verify`.
++ The passwordCredentials object.
 All the objects have the same value of **customKeyIdentifier**.
 The **passwordCredential** is used to open the PFX file (private key).
 It and the associated private key object have the same value of **keyId**.

--- a/src/Compliance/Compliance/docs/v1.0-beta/Clear-MgComplianceEdiscoveryCaseSourceCollectionData.md
+++ b/src/Compliance/Compliance/docs/v1.0-beta/Clear-MgComplianceEdiscoveryCaseSourceCollectionData.md
@@ -9,10 +9,17 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Permanently delete Microsoft Teams messages contained in a sourceCollection.
-You can collect and purge the following categories of Teams content:\n- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
-Teams 1:1 chats are also called *conversations*.\n- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
-Also called *1:N* chats or *group conversations*.\n- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.\n- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.\n- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
-For more information about purging Teams messages, see:\n- eDiscovery solution series: Data spillage scenario - Search and purge\n- Advanced eDiscovery workflow for content in Microsoft Teams
+You can collect and purge the following categories of Teams content:
+- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
+Teams 1:1 chats are also called *conversations*.
+- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
+Also called *1:N* chats or *group conversations*.
+- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
+- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.
+- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
+For more information about purging Teams messages, see:
+- eDiscovery solution series: Data spillage scenario - Search and purge
+- Advanced eDiscovery workflow for content in Microsoft Teams
 
 ## SYNTAX
 
@@ -30,10 +37,17 @@ Clear-MgComplianceEdiscoveryCaseSourceCollectionData -InputObject <IComplianceId
 
 ## DESCRIPTION
 Permanently delete Microsoft Teams messages contained in a sourceCollection.
-You can collect and purge the following categories of Teams content:\n- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
-Teams 1:1 chats are also called *conversations*.\n- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
-Also called *1:N* chats or *group conversations*.\n- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.\n- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.\n- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
-For more information about purging Teams messages, see:\n- eDiscovery solution series: Data spillage scenario - Search and purge\n- Advanced eDiscovery workflow for content in Microsoft Teams
+You can collect and purge the following categories of Teams content:
+- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
+Teams 1:1 chats are also called *conversations*.
+- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
+Also called *1:N* chats or *group conversations*.
+- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
+- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.
+- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
+For more information about purging Teams messages, see:
+- eDiscovery solution series: Data spillage scenario - Search and purge
+- Advanced eDiscovery workflow for content in Microsoft Teams
 
 ## EXAMPLES
 

--- a/src/Compliance/Compliance/docs/v1.0-beta/Microsoft.Graph.Compliance.md
+++ b/src/Compliance/Compliance/docs/v1.0-beta/Microsoft.Graph.Compliance.md
@@ -27,10 +27,17 @@ The location provides a URL that will return a caseExportOperation.
 
 ### [Clear-MgComplianceEdiscoveryCaseSourceCollectionData](Clear-MgComplianceEdiscoveryCaseSourceCollectionData.md)
 Permanently delete Microsoft Teams messages contained in a sourceCollection.
-You can collect and purge the following categories of Teams content:\n- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
-Teams 1:1 chats are also called *conversations*.\n- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
-Also called *1:N* chats or *group conversations*.\n- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.\n- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.\n- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
-For more information about purging Teams messages, see:\n- eDiscovery solution series: Data spillage scenario - Search and purge\n- Advanced eDiscovery workflow for content in Microsoft Teams
+You can collect and purge the following categories of Teams content:
+- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
+Teams 1:1 chats are also called *conversations*.
+- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
+Also called *1:N* chats or *group conversations*.
+- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
+- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.
+- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
+For more information about purging Teams messages, see:
+- eDiscovery solution series: Data spillage scenario - Search and purge
+- Advanced eDiscovery workflow for content in Microsoft Teams
 
 ### [Close-MgComplianceEdiscoveryCase](Close-MgComplianceEdiscoveryCase.md)
 Close an eDiscovery case.

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/Microsoft.Graph.DeviceManagement.Enrolment.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/Microsoft.Graph.DeviceManagement.Enrolment.md
@@ -631,7 +631,9 @@ Create new navigation property to resourceActions for roleManagement
 
 ### [New-MgRoleManagementCloudPcRoleAssignment](New-MgRoleManagementCloudPcRoleAssignment.md)
 Create a new unifiedRoleAssignmentMultiple object for an RBAC provider.
-The following RBAC providers are currently supported:\n- Cloud PC \n- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
+The following RBAC providers are currently supported:
+- Cloud PC 
+- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
 
 ### [New-MgRoleManagementCloudPcRoleAssignmentAppScope](New-MgRoleManagementCloudPcRoleAssignmentAppScope.md)
 Create new navigation property to appScopes for roleManagement
@@ -639,7 +641,10 @@ Create new navigation property to appScopes for roleManagement
 ### [New-MgRoleManagementCloudPcRoleDefinition](New-MgRoleManagementCloudPcRoleDefinition.md)
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ### [New-MgRoleManagementCloudPcRoleDefinitionInheritPermissionFrom](New-MgRoleManagementCloudPcRoleDefinitionInheritPermissionFrom.md)
 Create new navigation property to inheritsPermissionsFrom for roleManagement
@@ -652,7 +657,9 @@ Create new navigation property to resourceActions for roleManagement
 
 ### [New-MgRoleManagementDeviceManagementRoleAssignment](New-MgRoleManagementDeviceManagementRoleAssignment.md)
 Create a new unifiedRoleAssignmentMultiple object for an RBAC provider.
-The following RBAC providers are currently supported:\n- Cloud PC \n- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
+The following RBAC providers are currently supported:
+- Cloud PC 
+- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
 
 ### [New-MgRoleManagementDeviceManagementRoleAssignmentAppScope](New-MgRoleManagementDeviceManagementRoleAssignmentAppScope.md)
 Create new navigation property to appScopes for roleManagement
@@ -660,7 +667,10 @@ Create new navigation property to appScopes for roleManagement
 ### [New-MgRoleManagementDeviceManagementRoleDefinition](New-MgRoleManagementDeviceManagementRoleDefinition.md)
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ### [New-MgRoleManagementDeviceManagementRoleDefinitionInheritPermissionFrom](New-MgRoleManagementDeviceManagementRoleDefinitionInheritPermissionFrom.md)
 Create new navigation property to inheritsPermissionsFrom for roleManagement
@@ -695,7 +705,10 @@ See Enable per-user Azure AD Multi-Factor Authentication to secure sign-in event
 ### [New-MgRoleManagementDirectoryRoleDefinition](New-MgRoleManagementDirectoryRoleDefinition.md)
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ### [New-MgRoleManagementDirectoryRoleDefinitionInheritPermissionFrom](New-MgRoleManagementDirectoryRoleDefinitionInheritPermissionFrom.md)
 Create new navigation property to inheritsPermissionsFrom for roleManagement
@@ -743,7 +756,10 @@ See Enable per-user Azure AD Multi-Factor Authentication to secure sign-in event
 ### [New-MgRoleManagementEntitlementManagementRoleDefinition](New-MgRoleManagementEntitlementManagementRoleDefinition.md)
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ### [New-MgRoleManagementEntitlementManagementRoleDefinitionInheritPermissionFrom](New-MgRoleManagementEntitlementManagementRoleDefinitionInheritPermissionFrom.md)
 Create new navigation property to inheritsPermissionsFrom for roleManagement

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementCloudPcRoleAssignment.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementCloudPcRoleAssignment.md
@@ -9,7 +9,9 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a new unifiedRoleAssignmentMultiple object for an RBAC provider.
-The following RBAC providers are currently supported:\n- Cloud PC \n- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
+The following RBAC providers are currently supported:
+- Cloud PC 
+- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
 
 ## SYNTAX
 
@@ -31,7 +33,9 @@ New-MgRoleManagementCloudPcRoleAssignment -BodyParameter <IMicrosoftGraphUnified
 
 ## DESCRIPTION
 Create a new unifiedRoleAssignmentMultiple object for an RBAC provider.
-The following RBAC providers are currently supported:\n- Cloud PC \n- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
+The following RBAC providers are currently supported:
+- Cloud PC 
+- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
 
 ## EXAMPLES
 

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementCloudPcRoleDefinition.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementCloudPcRoleDefinition.md
@@ -10,7 +10,10 @@ schema: 2.0.0
 ## SYNOPSIS
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ## SYNTAX
 
@@ -32,7 +35,10 @@ New-MgRoleManagementCloudPcRoleDefinition -BodyParameter <IMicrosoftGraphUnified
 ## DESCRIPTION
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ## EXAMPLES
 

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementDeviceManagementRoleAssignment.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementDeviceManagementRoleAssignment.md
@@ -9,7 +9,9 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a new unifiedRoleAssignmentMultiple object for an RBAC provider.
-The following RBAC providers are currently supported:\n- Cloud PC \n- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
+The following RBAC providers are currently supported:
+- Cloud PC 
+- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
 
 ## SYNTAX
 
@@ -31,7 +33,9 @@ New-MgRoleManagementDeviceManagementRoleAssignment
 
 ## DESCRIPTION
 Create a new unifiedRoleAssignmentMultiple object for an RBAC provider.
-The following RBAC providers are currently supported:\n- Cloud PC \n- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
+The following RBAC providers are currently supported:
+- Cloud PC 
+- device management (Intune) For other Microsoft 365 applications (like Azure AD), use unifiedRoleAssignment.
 
 ## EXAMPLES
 

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementDeviceManagementRoleDefinition.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementDeviceManagementRoleDefinition.md
@@ -10,7 +10,10 @@ schema: 2.0.0
 ## SYNOPSIS
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ## SYNTAX
 
@@ -32,7 +35,10 @@ New-MgRoleManagementDeviceManagementRoleDefinition -BodyParameter <IMicrosoftGra
 ## DESCRIPTION
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ## EXAMPLES
 

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementDirectoryRoleDefinition.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementDirectoryRoleDefinition.md
@@ -10,7 +10,10 @@ schema: 2.0.0
 ## SYNOPSIS
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ## SYNTAX
 
@@ -32,7 +35,10 @@ New-MgRoleManagementDirectoryRoleDefinition -BodyParameter <IMicrosoftGraphUnifi
 ## DESCRIPTION
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ## EXAMPLES
 

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementEntitlementManagementRoleDefinition.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0-beta/New-MgRoleManagementEntitlementManagementRoleDefinition.md
@@ -10,7 +10,10 @@ schema: 2.0.0
 ## SYNOPSIS
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ## SYNTAX
 
@@ -32,7 +35,10 @@ New-MgRoleManagementEntitlementManagementRoleDefinition -BodyParameter <IMicroso
 ## DESCRIPTION
 Create a new unifiedRoleDefinition object for an RBAC provider.
 This feature requires an Azure AD Premium P1 or P2 license.
-The following RBAC providers are currently supported:\n- Cloud PC\n- device management (Intune)\n- directory (Azure AD)
+The following RBAC providers are currently supported:
+- Cloud PC
+- device management (Intune)
+- directory (Azure AD)
 
 ## EXAMPLES
 

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0/Microsoft.Graph.DeviceManagement.Enrolment.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0/Microsoft.Graph.DeviceManagement.Enrolment.md
@@ -310,7 +310,9 @@ Create new navigation property to roleAssignmentSchedules for roleManagement
 Create new navigation property to roleAssignmentScheduleInstances for roleManagement
 
 ### [New-MgRoleManagementDirectoryRoleAssignmentScheduleRequest](New-MgRoleManagementDirectoryRoleAssignmentScheduleRequest.md)
-In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:\n+ Request active and persistent role assignments for a principal, with or without expiry dates.\n+ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
+In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:
++ Request active and persistent role assignments for a principal, with or without expiry dates.
++ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
 To call this API to update, renew, and extend assignments for yourself, you must have multi-factor authentication (MFA) enforced, and running the query in a session in which they were challenged for MFA.
 See Enable per-user Azure AD Multi-Factor Authentication to secure sign-in events.
 
@@ -341,7 +343,9 @@ Create new navigation property to roleAssignmentSchedules for roleManagement
 Create new navigation property to roleAssignmentScheduleInstances for roleManagement
 
 ### [New-MgRoleManagementEntitlementManagementRoleAssignmentScheduleRequest](New-MgRoleManagementEntitlementManagementRoleAssignmentScheduleRequest.md)
-In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:\n+ Request active and persistent role assignments for a principal, with or without expiry dates.\n+ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
+In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:
++ Request active and persistent role assignments for a principal, with or without expiry dates.
++ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
 To call this API to update, renew, and extend assignments for yourself, you must have multi-factor authentication (MFA) enforced, and running the query in a session in which they were challenged for MFA.
 See Enable per-user Azure AD Multi-Factor Authentication to secure sign-in events.
 

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0/New-MgRoleManagementDirectoryRoleAssignmentScheduleRequest.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0/New-MgRoleManagementDirectoryRoleAssignmentScheduleRequest.md
@@ -8,7 +8,9 @@ schema: 2.0.0
 # New-MgRoleManagementDirectoryRoleAssignmentScheduleRequest
 
 ## SYNOPSIS
-In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:\n+ Request active and persistent role assignments for a principal, with or without expiry dates.\n+ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
+In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:
++ Request active and persistent role assignments for a principal, with or without expiry dates.
++ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
 To call this API to update, renew, and extend assignments for yourself, you must have multi-factor authentication (MFA) enforced, and running the query in a session in which they were challenged for MFA.
 See Enable per-user Azure AD Multi-Factor Authentication to secure sign-in events.
 
@@ -36,7 +38,9 @@ New-MgRoleManagementDirectoryRoleAssignmentScheduleRequest
 ```
 
 ## DESCRIPTION
-In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:\n+ Request active and persistent role assignments for a principal, with or without expiry dates.\n+ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
+In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:
++ Request active and persistent role assignments for a principal, with or without expiry dates.
++ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
 To call this API to update, renew, and extend assignments for yourself, you must have multi-factor authentication (MFA) enforced, and running the query in a session in which they were challenged for MFA.
 See Enable per-user Azure AD Multi-Factor Authentication to secure sign-in events.
 

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0/New-MgRoleManagementEntitlementManagementRoleAssignmentScheduleRequest.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/docs/v1.0/New-MgRoleManagementEntitlementManagementRoleAssignmentScheduleRequest.md
@@ -8,7 +8,9 @@ schema: 2.0.0
 # New-MgRoleManagementEntitlementManagementRoleAssignmentScheduleRequest
 
 ## SYNOPSIS
-In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:\n+ Request active and persistent role assignments for a principal, with or without expiry dates.\n+ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
+In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:
++ Request active and persistent role assignments for a principal, with or without expiry dates.
++ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
 To call this API to update, renew, and extend assignments for yourself, you must have multi-factor authentication (MFA) enforced, and running the query in a session in which they were challenged for MFA.
 See Enable per-user Azure AD Multi-Factor Authentication to secure sign-in events.
 
@@ -36,7 +38,9 @@ New-MgRoleManagementEntitlementManagementRoleAssignmentScheduleRequest
 ```
 
 ## DESCRIPTION
-In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:\n+ Request active and persistent role assignments for a principal, with or without expiry dates.\n+ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
+In PIM, carry out the following operations through the unifiedRoleAssignmentScheduleRequest object:
++ Request active and persistent role assignments for a principal, with or without expiry dates.
++ Activate, deactivate, extend, or renew an eligible role assignment for a principal.
 To call this API to update, renew, and extend assignments for yourself, you must have multi-factor authentication (MFA) enforced, and running the query in a session in which they were challenged for MFA.
 See Enable per-user Azure AD Multi-Factor Authentication to secure sign-in events.
 

--- a/src/DirectoryObjects/DirectoryObjects/docs/v1.0/Get-MgDirectoryObjectAvailableExtensionProperty.md
+++ b/src/DirectoryObjects/DirectoryObjects/docs/v1.0/Get-MgDirectoryObjectAvailableExtensionProperty.md
@@ -9,7 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## SYNTAX
 
@@ -28,7 +34,13 @@ Get-MgDirectoryObjectAvailableExtensionProperty
 
 ## DESCRIPTION
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## EXAMPLES
 

--- a/src/DirectoryObjects/DirectoryObjects/docs/v1.0/Microsoft.Graph.DirectoryObjects.md
+++ b/src/DirectoryObjects/DirectoryObjects/docs/v1.0/Microsoft.Graph.DirectoryObjects.md
@@ -26,7 +26,13 @@ Retrieve the properties and relationships of a directoryObject object.
 
 ### [Get-MgDirectoryObjectAvailableExtensionProperty](Get-MgDirectoryObjectAvailableExtensionProperty.md)
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ### [Get-MgDirectoryObjectById](Get-MgDirectoryObjectById.md)
 Return the directory objects specified in a list of IDs.

--- a/src/Groups/Groups/docs/v1.0/Get-MgGroupPermissionGrantAvailableExtensionProperty.md
+++ b/src/Groups/Groups/docs/v1.0/Get-MgGroupPermissionGrantAvailableExtensionProperty.md
@@ -9,7 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## SYNTAX
 
@@ -41,7 +47,13 @@ Get-MgGroupPermissionGrantAvailableExtensionProperty -InputObject <IGroupsIdenti
 
 ## DESCRIPTION
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## EXAMPLES
 

--- a/src/Groups/Groups/docs/v1.0/Microsoft.Graph.Groups.md
+++ b/src/Groups/Groups/docs/v1.0/Microsoft.Graph.Groups.md
@@ -295,7 +295,13 @@ Supports $expand.
 
 ### [Get-MgGroupPermissionGrantAvailableExtensionProperty](Get-MgGroupPermissionGrantAvailableExtensionProperty.md)
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ### [Get-MgGroupPermissionGrantById](Get-MgGroupPermissionGrantById.md)
 Return the directory objects specified in a list of IDs.

--- a/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0-beta/Microsoft.Graph.Identity.DirectoryManagement.md
+++ b/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0-beta/Microsoft.Graph.Identity.DirectoryManagement.md
@@ -1079,10 +1079,10 @@ Set mobile device management authority
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1090,10 +1090,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1101,10 +1101,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1112,10 +1112,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1123,10 +1123,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1134,10 +1134,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1145,10 +1145,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1156,10 +1156,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1167,10 +1167,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1178,10 +1178,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1189,10 +1189,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1328,12 +1328,16 @@ Update the navigation property settings in organization
 ### [Update-MgOrganizationSettingContactInsight](Update-MgOrganizationSettingContactInsight.md)
 Update the privacy settings to display or return the specified type of insights in an organization.
 The type of settings can be contact insights, item insights, or people insights.
-To learn more about customizing insights privacy for your organization, see:\n-  Customize item insights privacy \n-  Customize people insights privacy
+To learn more about customizing insights privacy for your organization, see:
+-  Customize item insights privacy 
+-  Customize people insights privacy
 
 ### [Update-MgOrganizationSettingItemInsight](Update-MgOrganizationSettingItemInsight.md)
 Update the privacy settings to display or return the specified type of insights in an organization.
 The type of settings can be contact insights, item insights, or people insights.
-To learn more about customizing insights privacy for your organization, see:\n-  Customize item insights privacy \n-  Customize people insights privacy
+To learn more about customizing insights privacy for your organization, see:
+-  Customize item insights privacy 
+-  Customize people insights privacy
 
 ### [Update-MgOrganizationSettingMicrosoftApplicationDataAccess](Update-MgOrganizationSettingMicrosoftApplicationDataAccess.md)
 Update the settings in a microsoftApplicationDataAccessSettings object that specify access from Microsoft applications to Microsoft 365 user data in an organization.
@@ -1341,7 +1345,9 @@ Update the settings in a microsoftApplicationDataAccessSettings object that spec
 ### [Update-MgOrganizationSettingPersonInsight](Update-MgOrganizationSettingPersonInsight.md)
 Update the privacy settings to display or return the specified type of insights in an organization.
 The type of settings can be contact insights, item insights, or people insights.
-To learn more about customizing insights privacy for your organization, see:\n-  Customize item insights privacy \n-  Customize people insights privacy
+To learn more about customizing insights privacy for your organization, see:
+-  Customize item insights privacy 
+-  Customize people insights privacy
 
 ### [Update-MgOrganizationSettingProfileCardProperty](Update-MgOrganizationSettingProfileCardProperty.md)
 Update the navigation property profileCardProperties in organization

--- a/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0-beta/Update-MgOrganizationSettingContactInsight.md
+++ b/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0-beta/Update-MgOrganizationSettingContactInsight.md
@@ -10,7 +10,9 @@ schema: 2.0.0
 ## SYNOPSIS
 Update the privacy settings to display or return the specified type of insights in an organization.
 The type of settings can be contact insights, item insights, or people insights.
-To learn more about customizing insights privacy for your organization, see:\n-  Customize item insights privacy \n-  Customize people insights privacy
+To learn more about customizing insights privacy for your organization, see:
+-  Customize item insights privacy 
+-  Customize people insights privacy
 
 ## SYNTAX
 
@@ -43,7 +45,9 @@ Update-MgOrganizationSettingContactInsight -InputObject <IIdentityDirectoryManag
 ## DESCRIPTION
 Update the privacy settings to display or return the specified type of insights in an organization.
 The type of settings can be contact insights, item insights, or people insights.
-To learn more about customizing insights privacy for your organization, see:\n-  Customize item insights privacy \n-  Customize people insights privacy
+To learn more about customizing insights privacy for your organization, see:
+-  Customize item insights privacy 
+-  Customize people insights privacy
 
 ## EXAMPLES
 

--- a/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0-beta/Update-MgOrganizationSettingItemInsight.md
+++ b/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0-beta/Update-MgOrganizationSettingItemInsight.md
@@ -10,7 +10,9 @@ schema: 2.0.0
 ## SYNOPSIS
 Update the privacy settings to display or return the specified type of insights in an organization.
 The type of settings can be contact insights, item insights, or people insights.
-To learn more about customizing insights privacy for your organization, see:\n-  Customize item insights privacy \n-  Customize people insights privacy
+To learn more about customizing insights privacy for your organization, see:
+-  Customize item insights privacy 
+-  Customize people insights privacy
 
 ## SYNTAX
 
@@ -43,7 +45,9 @@ Update-MgOrganizationSettingItemInsight -InputObject <IIdentityDirectoryManageme
 ## DESCRIPTION
 Update the privacy settings to display or return the specified type of insights in an organization.
 The type of settings can be contact insights, item insights, or people insights.
-To learn more about customizing insights privacy for your organization, see:\n-  Customize item insights privacy \n-  Customize people insights privacy
+To learn more about customizing insights privacy for your organization, see:
+-  Customize item insights privacy 
+-  Customize people insights privacy
 
 ## EXAMPLES
 

--- a/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0-beta/Update-MgOrganizationSettingPersonInsight.md
+++ b/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0-beta/Update-MgOrganizationSettingPersonInsight.md
@@ -10,7 +10,9 @@ schema: 2.0.0
 ## SYNOPSIS
 Update the privacy settings to display or return the specified type of insights in an organization.
 The type of settings can be contact insights, item insights, or people insights.
-To learn more about customizing insights privacy for your organization, see:\n-  Customize item insights privacy \n-  Customize people insights privacy
+To learn more about customizing insights privacy for your organization, see:
+-  Customize item insights privacy 
+-  Customize people insights privacy
 
 ## SYNTAX
 
@@ -43,7 +45,9 @@ Update-MgOrganizationSettingPersonInsight -InputObject <IIdentityDirectoryManage
 ## DESCRIPTION
 Update the privacy settings to display or return the specified type of insights in an organization.
 The type of settings can be contact insights, item insights, or people insights.
-To learn more about customizing insights privacy for your organization, see:\n-  Customize item insights privacy \n-  Customize people insights privacy
+To learn more about customizing insights privacy for your organization, see:
+-  Customize item insights privacy 
+-  Customize people insights privacy
 
 ## EXAMPLES
 

--- a/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0/Get-MgDirectoryDeletedItemAvailableExtensionProperty.md
+++ b/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0/Get-MgDirectoryDeletedItemAvailableExtensionProperty.md
@@ -9,7 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## SYNTAX
 
@@ -28,7 +34,13 @@ Get-MgDirectoryDeletedItemAvailableExtensionProperty
 
 ## DESCRIPTION
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## EXAMPLES
 

--- a/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0/Microsoft.Graph.Identity.DirectoryManagement.md
+++ b/src/Identity.DirectoryManagement/Identity.DirectoryManagement/docs/v1.0/Microsoft.Graph.Identity.DirectoryManagement.md
@@ -220,7 +220,13 @@ Nullable.
 
 ### [Get-MgDirectoryDeletedItemAvailableExtensionProperty](Get-MgDirectoryDeletedItemAvailableExtensionProperty.md)
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ### [Get-MgDirectoryDeletedItemById](Get-MgDirectoryDeletedItemById.md)
 Return the directory objects specified in a list of IDs.

--- a/src/Identity.Governance/Identity.Governance/docs/v1.0/Get-MgEntitlementManagementConnectedOrganizationExternalSponsorAvailableExtensionProperty.md
+++ b/src/Identity.Governance/Identity.Governance/docs/v1.0/Get-MgEntitlementManagementConnectedOrganizationExternalSponsorAvailableExtensionProperty.md
@@ -9,7 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## SYNTAX
 
@@ -45,7 +51,13 @@ Get-MgEntitlementManagementConnectedOrganizationExternalSponsorAvailableExtensio
 
 ## DESCRIPTION
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## EXAMPLES
 

--- a/src/Identity.Governance/Identity.Governance/docs/v1.0/Get-MgEntitlementManagementConnectedOrganizationInternalSponsorAvailableExtensionProperty.md
+++ b/src/Identity.Governance/Identity.Governance/docs/v1.0/Get-MgEntitlementManagementConnectedOrganizationInternalSponsorAvailableExtensionProperty.md
@@ -9,7 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## SYNTAX
 
@@ -45,7 +51,13 @@ Get-MgEntitlementManagementConnectedOrganizationInternalSponsorAvailableExtensio
 
 ## DESCRIPTION
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## EXAMPLES
 

--- a/src/Identity.Governance/Identity.Governance/docs/v1.0/Microsoft.Graph.Identity.Governance.md
+++ b/src/Identity.Governance/Identity.Governance/docs/v1.0/Microsoft.Graph.Identity.Governance.md
@@ -128,7 +128,13 @@ The external sponsors are a set of users who can approve requests on behalf of o
 
 ### [Get-MgEntitlementManagementConnectedOrganizationExternalSponsorAvailableExtensionProperty](Get-MgEntitlementManagementConnectedOrganizationExternalSponsorAvailableExtensionProperty.md)
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ### [Get-MgEntitlementManagementConnectedOrganizationExternalSponsorById](Get-MgEntitlementManagementConnectedOrganizationExternalSponsorById.md)
 Return the directory objects specified in a list of IDs.
@@ -144,7 +150,13 @@ The internal sponsors are a set of users who can approve requests on behalf of o
 
 ### [Get-MgEntitlementManagementConnectedOrganizationInternalSponsorAvailableExtensionProperty](Get-MgEntitlementManagementConnectedOrganizationInternalSponsorAvailableExtensionProperty.md)
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ### [Get-MgEntitlementManagementConnectedOrganizationInternalSponsorById](Get-MgEntitlementManagementConnectedOrganizationInternalSponsorById.md)
 Return the directory objects specified in a list of IDs.

--- a/src/Identity.SignIns/Identity.SignIns/docs/v1.0/Get-MgPolicyFeatureRolloutPolicyApplyToAvailableExtensionProperty.md
+++ b/src/Identity.SignIns/Identity.SignIns/docs/v1.0/Get-MgPolicyFeatureRolloutPolicyApplyToAvailableExtensionProperty.md
@@ -9,7 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## SYNTAX
 
@@ -41,7 +47,13 @@ Get-MgPolicyFeatureRolloutPolicyApplyToAvailableExtensionProperty -InputObject <
 
 ## DESCRIPTION
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ## EXAMPLES
 

--- a/src/Identity.SignIns/Identity.SignIns/docs/v1.0/Microsoft.Graph.Identity.SignIns.md
+++ b/src/Identity.SignIns/Identity.SignIns/docs/v1.0/Microsoft.Graph.Identity.SignIns.md
@@ -153,7 +153,13 @@ Specifies a list of directoryObjects that feature is enabled for.
 
 ### [Get-MgPolicyFeatureRolloutPolicyApplyToAvailableExtensionProperty](Get-MgPolicyFeatureRolloutPolicyApplyToAvailableExtensionProperty.md)
 Return all directory extension definitions that have been registered in a directory, including through multi-tenant apps.
-The following entities support extension properties:\n+ user\n+ group\n+ administrativeUnit\n+ application\n+ device\n+ organization
+The following entities support extension properties:
++ user
++ group
++ administrativeUnit
++ application
++ device
++ organization
 
 ### [Get-MgPolicyFeatureRolloutPolicyApplyToById](Get-MgPolicyFeatureRolloutPolicyApplyToById.md)
 Return the directory objects specified in a list of IDs.

--- a/src/Security/Security/docs/v1.0-beta/Clear-MgSecurityCaseEdiscoveryCaseSearchData.md
+++ b/src/Security/Security/docs/v1.0-beta/Clear-MgSecurityCaseEdiscoveryCaseSearchData.md
@@ -9,10 +9,17 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Permanently delete Microsoft Teams messages contained in a eDiscovery search.
-You can collect and purge the following categories of Teams content:\n- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
-Teams 1:1 chats are also called *conversations*.\n- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
-Also called *1:N* chats or *group conversations*.\n- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.\n- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.\n- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
-For more information about purging Teams messages, see:\n- eDiscovery solution series: Data spillage scenario - Search and purge\n- eDiscovery (Premium) workflow for content in Microsoft Teams
+You can collect and purge the following categories of Teams content:
+- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
+Teams 1:1 chats are also called *conversations*.
+- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
+Also called *1:N* chats or *group conversations*.
+- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
+- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.
+- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
+For more information about purging Teams messages, see:
+- eDiscovery solution series: Data spillage scenario - Search and purge
+- eDiscovery (Premium) workflow for content in Microsoft Teams
 
 ## SYNTAX
 
@@ -46,10 +53,17 @@ Clear-MgSecurityCaseEdiscoveryCaseSearchData -InputObject <ISecurityIdentity>
 
 ## DESCRIPTION
 Permanently delete Microsoft Teams messages contained in a eDiscovery search.
-You can collect and purge the following categories of Teams content:\n- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
-Teams 1:1 chats are also called *conversations*.\n- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
-Also called *1:N* chats or *group conversations*.\n- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.\n- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.\n- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
-For more information about purging Teams messages, see:\n- eDiscovery solution series: Data spillage scenario - Search and purge\n- eDiscovery (Premium) workflow for content in Microsoft Teams
+You can collect and purge the following categories of Teams content:
+- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
+Teams 1:1 chats are also called *conversations*.
+- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
+Also called *1:N* chats or *group conversations*.
+- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
+- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.
+- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
+For more information about purging Teams messages, see:
+- eDiscovery solution series: Data spillage scenario - Search and purge
+- eDiscovery (Premium) workflow for content in Microsoft Teams
 
 ## EXAMPLES
 

--- a/src/Security/Security/docs/v1.0-beta/Microsoft.Graph.Security.md
+++ b/src/Security/Security/docs/v1.0-beta/Microsoft.Graph.Security.md
@@ -32,10 +32,17 @@ The location provides a URL that will return a Add to review set operation.
 
 ### [Clear-MgSecurityCaseEdiscoveryCaseSearchData](Clear-MgSecurityCaseEdiscoveryCaseSearchData.md)
 Permanently delete Microsoft Teams messages contained in a eDiscovery search.
-You can collect and purge the following categories of Teams content:\n- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
-Teams 1:1 chats are also called *conversations*.\n- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
-Also called *1:N* chats or *group conversations*.\n- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.\n- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.\n- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
-For more information about purging Teams messages, see:\n- eDiscovery solution series: Data spillage scenario - Search and purge\n- eDiscovery (Premium) workflow for content in Microsoft Teams
+You can collect and purge the following categories of Teams content:
+- **Teams 1:1 chats** - Chat messages, posts, and attachments shared in a Teams conversation between two people.
+Teams 1:1 chats are also called *conversations*.
+- **Teams group chats** - Chat messages, posts, and attachments shared in a Teams conversation between three or more people.
+Also called *1:N* chats or *group conversations*.
+- **Teams channels** - Chat messages, posts, replies, and attachments shared in a standard Teams channel.
+- **Private channels** - Message posts, replies, and attachments shared in a private Teams channel.
+- **Shared channels** - Message posts, replies, and attachments shared in a shared Teams channel.
+For more information about purging Teams messages, see:
+- eDiscovery solution series: Data spillage scenario - Search and purge
+- eDiscovery (Premium) workflow for content in Microsoft Teams
 
 ### [Close-MgSecurityCaseEdiscoveryCase](Close-MgSecurityCaseEdiscoveryCase.md)
 Close an eDiscovery case.

--- a/src/Teams/Teams/docs/v1.0-beta/Copy-MgTeam.md
+++ b/src/Teams/Teams/docs/v1.0-beta/Copy-MgTeam.md
@@ -9,7 +9,8 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a copy of a team.
-This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state \n-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
+This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state 
+-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
 \n(If the person opening the tab does not have permission to configure apps, they will see a message explaining that the tab hasn't been configured.) Cloning is a long-running operation.\nAfter the POST clone returns, you need to GET the operation \nreturned by the Location: header to see if it's 'running' or 'succeeded' or 'failed'.
 \nYou should continue to GET until the status is not 'running'.
 \nThe recommended delay between GETs is 5 seconds.
@@ -46,7 +47,8 @@ Copy-MgTeam -InputObject <ITeamsIdentity> [-AdditionalProperties <Hashtable>] [-
 
 ## DESCRIPTION
 Create a copy of a team.
-This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state \n-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
+This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state 
+-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
 \n(If the person opening the tab does not have permission to configure apps, they will see a message explaining that the tab hasn't been configured.) Cloning is a long-running operation.\nAfter the POST clone returns, you need to GET the operation \nreturned by the Location: header to see if it's 'running' or 'succeeded' or 'failed'.
 \nYou should continue to GET until the status is not 'running'.
 \nThe recommended delay between GETs is 5 seconds.

--- a/src/Teams/Teams/docs/v1.0-beta/Microsoft.Graph.Teams.md
+++ b/src/Teams/Teams/docs/v1.0-beta/Microsoft.Graph.Teams.md
@@ -104,7 +104,8 @@ Confirm a specific timeCard.
 
 ### [Copy-MgTeam](Copy-MgTeam.md)
 Create a copy of a team.
-This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state \n-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
+This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state 
+-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
 \n(If the person opening the tab does not have permission to configure apps, they will see a message explaining that the tab hasn't been configured.) Cloning is a long-running operation.\nAfter the POST clone returns, you need to GET the operation \nreturned by the Location: header to see if it's 'running' or 'succeeded' or 'failed'.
 \nYou should continue to GET until the status is not 'running'.
 \nThe recommended delay between GETs is 5 seconds.
@@ -1599,10 +1600,10 @@ End the open break in a specific timeCard.
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -1610,10 +1611,10 @@ However, you can validate both the mail nickname and the display name and receiv
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 

--- a/src/Teams/Teams/docs/v1.0-beta/Test-MgChatPermissionGrantProperty.md
+++ b/src/Teams/Teams/docs/v1.0-beta/Test-MgChatPermissionGrantProperty.md
@@ -11,10 +11,10 @@ schema: 2.0.0
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
@@ -52,10 +52,10 @@ Test-MgChatPermissionGrantProperty -InputObject <ITeamsIdentity> [-AdditionalPro
 Validate that a Microsoft 365 group's display name or mail nickname complies with naming policies.
 Clients can use this API to determine whether a display name or mail nickname is valid before trying to **create** a Microsoft 365 group.
 For validating properties of an existing group, use the validateProperties function for groups.
-The following validations are performed for the display name and mail nickname properties: \n1.
-Validate the prefix and suffix naming policy\n2.
-Validate the custom banned words policy\n3.
-Validate the mail nickname is unique This API returns with the first failure encountered.
+The following validations are performed for the display name and mail nickname properties: 
+1. Validate the prefix and suffix naming policy
+2. Validate the custom banned words policy
+3. Validate the mail nickname is unique This API returns with the first failure encountered.
 If one or more properties fail multiple validations, only the property with the first validation failure is returned.
 However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 

--- a/src/Teams/Teams/docs/v1.0/Copy-MgTeam.md
+++ b/src/Teams/Teams/docs/v1.0/Copy-MgTeam.md
@@ -9,7 +9,8 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a copy of a team.
-This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state \n-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
+This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state 
+-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
 \n(If the person opening the tab does not have permission to configure apps, they will see a message explaining that the tab hasn't been configured.) Cloning is a long-running operation.\nAfter the POST clone returns, you need to GET the operation to see if it's 'running' or 'succeeded' or 'failed'.
 \nYou should continue to GET until the status is not 'running'.
 \nThe recommended delay between GETs is 5 seconds.
@@ -46,7 +47,8 @@ Copy-MgTeam -InputObject <ITeamsIdentity> [-AdditionalProperties <Hashtable>] [-
 
 ## DESCRIPTION
 Create a copy of a team.
-This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state \n-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
+This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state 
+-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
 \n(If the person opening the tab does not have permission to configure apps, they will see a message explaining that the tab hasn't been configured.) Cloning is a long-running operation.\nAfter the POST clone returns, you need to GET the operation to see if it's 'running' or 'succeeded' or 'failed'.
 \nYou should continue to GET until the status is not 'running'.
 \nThe recommended delay between GETs is 5 seconds.

--- a/src/Teams/Teams/docs/v1.0/Microsoft.Graph.Teams.md
+++ b/src/Teams/Teams/docs/v1.0/Microsoft.Graph.Teams.md
@@ -47,7 +47,8 @@ You can add members to the team after the request returns a successful response.
 
 ### [Copy-MgTeam](Copy-MgTeam.md)
 Create a copy of a team.
-This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state \n-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
+This operation also creates a copy of the corresponding group.\nYou can specify which parts of the team to clone: When tabs are cloned, they are put into an unconfigured state 
+-- they are displayed on the tab bar in Microsoft Teams, and the first time you open them, you'll go through the configuration screen.
 \n(If the person opening the tab does not have permission to configure apps, they will see a message explaining that the tab hasn't been configured.) Cloning is a long-running operation.\nAfter the POST clone returns, you need to GET the operation to see if it's 'running' or 'succeeded' or 'failed'.
 \nYou should continue to GET until the status is not 'running'.
 \nThe recommended delay between GETs is 5 seconds.

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgForwardUserMailFolderChildFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgForwardUserMailFolderChildFolderMessage.md
@@ -9,10 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
@@ -50,10 +54,14 @@ Invoke-MgForwardUserMailFolderChildFolderMessage -InputObject <IUsersActionsIden
 
 ## DESCRIPTION
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgForwardUserMailFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgForwardUserMailFolderMessage.md
@@ -9,10 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
@@ -48,10 +52,14 @@ Invoke-MgForwardUserMailFolderMessage -InputObject <IUsersActionsIdentity> [-Add
 
 ## DESCRIPTION
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgForwardUserMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgForwardUserMessage.md
@@ -9,10 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
@@ -48,10 +52,14 @@ Invoke-MgForwardUserMessage -InputObject <IUsersActionsIdentity> [-AdditionalPro
 
 ## DESCRIPTION
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyAllUserMailFolderChildFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyAllUserMailFolderChildFolderMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message, and send it later.
 
@@ -48,9 +52,13 @@ Invoke-MgReplyAllUserMailFolderChildFolderMessage -InputObject <IUsersActionsIde
 
 ## DESCRIPTION
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyAllUserMailFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyAllUserMailFolderMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message, and send it later.
 
@@ -47,9 +51,13 @@ Invoke-MgReplyAllUserMailFolderMessage -InputObject <IUsersActionsIdentity>
 
 ## DESCRIPTION
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyAllUserMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyAllUserMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message, and send it later.
 
@@ -45,9 +49,13 @@ Invoke-MgReplyAllUserMessage -InputObject <IUsersActionsIdentity> [-AdditionalPr
 
 ## DESCRIPTION
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyUserMailFolderChildFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyUserMailFolderChildFolderMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to a message, and send it later.
 
@@ -48,9 +52,13 @@ Invoke-MgReplyUserMailFolderChildFolderMessage -InputObject <IUsersActionsIdenti
 
 ## DESCRIPTION
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyUserMailFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyUserMailFolderMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to a message, and send it later.
 
@@ -46,9 +50,13 @@ Invoke-MgReplyUserMailFolderMessage -InputObject <IUsersActionsIdentity> [-Addit
 
 ## DESCRIPTION
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyUserMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Invoke-MgReplyUserMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to a message, and send it later.
 
@@ -45,9 +49,13 @@ Invoke-MgReplyUserMessage -InputObject <IUsersActionsIdentity> [-AdditionalPrope
 
 ## DESCRIPTION
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Microsoft.Graph.Users.Actions.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Microsoft.Graph.Users.Actions.md
@@ -418,28 +418,40 @@ This convenience is not available when forwarding from an Outlook.com account.
 
 ### [Invoke-MgForwardUserMailFolderChildFolderMessage](Invoke-MgForwardUserMailFolderChildFolderMessage.md)
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
 ### [Invoke-MgForwardUserMailFolderMessage](Invoke-MgForwardUserMailFolderMessage.md)
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
 ### [Invoke-MgForwardUserMessage](Invoke-MgForwardUserMessage.md)
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
@@ -510,49 +522,73 @@ Invoke action reenable
 
 ### [Invoke-MgReplyAllUserMailFolderChildFolderMessage](Invoke-MgReplyAllUserMailFolderChildFolderMessage.md)
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message, and send it later.
 
 ### [Invoke-MgReplyAllUserMailFolderMessage](Invoke-MgReplyAllUserMailFolderMessage.md)
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message, and send it later.
 
 ### [Invoke-MgReplyAllUserMessage](Invoke-MgReplyAllUserMessage.md)
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message, and send it later.
 
 ### [Invoke-MgReplyUserMailFolderChildFolderMessage](Invoke-MgReplyUserMailFolderChildFolderMessage.md)
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to a message, and send it later.
 
 ### [Invoke-MgReplyUserMailFolderMessage](Invoke-MgReplyUserMailFolderMessage.md)
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to a message, and send it later.
 
 ### [Invoke-MgReplyUserMessage](Invoke-MgReplyUserMessage.md)
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to a message, and send it later.
 
@@ -735,27 +771,42 @@ The following are the steps to attach a file to an Outlook item using an upload 
 
 ### [New-MgUserMailFolderChildFolderMessageForward](New-MgUserMailFolderChildFolderMessageForward.md)
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can: \n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can: 
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
 ### [New-MgUserMailFolderChildFolderMessageReply](New-MgUserMailFolderChildFolderMessageReply.md)
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
 ### [New-MgUserMailFolderChildFolderMessageReplyAll](New-MgUserMailFolderChildFolderMessageReplyAll.md)
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft message later.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft message later.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -771,27 +822,42 @@ The following are the steps to attach a file to an Outlook item using an upload 
 
 ### [New-MgUserMailFolderMessageForward](New-MgUserMailFolderMessageForward.md)
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can: \n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can: 
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
 ### [New-MgUserMailFolderMessageReply](New-MgUserMailFolderMessageReply.md)
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
 ### [New-MgUserMailFolderMessageReplyAll](New-MgUserMailFolderMessageReplyAll.md)
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft message later.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft message later.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -819,27 +885,42 @@ The following are the steps to attach a file to an Outlook item using an upload 
 
 ### [New-MgUserMessageForward](New-MgUserMessageForward.md)
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can: \n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can: 
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
 ### [New-MgUserMessageReply](New-MgUserMessageReply.md)
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
 ### [New-MgUserMessageReplyAll](New-MgUserMessageReplyAll.md)
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft message later.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft message later.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -994,7 +1075,9 @@ For more details about sending notifications and the requirements for doing so, 
 ### [Send-MgUserMail](Send-MgUserMail.md)
 Send the message specified in the request body using either JSON or MIME format.
 When using JSON format you can include an attachment and use a mention to call out another user in the new message.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft message to send later.
 To learn more about the steps involved in the backend before a mail is delivered to recipients, see here.

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderChildFolderMessageForward.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderChildFolderMessageForward.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can: \n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can: 
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
@@ -50,10 +55,15 @@ New-MgUserMailFolderChildFolderMessageForward -InputObject <IUsersActionsIdentit
 
 ## DESCRIPTION
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can: \n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can: 
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderChildFolderMessageReply.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderChildFolderMessageReply.md
@@ -9,9 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
@@ -48,9 +53,14 @@ New-MgUserMailFolderChildFolderMessageReply -InputObject <IUsersActionsIdentity>
 
 ## DESCRIPTION
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderChildFolderMessageReplyAll.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderChildFolderMessageReplyAll.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft message later.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft message later.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -49,10 +54,15 @@ New-MgUserMailFolderChildFolderMessageReplyAll -InputObject <IUsersActionsIdenti
 
 ## DESCRIPTION
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft message later.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft message later.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderMessageForward.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderMessageForward.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can: \n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can: 
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
@@ -48,10 +53,15 @@ New-MgUserMailFolderMessageForward -InputObject <IUsersActionsIdentity> [-Additi
 
 ## DESCRIPTION
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can: \n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can: 
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderMessageReply.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderMessageReply.md
@@ -9,9 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
@@ -46,9 +51,14 @@ New-MgUserMailFolderMessageReply -InputObject <IUsersActionsIdentity> [-Addition
 
 ## DESCRIPTION
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderMessageReplyAll.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMailFolderMessageReplyAll.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft message later.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft message later.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -47,10 +52,15 @@ New-MgUserMailFolderMessageReplyAll -InputObject <IUsersActionsIdentity> [-Addit
 
 ## DESCRIPTION
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft message later.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft message later.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMessageForward.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMessageForward.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can: \n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can: 
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
@@ -48,10 +53,15 @@ New-MgUserMessageForward -InputObject <IUsersActionsIdentity> [-AdditionalProper
 
 ## DESCRIPTION
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can: \n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can: 
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMessageReply.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMessageReply.md
@@ -9,9 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
@@ -45,9 +50,14 @@ New-MgUserMessageReply -InputObject <IUsersActionsIdentity> [-AdditionalProperti
 
 ## DESCRIPTION
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMessageReplyAll.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/New-MgUserMessageReplyAll.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft message later.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft message later.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -46,10 +51,15 @@ New-MgUserMessageReplyAll -InputObject <IUsersActionsIdentity> [-AdditionalPrope
 
 ## DESCRIPTION
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft message later.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft message later.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0-beta/Send-MgUserMail.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0-beta/Send-MgUserMail.md
@@ -10,7 +10,9 @@ schema: 2.0.0
 ## SYNOPSIS
 Send the message specified in the request body using either JSON or MIME format.
 When using JSON format you can include an attachment and use a mention to call out another user in the new message.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft message to send later.
 To learn more about the steps involved in the backend before a mail is delivered to recipients, see here.
@@ -46,7 +48,9 @@ Send-MgUserMail -InputObject <IUsersActionsIdentity> [-AdditionalProperties <Has
 ## DESCRIPTION
 Send the message specified in the request body using either JSON or MIME format.
 When using JSON format you can include an attachment and use a mention to call out another user in the new message.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft message to send later.
 To learn more about the steps involved in the backend before a mail is delivered to recipients, see here.

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgForwardUserMailFolderChildFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgForwardUserMailFolderChildFolderMessage.md
@@ -9,10 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
@@ -50,10 +54,14 @@ Invoke-MgForwardUserMailFolderChildFolderMessage -InputObject <IUsersActionsIden
 
 ## DESCRIPTION
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgForwardUserMailFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgForwardUserMailFolderMessage.md
@@ -9,10 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
@@ -48,10 +52,14 @@ Invoke-MgForwardUserMailFolderMessage -InputObject <IUsersActionsIdentity> [-Add
 
 ## DESCRIPTION
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgForwardUserMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgForwardUserMessage.md
@@ -9,10 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
@@ -48,10 +52,14 @@ Invoke-MgForwardUserMessage -InputObject <IUsersActionsIdentity> [-AdditionalPro
 
 ## DESCRIPTION
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyAllUserMailFolderChildFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyAllUserMailFolderChildFolderMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message and send it later.
 
@@ -48,9 +52,13 @@ Invoke-MgReplyAllUserMailFolderChildFolderMessage -InputObject <IUsersActionsIde
 
 ## DESCRIPTION
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyAllUserMailFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyAllUserMailFolderMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message and send it later.
 
@@ -47,9 +51,13 @@ Invoke-MgReplyAllUserMailFolderMessage -InputObject <IUsersActionsIdentity>
 
 ## DESCRIPTION
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyAllUserMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyAllUserMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message and send it later.
 
@@ -47,9 +51,13 @@ Invoke-MgReplyAllUserMessage -InputObject <IUsersActionsIdentity> [-AdditionalPr
 
 ## DESCRIPTION
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyUserMailFolderChildFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyUserMailFolderChildFolderMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to an existing message and send it later.
 
@@ -48,9 +52,13 @@ Invoke-MgReplyUserMailFolderChildFolderMessage -InputObject <IUsersActionsIdenti
 
 ## DESCRIPTION
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to an existing message and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyUserMailFolderMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyUserMailFolderMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to an existing message and send it later.
 
@@ -47,9 +51,13 @@ Invoke-MgReplyUserMailFolderMessage -InputObject <IUsersActionsIdentity> [-Addit
 
 ## DESCRIPTION
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to an existing message and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyUserMessage.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Invoke-MgReplyUserMessage.md
@@ -9,9 +9,13 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to an existing message and send it later.
 
@@ -47,9 +51,13 @@ Invoke-MgReplyUserMessage -InputObject <IUsersActionsIdentity> [-AdditionalPrope
 
 ## DESCRIPTION
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to an existing message and send it later.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Microsoft.Graph.Users.Actions.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Microsoft.Graph.Users.Actions.md
@@ -259,28 +259,40 @@ This convenience is not available when forwarding from an Outlook.com account.
 
 ### [Invoke-MgForwardUserMailFolderChildFolderMessage](Invoke-MgForwardUserMailFolderChildFolderMessage.md)
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
 ### [Invoke-MgForwardUserMailFolderMessage](Invoke-MgForwardUserMailFolderMessage.md)
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
 ### [Invoke-MgForwardUserMessage](Invoke-MgForwardUserMessage.md)
 Forward a message using either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
 Specifying both or specifying neither will return an HTTP 400 Bad Request error.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to forward a message, and send it later.
 
@@ -324,49 +336,73 @@ Invoke action reauthorize
 
 ### [Invoke-MgReplyAllUserMailFolderChildFolderMessage](Invoke-MgReplyAllUserMailFolderChildFolderMessage.md)
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message and send it later.
 
 ### [Invoke-MgReplyAllUserMailFolderMessage](Invoke-MgReplyAllUserMailFolderMessage.md)
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message and send it later.
 
 ### [Invoke-MgReplyAllUserMessage](Invoke-MgReplyAllUserMessage.md)
 Reply to all recipients of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply-all to a message and send it later.
 
 ### [Invoke-MgReplyUserMailFolderChildFolderMessage](Invoke-MgReplyUserMailFolderChildFolderMessage.md)
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to an existing message and send it later.
 
 ### [Invoke-MgReplyUserMailFolderMessage](Invoke-MgReplyUserMailFolderMessage.md)
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to an existing message and send it later.
 
 ### [Invoke-MgReplyUserMessage](Invoke-MgReplyUserMessage.md)
 Reply to the sender of a message using either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), send the reply to the recipients in **replyTo** and not the recipient in the **from** property.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft to reply to an existing message and send it later.
 
@@ -465,27 +501,42 @@ The following are the steps to attach a file to an Outlook item using an upload 
 
 ### [New-MgUserMailFolderChildFolderMessageForward](New-MgUserMailFolderChildFolderMessageForward.md)
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
 ### [New-MgUserMailFolderChildFolderMessageReply](New-MgUserMailFolderChildFolderMessageReply.md)
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
 ### [New-MgUserMailFolderChildFolderMessageReplyAll](New-MgUserMailFolderChildFolderMessageReplyAll.md)
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -501,27 +552,42 @@ The following are the steps to attach a file to an Outlook item using an upload 
 
 ### [New-MgUserMailFolderMessageForward](New-MgUserMailFolderMessageForward.md)
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
 ### [New-MgUserMailFolderMessageReply](New-MgUserMailFolderMessageReply.md)
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
 ### [New-MgUserMailFolderMessageReplyAll](New-MgUserMailFolderMessageReplyAll.md)
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -540,27 +606,42 @@ The following are the steps to attach a file to an Outlook item using an upload 
 
 ### [New-MgUserMessageForward](New-MgUserMessageForward.md)
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
 ### [New-MgUserMessageReply](New-MgUserMessageReply.md)
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
 ### [New-MgUserMessageReplyAll](New-MgUserMessageReplyAll.md)
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -645,7 +726,9 @@ For more details about sending notifications and the requirements for doing so, 
 ### [Send-MgUserMail](Send-MgUserMail.md)
 Send the message specified in the request body using either JSON or MIME format.
 When using JSON format you can include a file attachment in the same **sendMail** action call.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft message to send later.
 To learn more about the steps involved in the backend before a mail is delivered to recipients, see here.

--- a/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderChildFolderMessageForward.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderChildFolderMessageForward.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
@@ -50,10 +55,15 @@ New-MgUserMailFolderChildFolderMessageForward -InputObject <IUsersActionsIdentit
 
 ## DESCRIPTION
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderChildFolderMessageReply.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderChildFolderMessageReply.md
@@ -9,9 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
@@ -48,9 +53,14 @@ New-MgUserMailFolderChildFolderMessageReply -InputObject <IUsersActionsIdentity>
 
 ## DESCRIPTION
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderChildFolderMessageReplyAll.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderChildFolderMessageReplyAll.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -49,10 +54,15 @@ New-MgUserMailFolderChildFolderMessageReplyAll -InputObject <IUsersActionsIdenti
 
 ## DESCRIPTION
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderMessageForward.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderMessageForward.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
@@ -48,10 +53,15 @@ New-MgUserMailFolderMessageForward -InputObject <IUsersActionsIdentity> [-Additi
 
 ## DESCRIPTION
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderMessageReply.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderMessageReply.md
@@ -9,9 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
@@ -46,9 +51,14 @@ New-MgUserMailFolderMessageReply -InputObject <IUsersActionsIdentity> [-Addition
 
 ## DESCRIPTION
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderMessageReplyAll.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMailFolderMessageReplyAll.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -47,10 +52,15 @@ New-MgUserMailFolderMessageReplyAll -InputObject <IUsersActionsIdentity> [-Addit
 
 ## DESCRIPTION
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMessageForward.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMessageForward.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 
@@ -48,10 +53,15 @@ New-MgUserMessageForward -InputObject <IUsersActionsIdentity> [-AdditionalProper
 
 ## DESCRIPTION
 Create a draft to forward an existing message, in either JSON or MIME format.
-When using JSON format, you can:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
-Specifying both or specifying neither will return an HTTP 400 Bad Request error.\n- Update the draft later to add content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format, you can:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- Specify either the `toRecipients` parameter or the **toRecipients** property of the `message` parameter.
+Specifying both or specifying neither will return an HTTP 400 Bad Request error.
+- Update the draft later to add content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, forward a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMessageReply.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMessageReply.md
@@ -9,9 +9,14 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 
@@ -45,9 +50,14 @@ New-MgUserMessageReply -InputObject <IUsersActionsIdentity> [-AdditionalProperti
 
 ## DESCRIPTION
 Create a draft to reply to the sender of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If **replyTo** is specified in the original message, per Internet Message Format (RFC 2822), you should send the reply to the recipients in **replyTo**, and not the recipients in **from**.
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply to a message in a single operation.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMessageReplyAll.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/New-MgUserMessageReplyAll.md
@@ -9,10 +9,15 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 
@@ -46,10 +51,15 @@ New-MgUserMessageReplyAll -InputObject <IUsersActionsIdentity> [-AdditionalPrope
 
 ## DESCRIPTION
 Create a draft to reply to the sender and all recipients of a message in either JSON or MIME format.
-When using JSON format:\n- Specify either a comment or the **body** property of the `message` parameter.
-Specifying both will return an HTTP 400 Bad Request error.\n- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
-\n- You can update the draft later to add reply content to the **body** or change other message properties.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using JSON format:
+- Specify either a comment or the **body** property of the `message` parameter.
+Specifying both will return an HTTP 400 Bad Request error.
+- If the original message specifies a recipient in the **replyTo** property, per Internet Message Format (RFC 2822), you should send the reply to the recipients in the **replyTo** and **toRecipients** properties, and not the recipients in the **from** and **toRecipients** properties.
+
+- You can update the draft later to add reply content to the **body** or change other message properties.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 Send the draft message in a subsequent operation.
 Alternatively, reply-all to a message in a single action.
 

--- a/src/Users.Actions/Users.Actions/docs/v1.0/Send-MgUserMail.md
+++ b/src/Users.Actions/Users.Actions/docs/v1.0/Send-MgUserMail.md
@@ -10,7 +10,9 @@ schema: 2.0.0
 ## SYNOPSIS
 Send the message specified in the request body using either JSON or MIME format.
 When using JSON format you can include a file attachment in the same **sendMail** action call.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft message to send later.
 To learn more about the steps involved in the backend before a mail is delivered to recipients, see here.
@@ -46,7 +48,9 @@ Send-MgUserMail -InputObject <IUsersActionsIdentity> [-AdditionalProperties <Has
 ## DESCRIPTION
 Send the message specified in the request body using either JSON or MIME format.
 When using JSON format you can include a file attachment in the same **sendMail** action call.
-When using MIME format:\n- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.\n- Add any attachments and S/MIME properties to the MIME content.
+When using MIME format:
+- Provide the applicable Internet message headers and the MIME content, all encoded in **base64** format in the request body.
+- Add any attachments and S/MIME properties to the MIME content.
 This method saves the message in the **Sent Items** folder.
 Alternatively, create a draft message to send later.
 To learn more about the steps involved in the backend before a mail is delivered to recipients, see here.


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Correct `\n` literals in markdown to new line (these look like conversion artifacts; explicit breaks should be `</br>` elements)
- Fix unordered lists following `\n` literals 
- Fix ordered lists following `\n` literals 

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
