### PR TITLE
Adds HelpUri to commands in Authentication module.

### DIFF
--- a/src/Authentication/Authentication/Cmdlets/ConnectMgGraph.cs
+++ b/src/Authentication/Authentication/Cmdlets/ConnectMgGraph.cs
@@ -2,17 +2,6 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Management.Automation;
-using System.Net;
-using System.Security;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Graph.PowerShell.Authentication.Common;
 using Microsoft.Graph.PowerShell.Authentication.Core.Extensions;
 using Microsoft.Graph.PowerShell.Authentication.Core.TokenCache;
@@ -21,12 +10,22 @@ using Microsoft.Graph.PowerShell.Authentication.Helpers;
 using Microsoft.Graph.PowerShell.Authentication.Interfaces;
 using Microsoft.Graph.PowerShell.Authentication.Models;
 using Microsoft.Graph.PowerShell.Authentication.Utilities;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using static Microsoft.Graph.PowerShell.Authentication.Constants;
 using static Microsoft.Graph.PowerShell.Authentication.Helpers.AsyncHelpers;
 
 namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
 {
-    [Cmdlet(VerbsCommunications.Connect, "MgGraph", DefaultParameterSetName = Constants.UserParameterSet)]
+    [Cmdlet(VerbsCommunications.Connect, "MgGraph", DefaultParameterSetName = Constants.UserParameterSet, HelpUri = "https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands#using-connect-mggraph")]
     [Alias("Connect-Graph")]
     public class ConnectMgGraph : PSCmdlet, IModuleAssemblyInitializer, IModuleAssemblyCleanup
     {

--- a/src/Authentication/Authentication/Cmdlets/DisconnectMgGraph.cs
+++ b/src/Authentication/Authentication/Cmdlets/DisconnectMgGraph.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
 {
-    [Cmdlet(VerbsCommunications.Disconnect, "MgGraph")]
+    [Cmdlet(VerbsCommunications.Disconnect, "MgGraph", HelpUri = "https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands#using-disconnect-mggraph")]
     [Alias("Disconnect-Graph")]
     [OutputType(typeof(IAuthContext))]
     public class DisconnectMgGraph : PSCmdlet
@@ -46,7 +46,9 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
             if (GraphSession.Instance.AuthContext is null)
             {
                 WriteError(new ErrorRecord(new ArgumentException("No application to sign out from."), string.Empty, ErrorCategory.CloseError, null));
-            } else {
+            }
+            else
+            {
                 var authContext = await AuthenticationHelpers.LogoutAsync();
                 WriteObject(authContext);
             }

--- a/src/Authentication/Authentication/Cmdlets/Environment/AddMgEnvironment.cs
+++ b/src/Authentication/Authentication/Cmdlets/Environment/AddMgEnvironment.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     /// <summary>
     /// Adds Microsoft Graph environment to the settings file.
     /// </summary>
-    [Cmdlet(VerbsCommon.Add, "MgEnvironment", SupportsShouldProcess = true)]
+    [Cmdlet(VerbsCommon.Add, "MgEnvironment", SupportsShouldProcess = true, HelpUri = "https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands#using-get-mgenvironment")]
     [OutputType(typeof(GraphEnvironment))]
     public class AddMgEnvironment : PSCmdlet
     {

--- a/src/Authentication/Authentication/Cmdlets/Environment/GetMgEnvironment.cs
+++ b/src/Authentication/Authentication/Cmdlets/Environment/GetMgEnvironment.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     /// <summary>
     /// Gets or lists available Microsoft Graph environments to the settings file..
     /// </summary>
-    [Cmdlet(VerbsCommon.Get, "MgEnvironment")]
+    [Cmdlet(VerbsCommon.Get, "MgEnvironment", HelpUri = "https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands#using-get-mgenvironment")]
     [OutputType(typeof(GraphEnvironment))]
     public class GetMgEnvironment : PSCmdlet
     {

--- a/src/Authentication/Authentication/Cmdlets/Environment/RemoveMgEnvironment.cs
+++ b/src/Authentication/Authentication/Cmdlets/Environment/RemoveMgEnvironment.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     /// <summary>
     /// Removes Microsoft Graph environment to the settings file..
     /// </summary>
-    [Cmdlet(VerbsCommon.Remove, "MgEnvironment", SupportsShouldProcess = true)]
+    [Cmdlet(VerbsCommon.Remove, "MgEnvironment", SupportsShouldProcess = true, HelpUri = "https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands#using-get-mgenvironment")]
     [OutputType(typeof(GraphEnvironment))]
     public class RemoveMgEnvironment : PSCmdlet
     {

--- a/src/Authentication/Authentication/Cmdlets/Environment/SetMgEnvironment.cs
+++ b/src/Authentication/Authentication/Cmdlets/Environment/SetMgEnvironment.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
     /// <summary>
     /// Sets a Microsoft Graph environment to the settings file..
     /// </summary>
-    [Cmdlet(VerbsCommon.Set, "MgEnvironment", SupportsShouldProcess = true)]
+    [Cmdlet(VerbsCommon.Set, "MgEnvironment", SupportsShouldProcess = true, HelpUri = "https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands#using-get-mgenvironment")]
     [OutputType(typeof(GraphEnvironment))]
     public class SetMgEnvironment : PSCmdlet
     {

--- a/src/Authentication/Authentication/Cmdlets/GetMGContext.cs
+++ b/src/Authentication/Authentication/Cmdlets/GetMGContext.cs
@@ -6,9 +6,9 @@ using System.Management.Automation;
 
 namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
 {
-    [Cmdlet(VerbsCommon.Get, "MgContext", DefaultParameterSetName = Constants.UserParameterSet)]
+    [Cmdlet(VerbsCommon.Get, "MgContext", DefaultParameterSetName = Constants.UserParameterSet, HelpUri = "https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands#using-get-mgcontext")]
     [OutputType(typeof(IAuthContext))]
-    public class GetMgContext: PSCmdlet
+    public class GetMgContext : PSCmdlet
     {
         protected override void BeginProcessing()
         {

--- a/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
@@ -2,6 +2,13 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
+using Microsoft.Graph.PowerShell.Authentication.Extensions;
+using Microsoft.Graph.PowerShell.Authentication.Helpers;
+using Microsoft.Graph.PowerShell.Authentication.Interfaces;
+using Microsoft.Graph.PowerShell.Authentication.Models;
+using Microsoft.Graph.PowerShell.Authentication.Properties;
+using Microsoft.PowerShell.Commands;
+using Newtonsoft.Json;
 using System;
 using System.Collections;
 using System.Globalization;
@@ -13,19 +20,12 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Graph.PowerShell.Authentication.Extensions;
-using Microsoft.Graph.PowerShell.Authentication.Helpers;
-using Microsoft.Graph.PowerShell.Authentication.Interfaces;
-using Microsoft.Graph.PowerShell.Authentication.Models;
-using Microsoft.Graph.PowerShell.Authentication.Properties;
-using Microsoft.PowerShell.Commands;
-using Newtonsoft.Json;
 using static Microsoft.Graph.PowerShell.Authentication.Helpers.AsyncHelpers;
 using DriveNotFoundException = System.Management.Automation.DriveNotFoundException;
 
 namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
 {
-    [Cmdlet(VerbsLifecycle.Invoke, "MgGraphRequest", DefaultParameterSetName = Constants.UserParameterSet)]
+    [Cmdlet(VerbsLifecycle.Invoke, "MgGraphRequest", DefaultParameterSetName = Constants.UserParameterSet, HelpUri = "https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands#using-invoke-mggraphrequest")]
     [Alias("Invoke-GraphRequest", "Invoke-MgRestMethod")]
     public class InvokeMgGraphRequest : PSCmdlet
     {

--- a/src/Authentication/Authentication/custom/Find-MgGraphCommand.ps1
+++ b/src/Authentication/Authentication/custom/Find-MgGraphCommand.ps1
@@ -6,16 +6,22 @@ Set-StrictMode -Version 2
 <#
 .Synopsis
 Find Microsoft Graph PowerShell command meta-info by URI or command name.
+
 .Description
 The Find-MgGraphCommand command retrieves meta-info about Microsoft Graph PowerShell commands by URI or command name.
+
 .PARAMETER Uri
 The API path a command calls. e.g., /users.
+
 .PARAMETER Method
 The HTTP method a command makes.
+
 .PARAMETER ApiVersion
 The service API version.
+
 .PARAMETER Command
 The name of a command. e.g., Get-MgUser.
+
 .Example
 PS C:\> Find-MgGraphCommand -Uri "/users/{id}"
 
@@ -36,6 +42,7 @@ Remove-MgUser Users  DELETE /users/{user-id}                     {DeviceManageme
 Update-MgUser Users  PATCH  /users/{user-id}                     {DeviceManagementApps.ReadWrite.All DeviceManagementMana…
 
 This example finds all commands that call the provided Microsoft Graph URI.
+
 .Example
 PS C:\> Find-MgGraphCommand -Command Send-MgUserMessage -ApiVersion beta
 
@@ -46,8 +53,10 @@ Command            Module        Method URI                                     
 Send-MgUserMessage Users.Actions POST   /users/{user-id}/messages/{message-id}/microsoft.graph.send            {Mail.Send}
 
 This example looks up a command with the provided command name that calls the beta version of the API.
+
 .Inputs
 Pipeline input accepts API URIs as an array of strings.
+
 .Outputs
 Microsoft.Graph.PowerShell.Authentication.Models.IGraphCommand with the following properties:
     1. Command: Name of command.
@@ -57,6 +66,9 @@ Microsoft.Graph.PowerShell.Authentication.Models.IGraphCommand with the followin
     5. OutputType: The return type of a command.
     6. Permissions: Permissions needed to use a command. This field can be empty if the permissions are not yet available in Graph Explorer.
     7. Variants: The parameter sets of a command.
+
+.LINK
+https://learn.microsoft.com/powershell/microsoftgraph/find-mg-graph-command
 #>
 Function Find-MgGraphCommand {
     [CmdletBinding(DefaultParameterSetName = 'FindByUri', PositionalBinding = $false)]

--- a/src/Authentication/Authentication/custom/Find-MgGraphPermission.ps1
+++ b/src/Authentication/Authentication/custom/Find-MgGraphPermission.ps1
@@ -165,7 +165,10 @@ result is piped to the Format-List command so that the output of the Description
 in the default table view.
 
 .LINK
-https://docs.microsoft.com/en-us/graph/permissions-reference
+https://learn.microsoft.com/powershell/microsoftgraph/find-mg-graph-permission
+
+.LINK
+https://docs.microsoft.com/graph/permissions-reference
 #>
 function Find-MgGraphPermission {
     [cmdletbinding(positionalbinding=$false)]

--- a/src/Authentication/Authentication/custom/ParameterCompleters.ps1
+++ b/src/Authentication/Authentication/custom/ParameterCompleters.ps1
@@ -38,5 +38,4 @@ $environmentParameterBlock = {
 
 Register-ArgumentCompleter -CommandName Connect-MgGraph -ParameterName Scopes -ScriptBlock $scopesParameterBlock
 Register-ArgumentCompleter -CommandName Connect-MgGraph -ParameterName Environment -ScriptBlock $environmentParameterBlock
-
 Register-ArgumentCompleter -CommandName Get-MgEnvironment -ParameterName Name -ScriptBlock $environmentParameterBlock


### PR DESCRIPTION
This PR closes #1413 by adding `HelpUri` to commands in Authentication module. This should allow customers to open online command reference for commands in Authentication module. e.g., `Get-Help Connect-MgGraph -Online`.