### PR TITLE
Fix bad https link

### DIFF
--- a/src/Identity.SignIns/Identity.SignIns/readme.md
+++ b/src/Identity.SignIns/Identity.SignIns/readme.md
@@ -73,5 +73,5 @@ directive:
 
 ``` yaml
 module-version: 1.20.0
-release-notes: See https://aka.ms/GraphPowerShell-Release.
+release-notes: See https://aka.ms/GraphPowerShell-Release
 ```


### PR DESCRIPTION
I'm not sure if this markdown is auto-generated, if so, this should be fixed at the source.
As-is, this link is clickable in the github rendered UI, except that github "helpfully" assumes that the period is part of the link.
Since this isn't really a sentence, I don't think the punctuation is helping anyone -- so I'm proposing that you remove it.