### PR TITLE
Switch to UTF8 as the default encoding for `Invoke-MgGraphRequest`.

### DIFF
--- a/src/Authentication/Authentication/Helpers/ContentHelper.cs
+++ b/src/Authentication/Authentication/Helpers/ContentHelper.cs
@@ -2,25 +2,16 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
+using Microsoft.Graph.PowerShell.Authentication.Models;
+using Microsoft.Win32;
 using System;
 using System.Globalization;
 using System.Net.Http;
-using System.Text;
-
-using Microsoft.Graph.PowerShell.Authentication.Models;
-using Microsoft.Win32;
 
 namespace Microsoft.Graph.PowerShell.Authentication.Helpers
 {
     internal static class ContentHelper
     {
-        #region Constants
-
-        // default codepage encoding for web content.  See RFC 2616.
-        private const string DefaultCodePage = "ISO-8859-1";
-
-        #endregion Constants
-
         #region Fields
         internal static RestReturnType CheckReturnType(this HttpResponseMessage response)
         {
@@ -102,29 +93,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
             }
             // ContentType may not exist in response header.  Return null if not.
             return response.Content.Headers.ContentType?.MediaType;
-        }
-
-        internal static Encoding GetDefaultEncoding()
-        {
-            return GetEncodingOrDefault(null);
-        }
-
-        internal static Encoding GetEncodingOrDefault(string characterSet)
-        {
-            // get the name of the codepage to use for response content
-            var codepage = string.IsNullOrEmpty(characterSet) ? DefaultCodePage : characterSet;
-            Encoding encoding;
-            try
-            {
-                encoding = Encoding.GetEncoding(codepage);
-            }
-            catch (ArgumentException)
-            {
-                // 0, default code page
-                encoding = Encoding.GetEncoding(0);
-            }
-
-            return encoding;
         }
 
         internal static bool IsJson(string contentType)

--- a/src/Authentication/Authentication/Helpers/CustomAsyncCommandRuntime.cs
+++ b/src/Authentication/Authentication/Helpers/CustomAsyncCommandRuntime.cs
@@ -754,7 +754,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         private void WaitForCompletion()
         {
             // wait for the result (or cancellation!)
-            WaitHandle.WaitAny(new[] {CancellationToken.WaitHandle, _completed?.WaitHandle});
+            WaitHandle.WaitAny(new[] { CancellationToken.WaitHandle, _completed?.WaitHandle });
 
             // let go of the semaphore
             _semaphore?.Release();

--- a/src/Authentication/Authentication/Helpers/StreamHelper.cs
+++ b/src/Authentication/Authentication/Helpers/StreamHelper.cs
@@ -2,6 +2,8 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
+using Microsoft.Graph.PowerShell.Authentication.Cmdlets;
+using Microsoft.Graph.PowerShell.Authentication.Properties;
 using System;
 using System.IO;
 using System.Management.Automation;
@@ -9,8 +11,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Graph.PowerShell.Authentication.Cmdlets;
-using Microsoft.Graph.PowerShell.Authentication.Properties;
 
 namespace Microsoft.Graph.PowerShell.Authentication.Helpers
 {
@@ -31,7 +31,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
             if (encoding == null)
             {
                 // just use the default encoding if one wasn't provided
-                encoding = ContentHelper.GetDefaultEncoding();
+                encoding = Encoding.UTF8;
             }
 
             return encoding.GetBytes(str);
@@ -41,33 +41,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
         {
             var responseStream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
             return responseStream;
-        }
-
-        internal static bool TryGetEncoding(this string characterSet, out Encoding encoding)
-        {
-            var result = false;
-            try
-            {
-                encoding = Encoding.GetEncoding(characterSet);
-                result = true;
-            }
-            catch (ArgumentException)
-            {
-                encoding = null;
-            }
-
-            return result;
-        }
-
-        internal static string DecodeStream(this BufferingStreamReader responseStream, ref Encoding encoding)
-        {
-            if (encoding == null)
-            {
-                // Use the default encoding if one wasn't provided
-                encoding = ContentHelper.GetDefaultEncoding();
-            }
-            var content = responseStream.StreamToString(encoding);
-            return content;
         }
 
         internal static string StreamToString(this Stream stream, Encoding encoding)

--- a/src/Authentication/Authentication/Helpers/StringUtil.cs
+++ b/src/Authentication/Authentication/Helpers/StringUtil.cs
@@ -2,6 +2,9 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
+using Microsoft.Graph.PowerShell.Authentication.Properties;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -11,11 +14,6 @@ using System.Management.Automation;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
-
-using Microsoft.Graph.PowerShell.Authentication.Properties;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Graph.PowerShell.Authentication.Helpers
 {


### PR DESCRIPTION
Fixes #1757 by applying changes made in #1764.

The fix will go as part of next week's release.