### PR TITLE
Updated script to log missing external dos url and added optional nam…

### DIFF
--- a/tools/ExamplesGenerator.ps1
+++ b/tools/ExamplesGenerator.ps1
@@ -6,17 +6,36 @@ Param(
 )
 function Start-Generator {
     Param(
-        $ModulesToGenerate = @()
+        $ModulesToGenerate = @(),
+        [ValidateNotNullOrEmpty()]
+        [string] $GenerationMode = "auto",
+        [string] $GraphCommand = "GetMg-User",
+        [string] $GraphModule = "Users",
+        [string] $ProfilePath = "v1.0",
+        [string] $ManualExternalDocsUrl = "https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=powershell"
     )
 
     $GraphMapping = @{
         "v1.0" = "examples\v1.0"
         "beta" = "examples\v1.0-beta"
     }
-    $GraphMapping.Keys | ForEach-Object {
-        $graphProfile = $_
-        Get-FilesByProfile -GraphProfile $graphProfile -GraphProfilePath $GraphMapping[$graphProfile] -ModulesToGenerate $ModulesToGenerate 
+    if ($GenerationMode -eq "auto") {
+        $GraphMapping.Keys | ForEach-Object {
+            $graphProfile = $_
+            Get-FilesByProfile -GraphProfile $graphProfile -GraphProfilePath $GraphMapping[$graphProfile] -ModulesToGenerate $ModulesToGenerate 
+        }
     }
+    else {
+          
+        $ProfilePathMapping = "examples\v1.0"
+        if($ProfilePath -eq "beta"){
+            $ProfilePathMapping = "examples\v1.0-beta"
+        }
+        $ModulePath = Join-Path $PSScriptRoot "..\src\$GraphModule\$GraphModule\$ProfilePathMapping"
+        Get-ExternalDocs-Url -ManualExternalDocsUrl $ManualExternalDocsUrl -GenerationMode $GenerationMode -GraphProfilePath $ModulePath -Command $GraphCommand -GraphProfile $ProfilePath -Module -$Module
+            
+    }
+
 }
 function Get-FilesByProfile {
     Param(
@@ -29,15 +48,15 @@ function Get-FilesByProfile {
     )
 
 
-    $ModulesToGenerate | ForEach-Object {
-        $ModuleName = $_
+     $ModulesToGenerate | ForEach-Object {
+         $ModuleName = $_
         $ModulePath = Join-Path $PSScriptRoot "..\src\$ModuleName\$ModuleName\$GraphProfilePath"
         $OpenApiFile = Join-Path $PSScriptRoot "..\openApiDocs\v1.0\$ModuleName.yml"
         #test this path first before proceeding
         if (Test-Path $OpenApiFile) {
-        $yamlContent = Get-Content -Path $OpenApiFile
-        $OpenApiContent = ($yamlContent | ConvertFrom-Yaml)
-        Get-Files -GraphProfile $GraphProfile -GraphProfilePath $modulePath -Module $ModuleName -OpenApiContent $OpenApiContent
+            $yamlContent = Get-Content -Path $OpenApiFile
+            $OpenApiContent = ($yamlContent | ConvertFrom-Yaml)
+            Get-Files -GraphProfile $GraphProfile -GraphProfilePath $modulePath -Module $ModuleName -OpenApiContent $OpenApiContent
         }
     }
 
@@ -59,27 +78,31 @@ function Get-Files {
         if (Test-Path $GraphProfilePath) {
 
             foreach ($File in Get-ChildItem $GraphProfilePath) {
+               
                 #Extract command over here
                 $Command = [System.IO.Path]::GetFileNameWithoutExtension($File)
                 #Check for cmdlet existence from the module manifest file
                 if ($ModuleManifestFileContent | Select-String -pattern $Command) {
                 
-                #Extract URI path
-                $Uripaths = Find-MgGraphCommand -Command $Command
-                $UriPath = $null
-                if ($Uripaths.APIVersion.Contains($GraphProfile)) {
-                    if($Uripaths.Length -gt 1){
-                        $UriPath = $UriPaths.URI[0].ToString() 
-                    }else{
-                        $UriPath = $UriPaths.URI.ToString() 
-                    } 
-                }
+                    #Extract URI path
+                    $Uripaths = Find-MgGraphCommand -Command $Command
+                    $UriPath = $null
+                    if (-not([string]::IsNullOrEmpty($Uripaths))) {
+                        if ($Uripaths.APIVersion.Contains($GraphProfile)) {
+                            if ($Uripaths.Length -gt 1) {
+                                $UriPath = $UriPaths.URI[0].ToString() 
+                            }
+                            else {
+                                $UriPath = $UriPaths.URI.ToString() 
+                            } 
+                        }
                
-                if ($UriPath) {
-                   
-                    Get-ExternalDocs-Url -GraphProfile $GraphProfile -Url -UriPath $UriPath -Command $Command -OpenApiContent $OpenApiContent -GraphProfilePath $GraphProfilePath
+                        if ($UriPath) {
+                            $Method = $UriPaths.Method
+                            Get-ExternalDocs-Url -GraphProfile $GraphProfile -Url -UriPath $UriPath -Command $Command -OpenApiContent $OpenApiContent -GraphProfilePath $GraphProfilePath -Method $Method -Module $Module
+                        }
+                    }
                 }
-             }
 
             }
         }
@@ -98,24 +121,84 @@ function Get-ExternalDocs-Url {
         [ValidateSet("beta", "v1.0")]
         [string] $GraphProfile = "v1.0",
         [string] $UriPath,
+        [string] $Module = "Users",
+        [string] $GenerationMode = "auto",
+        [string] $ManualExternalDocsUrl,
         [ValidateNotNullOrEmpty()]
         [string] $Command = "Get-MgUser",
         [Hashtable] $OpenApiContent,
+        [System.Object] $Method = "GET",
         [string] $GraphProfilePath = (Join-Path $PSScriptRoot "..\src\Users\Users\examples\v1.0")
     )
+    $MissingExternalDocsUrlFolder = Join-Path $PSScriptRoot "..\openApiDocs\MissingExternalDocsUrl\$Module.csv"
+    if ($GenerationMode -eq "manual") {
 
-    if ($UriPath) {
-        if ($openApiContent.openapi && $openApiContent.info.version) {
-            foreach ($path in $openApiContent.paths) {
-                $externalDocUrl = $path[$UriPath].values.externalDocs.url
+        if (-not([string]::IsNullOrEmpty($ManualExternalDocsUrl))) {
+    
+            WebScrapping -GraphProfile $GraphProfile -ExternalDocUrl $ManualExternalDocsUrl -Command $Command -GraphProfilePath $GraphProfilePath
+        }
 
-                if ($externalDocUrl) {
-                    $url = $externalDocUrl.split(" ")
-                    WebScrapping -GraphProfile $GraphProfile -ExternalDocUrl $url[0] -Command $Command -GraphProfilePath $GraphProfilePath
-                }
+    }
+    else {
+        if ($UriPath) {
+            if ($openApiContent.openapi && $openApiContent.info.version) {
+                foreach ($path in $openApiContent.paths) {
+                    $MethodName = $Method | Out-String
+               
+                    $externalDocUrl = $path[$UriPath].get.externalDocs.url
+                    if([string]::IsNullOrEmpty($externalDocUrl)) {
+                       $PathSplit = $UriPath.Split("/")
+                       $PathToAppend = $PathSplit[$PathSplit.Count - 1]
+                       if($PathToAppend.StartsWith("{") -or $PathToAppend.StartsWith("$")){
+                        #skip
+                       }else{
+                       $PathRebuild = "/"+$PathSplit[0]
+                       for($i = 1; $i -lt $PathSplit.Count - 1; $i++){
+                        $PathRebuild += $PathSplit[$i]+"/" 
+                       }
+                       $RebuiltPath =  $PathRebuild + "microsoft.graph." +$PathToAppend
+                       $externalDocUrl = $path[$RebuiltPath].get.externalDocs.url
+                    }
+                    }
+                    if ($MethodName -eq "POST") {
+                        $externalDocUrl = $path[$UriPath].post.externalDocs.url 
+                    }
+                
+                    if ($MethodName -eq "PATCH") {
+                        $externalDocUrl = $path[$UriPath].patch.externalDocs.url 
+                    }
+                
+                    if ($MethodName -eq "DELETE") {
+                        $externalDocUrl = $path[$UriPath].delete.externalDocs.url 
+                    }
+
+                    if ($MethodName -eq "PUT") {
+                        $externalDocUrl = $path[$UriPath].put.externalDocs.url 
+                    }
+                    if (-not([string]::IsNullOrEmpty($externalDocUrl))) {
+                        WebScrapping -GraphProfile $GraphProfile -ExternalDocUrl $externalDocUrl -Command $Command -GraphProfilePath $GraphProfilePath
+                    }
+                    else {
+                        if (-not (Test-Path $MissingExternalDocsUrlFolder)) {
+                            Write-Error "File: $MissingExternalDocsUrlFolder."
+                            #New-Item -Path $MissingExternalDocsUrlFolder -ItemType File
+                            "Graph profile, Graph Module, Command, UriPath, ExternalUrlDoc " | Out-File -FilePath  $MissingExternalDocsUrlFolder -Encoding ASCII
+                        }
+
+                        #Check if module already exists
+                        $File = Get-Content $MissingExternalDocsUrlFolder
+                        $containsWord = $file | % { $_ -match "$GraphProfile, $Module, $Command, $UriPath" }
+                        if ($containsWord -contains $true) {
+                            #Skip adding to csv
+                        }
+                        else {
+                            "$GraphProfile, $Module, $Command, $UriPath" | Out-File -FilePath $MissingExternalDocsUrlFolder -Append -Encoding ASCII
+                        }
+                    }
             
-            }
+                }
 
+            }
         }
     }
 
@@ -195,8 +278,10 @@ function UpdateExampleFile {
     }
 
     $headCount = $HeaderList.Count
+    Write-Host "Header count $headCount"
     $exampleCount = $ExampleList.Count
-        
+    Write-Host "example count $exampleCount"
+    Write-Host "Flag for replacing everything $ReplaceEverything"    
     if ($ReplaceEverything -and $exampleCount -gt 0 -and $headCount -eq $exampleCount) {
         Clear-Content $ExampleFile -Force
         for ($d = 0; $d -lt $headerList.Count; $d++) { 
@@ -254,5 +339,11 @@ if ([string]::IsNullOrEmpty($Exists)) {
      git checkout $ProposedBranch
 }
 
-Start-Generator -ModulesToGenerate $ModulesToGenerate
+Start-Generator -ModulesToGenerate $ModulesToGenerate -GenerationMode "auto"
+
+#Comment the above and uncomment the below start command, if you manually want to manually pass ExternalDocs url.
+#This is for scenarios where the correponding external docs url to the uri path gotten from Find-MgGraph command, is missing on the openapi.yml file for a particular module.
+#Ensure that you pass all correct parameters as oer the already existing example
+
+#Start-Generator -GenerationMode "manual" -ManualExternalDocsUrl "https://docs.microsoft.com/graph/api/serviceprincipal-post-approleassignedto?view=graph-rest-1.0&tabs=http" -GraphCommand "New-MgServicePrincipalAppRoleAssignedTo" -GraphModule "Applications" -Profile "v1.0"
 Write-Host -ForegroundColor Green "-------------Done-------------"

--- a/tools/ExamplesGenerator.ps1
+++ b/tools/ExamplesGenerator.ps1
@@ -9,7 +9,7 @@ function Start-Generator {
         $ModulesToGenerate = @(),
         [ValidateNotNullOrEmpty()]
         [string] $GenerationMode = "auto",
-        [string] $GraphCommand = "GetMg-User",
+        [string] $GraphCommand = "Get-MgUser",
         [string] $GraphModule = "Users",
         [string] $ProfilePath = "v1.0",
         [string] $ManualExternalDocsUrl = "https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=powershell"

--- a/tools/ExamplesGenerator.ps1
+++ b/tools/ExamplesGenerator.ps1
@@ -32,7 +32,7 @@ function Start-Generator {
             $ProfilePathMapping = "examples\v1.0-beta"
         }
         $ModulePath = Join-Path $PSScriptRoot "..\src\$GraphModule\$GraphModule\$ProfilePathMapping"
-        Get-ExternalDocs-Url -ManualExternalDocsUrl $ManualExternalDocsUrl -GenerationMode $GenerationMode -GraphProfilePath $ModulePath -Command $GraphCommand -GraphProfile $ProfilePath -Module -$Module
+        Get-ExternalDocsUrl -ManualExternalDocsUrl $ManualExternalDocsUrl -GenerationMode $GenerationMode -GraphProfilePath $ModulePath -Command $GraphCommand -GraphProfile $ProfilePath -Module -$Module
             
     }
 


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #
Automated update on example files (scrapping examples from api reference docs) is not working for all documented commands because of missing external docs url parameter from open api files. the automation depends on this parameter in order to get examples. We need to have a way of logging such commands for specific troubleshooting.

The figures below show uri paths that have and doesn't have the external docs url parameter respectively.

**Has an external docs url parameter**
<img width="620" alt="image" src="https://user-images.githubusercontent.com/10947120/215411764-d5a74e7e-3f67-4e18-8831-6fbf65611951.png">

**Doesn't have an external docs url parameter**
<img width="557" alt="image" src="https://user-images.githubusercontent.com/10947120/215411931-4073a623-f847-4a1f-aeed-f0dc6176dcfb.png">



<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Update the example generator script to allow logging of commands that miss the external docs url parameter 
- Provide a manual way of executing the script provided that the external docs/api reference url is known
- Append "microsoft.graph" namespace to retry fetching the external docs url for commands that missed the parameter on the first fetch, because there is no way of knowing if a command is an action or function.


