### PR TITLE
Updates `Find-MgGraphPermission` to a local cache when no connection to MS Graph exists

### DIFF
--- a/src/Authentication/Authentication/custom/common/Permissions.ps1
+++ b/src/Authentication/Authentication/custom/common/Permissions.ps1
@@ -21,8 +21,8 @@ function _Permissions_Initialize {
     # This structure models the state of the permissions class
     $permissionsVariable.Value = [PSCustomObject] @{
         msGraphPermissionsRequestUri = "https://graph.microsoft.com/v1.0/servicePrincipals?`$filter=appId eq '$Permissions_msGraphApplicationId'"
-        msGraphServicePrincipal = $null
-        isFromInvokeMgGraphRequest = $false
+        msGraphServicePrincipal      = $null
+        isFromInvokeMgGraphRequest   = $false
     }
 }
 
@@ -40,7 +40,8 @@ function Permissions_GetPermissionsData([bool] $online) {
                 $_permissions.msGraphServicePrincipal = $restResult | Select-Object -ExpandProperty value
                 $_permissions.isFromInvokeMgGraphRequest = $true
             }
-        } catch [System.Management.Automation.ValidationMetadataException], [System.Net.Http.HttpRequestException] {
+        }
+        catch [System.Management.Automation.ValidationMetadataException], [System.Net.Http.HttpRequestException], [Microsoft.Graph.PowerShell.AuthenticationException] {
             if ( $online ) {
                 throw
             }
@@ -58,16 +59,17 @@ function Permissions_GetOauthData( [PSCustomObject] $permissionsData ) {
     foreach ( $oauth2grant in $permissionsData.oauth2PermissionScopes ) {
         $description = If ($oauth2grant.type -eq 'Admin') {
             $oauth2grant.adminConsentDescription
-        } elseif ($oauth2grant.type -eq 'User') {
+        }
+        elseif ($oauth2grant.type -eq 'User') {
             $oauth2grant.userConsentDescription
         }
 
         $entry = [ordered] @{
-            Id = $oauth2grant.id
+            Id             = $oauth2grant.id
             PermissionType = 'Delegated'
-            Consent = $oauth2grant.type
-            Name = $oauth2grant.value
-            Description = $description
+            Consent        = $oauth2grant.type
+            Name           = $oauth2grant.value
+            Description    = $description
         }
 
         $permissions = [PSCustomObject] $entry
@@ -81,16 +83,17 @@ function Permissions_GetAppRolesData( [PSCustomObject] $permissionsData ) {
 
         $consent = if ($appRole.origin -eq 'Application') {
             'Admin'
-        } elseif ($appRole.origin -eq 'Delegated') {
+        }
+        elseif ($appRole.origin -eq 'Delegated') {
             'User'
         }
 
         $entry = [ordered] @{
-            Id = $appRole.id
+            Id             = $appRole.id
             PermissionType = 'Application'
-            Consent = $consent
-            Name = $appRole.value
-            Description = $appRole.description
+            Consent        = $consent
+            Name           = $appRole.value
+            Description    = $appRole.description
         }
 
         $permissions = [PSCustomObject] $entry

--- a/src/Authentication/Authentication/test/Find-MgGraphPermission.Tests.ps1
+++ b/src/Authentication/Authentication/test/Find-MgGraphPermission.Tests.ps1
@@ -9,14 +9,14 @@ Describe "The Find-MgGraphPermission Command" {
         . (Join-Path $PSScriptRoot  .\Find-MgGraphPermissionTestfile.ps1)
     }
 
-    Context "When executing the command with empty service principal results from MS Graph"  {
+    Context "When executing the command with empty service principal results from MS Graph" {
         BeforeAll {
 
             Mock Invoke-MgGraphRequest {
                 [PSCustomObject] @{
                     Value = [PSCustomObject] @{
                         oauth2PermissionScopes = @()
-                        appRoles = @()
+                        appRoles               = @()
                     }
                 }
             }
@@ -33,7 +33,7 @@ Describe "The Find-MgGraphPermission Command" {
     Context "When executing the command using a constrained set of permissions returned by MS Graph and there is a connection" {
         BeforeEach {
             _Permissions_Initialize
-            Mock Invoke-MgGraphRequest {$permissionData}
+            Mock Invoke-MgGraphRequest { $permissionData }
         }
 
         It 'Executes successfully with the All parameter' {
@@ -137,8 +137,8 @@ Describe "The Find-MgGraphPermission Command" {
 
         It "Should return exactly the permission specified" {
             Find-MgGraphPermission Group.read.basic |
-              Select-Object -ExpandProperty Name |
-              Should -Be 'Group.Read.Basic'
+            Select-Object -ExpandProperty Name |
+            Should -Be 'Group.Read.Basic'
         }
 
         It "It allows the PermissionType to be specified when the All parameter is specified and returns the filtered results" {
@@ -227,7 +227,7 @@ Describe "The Find-MgGraphPermission Command" {
         BeforeEach {
             _Permissions_Initialize
             Mock Invoke-MgGraphRequest {
-                Throw [System.Management.Automation.ValidationMetadataException]::new('mock connection error message')
+                Throw [Microsoft.Graph.PowerShell.AuthenticationException]::new('mock connection error message')
             }
         }
 
@@ -280,7 +280,7 @@ Describe "The Find-MgGraphPermission Command" {
             { Find-MgGraphPermission -Online | Out-Null } | Should -Throw 'mock connection error message'
 
             # Restoring the connection that was set to fail in the BeforeEach
-            Mock Invoke-MgGraphRequest{
+            Mock Invoke-MgGraphRequest {
                 $permissionData
             }
 
@@ -303,7 +303,7 @@ Describe "The Find-MgGraphPermission Command" {
             { Find-MgGraphPermission 'ReadWrite' -Online | Out-Null } | Should -Throw 'mock connection error message'
 
             # Restoring the connection that was set to fail in the BeforeEach
-            Mock Invoke-MgGraphRequest{
+            Mock Invoke-MgGraphRequest {
                 $permissionData
             }
 
@@ -325,7 +325,7 @@ Describe "The Find-MgGraphPermission Command" {
             { Find-MgGraphPermission 'Nigeria has the best jollof' -Online | Out-Null } | Should -Throw 'mock connection error message'
 
             # Restoring the connection that was set to fail in the BeforeEach
-            Mock Invoke-MgGraphRequest{
+            Mock Invoke-MgGraphRequest {
                 $permissionData
             }
 
@@ -355,7 +355,7 @@ Describe "The Find-MgGraphPermission Command" {
             { Find-MgGraphPermission -All -Online | Out-Null } | Should -Throw 'mock authentication error message'
 
             # Restoring the connection that was set to fail in the BeforeEach
-            Mock Invoke-MgGraphRequest{
+            Mock Invoke-MgGraphRequest {
                 $permissionData
             }
 
@@ -378,7 +378,7 @@ Describe "The Find-MgGraphPermission Command" {
             { Find-MgGraphPermission 'ReadWrite' -Online | Out-Null } | Should -Throw 'mock authentication error message'
 
             # Restoring the connection that was set to fail in the BeforeEach
-            Mock Invoke-MgGraphRequest{
+            Mock Invoke-MgGraphRequest {
                 $permissionData
             }
 
@@ -401,7 +401,7 @@ Describe "The Find-MgGraphPermission Command" {
             { Find-MgGraphPermission 'Nigeria has the best jollof' -Online | Out-Null } | Should -Throw 'mock authentication error message'
 
             # Restoring the connection that was set to fail in the BeforeEach
-            Mock Invoke-MgGraphRequest{
+            Mock Invoke-MgGraphRequest {
                 $permissionData
             }
 


### PR DESCRIPTION
This PR fixes #1778 by using a local permissions cache when `AuthenticationException` is thrown. In v2, an `AuthenticationException` type will be thrown when executing a command without a connection to MS Graph.