### PR TITLE
Adds support for downloading extensionless files as files

### DIFF
--- a/tools/Custom/PSCmdletExtensions.cs
+++ b/tools/Custom/PSCmdletExtensions.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Graph.PowerShell
 
     internal static class PSCmdletExtensions
     {
+        private static readonly char[] PathSeparators = new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
         /// <summary>
         /// Gets a resolved or unresolved path from PSPath.
         /// </summary>
@@ -121,20 +123,24 @@ namespace Microsoft.Graph.PowerShell
         private static bool IsPathDirectory(string path)
         {
             if (path == null) throw new ArgumentNullException("path");
+            bool isDirectory = false;
             path = path.Trim();
 
             if (Directory.Exists(path))
-                return true;
+                isDirectory = true;
 
             if (File.Exists(path))
-                return false;
+                isDirectory = false;
 
             // If path has a trailing slash then it's a directory.
-            if (new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }.Any(x => path.EndsWith(x.ToString())))
-                return true;
+            if (PathSeparators.Contains(path.Last()))
+                isDirectory = true;
 
-            // If path has an extension then its a file; directory otherwise.
-            return string.IsNullOrWhiteSpace(Path.GetExtension(path));
+            // If path has an extension then its a file.
+            if (Path.HasExtension(path))
+                isDirectory = false;
+
+            return isDirectory;
         }
 
         private static string GetFileName(HttpResponseMessage responseMessage)


### PR DESCRIPTION
This PR fixes #1775 by updating how directories are determined from the provided `-OutFile` parameter.