### PR TITLE
Unescape filter values

### DIFF
--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -633,6 +633,10 @@ directive:
           // Format all Search values by adding quotes around them.
           let searchQueryRegex = /this\.InvocationInformation\.BoundParameters\.ContainsKey\("Search"\)\s*\?\s*Search\s*:\s*null/gm
           $ = $.replace(searchQueryRegex, 'this.FormatSearchValue(this.InvocationInformation.BoundParameters, Search)');
+
+          // Unescape -Filter values before escaping.
+          let filterQueryRegex = /(this\.InvocationInformation\.BoundParameters\.ContainsKey\("Filter"\)\s*\?\s*)(Filter)(\s*:\s*null)/gm
+          $ = $.replace(filterQueryRegex, '$1this.UnescapeString($2)$3');
         }
         return $;
       }

--- a/tools/Custom/PSCmdletExtensions.cs
+++ b/tools/Custom/PSCmdletExtensions.cs
@@ -17,6 +17,24 @@ namespace NamespacePrefixPlaceholder.PowerShell
     internal static class PSCmdletExtensions
     {
         private static readonly char[] PathSeparators = new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        
+        // Converts a string to its unescaped form. The method also replaces '+' with spaces.
+        internal static string UnescapeString(this PSCmdlet cmdlet, string value)
+        {
+            if (value == null)
+                return null;
+
+            try
+            {
+                var unescapedString = Uri.UnescapeDataString(value);
+                return unescapedString.Replace('+', ' ');
+            }
+            catch (UriFormatException ex)
+            {
+                cmdlet.ThrowTerminatingError(new ErrorRecord(ex, string.Empty, ErrorCategory.InvalidArgument, value));
+                return null;
+            }
+        }
 
         /// <summary>
         /// Gets a resolved or unresolved path from PSPath.


### PR DESCRIPTION
This PR fixes #1339 by adding a directive to decode `$filter` values before encoding. This is done to avoid encoding an already encoded `$filter` value.