### PR TITLE
Enable generation of /alerts_v2 commands

### DIFF
--- a/src/Security/Security.md
+++ b/src/Security/Security.md
@@ -18,7 +18,7 @@ require:
 ``` yaml
 directive:
 # Remove invalid paths.
-  - remove-path-by-operation: ^security(_.*Alerts_v2|.cases.ediscoveryCases.noncustodialDataSources_.*DataSource)$
+  - remove-path-by-operation: ^security(.cases.ediscoveryCases.noncustodialDataSources_.*DataSource)$
 # Remove cmdlets
   - where:
       verb: Get|Update


### PR DESCRIPTION
This PR closes #1820 by enabling generation of `/alerts_v2` commands. This was previously hidden as the workload did not document/support the API.