### PR TITLE
Undo read-only nav properties

### DIFF
--- a/openApiDocs/beta/Applications.yml
+++ b/openApiDocs/beta/Applications.yml
@@ -17114,7 +17114,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this application.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             extensionProperties:
@@ -17122,35 +17122,35 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extensionProperty'
               description: 'Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0).'
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
               description: 'Federated identities for applications. Supports $expand and $filter (startsWith, /$count eq 0, /$count ne 0).'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of the application. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             connectorGroup:
               $ref: '#/components/schemas/microsoft.graph.connectorGroup'
             synchronization:
@@ -17177,12 +17177,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.application'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.connector'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryObject:
@@ -17362,13 +17362,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.synchronizationJob:
@@ -17463,7 +17463,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryDefinition:
@@ -17765,31 +17765,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onPremisesAgentGroup'
               description: List of existing onPremisesAgentGroup objects. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onPremisesAgent'
               description: List of existing onPremisesAgent objects. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             connectorGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.connectorGroup'
               description: List of existing connectorGroup objects for applications published through Application Proxy. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             connectors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.connector'
               description: List of existing connector objects for applications published through Application Proxy. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             publishedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.publishedResource'
               description: List of existing publishedResource objects. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onPremisesAgentGroup:
@@ -17811,13 +17811,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onPremisesAgent'
               description: List of onPremisesAgent that are assigned to an onPremisesAgentGroup. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             publishedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.publishedResource'
               description: List of publishedResource that are assigned to an onPremisesAgentGroup. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onPremisesAgent:
@@ -17843,7 +17843,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onPremisesAgentGroup'
               description: List of onPremisesAgentGroups that an onPremisesAgent is assigned to. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publishedResource:
@@ -17867,7 +17867,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onPremisesAgentGroup'
               description: List of onPremisesAgentGroups that a publishedResource is assigned to. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.connector:
@@ -17889,7 +17889,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.connectorGroup'
               description: The connectorGroup that the connector is a member of. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePrincipal:
@@ -18060,100 +18060,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -18172,7 +18172,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.delegatedPermissionClassification:
@@ -18797,7 +18797,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.synchronizationSchedule:

--- a/openApiDocs/beta/Bookings.yml
+++ b/openApiDocs/beta/Bookings.yml
@@ -3904,37 +3904,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingAppointment'
               description: All the appointments of this business. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingAppointment'
               description: The set of appointments of this business in a specified date range. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             customers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingCustomer'
               description: All the customers of this business. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             customQuestions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingCustomQuestion'
               description: All the custom questions of this business. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             services:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingService'
               description: All the services offered by this business. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             staffMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingStaffMember'
               description: All the staff members that provide services in this business. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Represents a Microsot Bookings Business.
@@ -4298,7 +4298,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.businessScenario'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.businessScenario:
@@ -4354,7 +4354,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.businessScenarioTask'
               description: The Planner tasks for the scenario.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.businessScenarioTaskTargetBase:
@@ -4411,7 +4411,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlanConfigurationLocalization'
               description: Localized names for the plan configuration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanConfigurationLocalization:

--- a/openApiDocs/beta/Calendar.yml
+++ b/openApiDocs/beta/Calendar.yml
@@ -109120,31 +109120,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarPermission:
@@ -109299,38 +109299,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attachment:
@@ -109441,7 +109441,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.entity:

--- a/openApiDocs/beta/CloudCommunications.yml
+++ b/openApiDocs/beta/CloudCommunications.yml
@@ -8588,22 +8588,22 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.call'
-              readOnly: true
+              x-ms-navigationProperty: true
             callRecords:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.callRecords.callRecord'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.presence'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callRecords.callRecord:
@@ -8654,7 +8654,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callRecords.session'
               description: 'List of sessions involved in the call. Peer-to-peer calls typically only have one session, whereas group calls typically have at least one session per participant. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callRecords.session:
@@ -8689,7 +8689,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callRecords.segment'
               description: The list of segments involved in the session. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callRecords.segment:
@@ -8806,22 +8806,22 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.audioRoutingGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentSharingSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentSharingSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.commsOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             participants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.participant'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.audioRoutingGroup:
@@ -9317,7 +9317,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -9327,7 +9327,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingAttendanceReport:
@@ -9360,7 +9360,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attendanceRecord:
@@ -9444,7 +9444,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistrationQuestion:
@@ -10226,7 +10226,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:

--- a/openApiDocs/beta/Compliance.yml
+++ b/openApiDocs/beta/Compliance.yml
@@ -7820,7 +7820,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.case'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ediscovery.case:
@@ -7870,31 +7870,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.custodian'
               description: Returns a list of case custodian objects for this case.  Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             legalHolds:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.legalHold'
               description: Returns a list of case legalHold objects for this case.  Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             noncustodialDataSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.noncustodialDataSource'
               description: Returns a list of case noncustodialDataSource objects for this case.  Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.caseOperation'
               description: Returns a list of case operation objects for this case. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             reviewSets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.reviewSet'
               description: Returns a list of reviewSet objects in the case. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               $ref: '#/components/schemas/microsoft.graph.ediscovery.caseSettings'
             sourceCollections:
@@ -7902,13 +7902,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.sourceCollection'
               description: Returns a list of sourceCollection objects associated with this case.
-              readOnly: true
+              x-ms-navigationProperty: true
             tags:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.tag'
               description: Returns a list of tag objects associated to this case.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ediscovery.custodian:
@@ -7935,19 +7935,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.siteSource'
               description: Data source entity for SharePoint sites associated with the custodian.
-              readOnly: true
+              x-ms-navigationProperty: true
             unifiedGroupSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.unifiedGroupSource'
               description: Data source entity for groups associated with the custodian.
-              readOnly: true
+              x-ms-navigationProperty: true
             userSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.userSource'
               description: Data source entity for a the custodian. This is the container for a custodian's mailbox and OneDrive for Business site.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ediscovery.siteSource:
@@ -7989,13 +7989,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -8003,49 +8003,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -8289,7 +8289,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -8297,61 +8297,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -8359,31 +8359,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -8391,25 +8391,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -8421,7 +8421,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -8494,18 +8494,18 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.siteSource'
               description: Data source entity for SharePoint sites associated with the legal hold.
-              readOnly: true
+              x-ms-navigationProperty: true
             unifiedGroupSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.unifiedGroupSource'
-              readOnly: true
+              x-ms-navigationProperty: true
             userSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.userSource'
               description: Data source entity for a the legal hold. This is the container for a mailbox and OneDrive for Business site.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ediscovery.noncustodialDataSource:
@@ -8601,7 +8601,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.reviewSetQuery'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ediscovery.sourceCollection:
@@ -8645,7 +8645,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.dataSource'
               description: Adds an additional source to the sourceCollection.
-              readOnly: true
+              x-ms-navigationProperty: true
             addToReviewSetOperation:
               $ref: '#/components/schemas/microsoft.graph.ediscovery.addToReviewSetOperation'
             custodianSources:
@@ -8653,7 +8653,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.dataSource'
               description: Custodian sources that are included in the sourceCollection.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastEstimateStatisticsOperation:
               $ref: '#/components/schemas/microsoft.graph.ediscovery.estimateStatisticsOperation'
             noncustodialSources:
@@ -8661,7 +8661,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.noncustodialDataSource'
               description: noncustodialDataSource sources that are included in the sourceCollection
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ediscovery.additionalDataOptions:
@@ -8750,7 +8750,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.ediscovery.tag'
               description: Returns the tags that are a child of a tag.
-              readOnly: true
+              x-ms-navigationProperty: true
             parent:
               $ref: '#/components/schemas/microsoft.graph.ediscovery.tag'
           additionalProperties:
@@ -9026,12 +9026,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -9040,7 +9040,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemAnalytics:
@@ -9055,7 +9055,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -9221,25 +9221,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -9265,25 +9265,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -9293,7 +9293,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -9317,17 +9317,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -9335,19 +9335,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -9416,7 +9416,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -9485,13 +9485,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -9505,37 +9505,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ediscovery.sourceType:
@@ -9850,31 +9850,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -10004,38 +10004,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversation:
@@ -10068,7 +10068,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -10113,7 +10113,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.extension:
@@ -10157,7 +10157,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -10247,13 +10247,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -10261,37 +10261,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -10301,7 +10301,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -11065,43 +11065,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -11109,48 +11109,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -11158,56 +11158,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -11215,7 +11215,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -11223,40 +11223,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -11264,48 +11264,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -11320,24 +11320,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -11346,13 +11346,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -11370,7 +11370,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -11432,7 +11432,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -11464,7 +11464,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -11496,7 +11496,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityStat:
@@ -11538,7 +11538,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -11851,12 +11851,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -12034,7 +12034,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -12042,7 +12042,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -12050,25 +12050,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listInfo:
@@ -12106,7 +12106,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -12114,7 +12114,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -12124,7 +12124,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -12356,7 +12356,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -12463,7 +12463,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -12497,7 +12497,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -12505,13 +12505,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -12545,13 +12545,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -12670,13 +12670,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -12700,7 +12700,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -13092,32 +13092,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -13155,7 +13155,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -13163,7 +13163,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamDiscoverySettings:
@@ -13361,25 +13361,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -13488,7 +13488,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -13595,56 +13595,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.MainError:
@@ -13969,7 +13969,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -13985,7 +13985,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -14260,100 +14260,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -14460,7 +14460,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -14486,25 +14486,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -14639,13 +14639,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -14653,7 +14653,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -14667,7 +14667,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -14718,36 +14718,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -14858,31 +14858,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -14896,22 +14896,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -15034,7 +15034,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -15047,7 +15047,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -15094,13 +15094,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -15108,7 +15108,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -15232,7 +15232,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -15595,37 +15595,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -15633,19 +15633,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -15727,19 +15727,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -15856,7 +15856,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -15908,36 +15908,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -15979,115 +15979,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -16139,7 +16139,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -16310,43 +16310,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -16469,7 +16469,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -16479,7 +16479,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -16513,65 +16513,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -16615,7 +16615,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -16623,37 +16623,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -16667,13 +16667,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -16687,7 +16687,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.bitlockerRecoveryKey:
@@ -16950,13 +16950,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -17516,7 +17516,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -17524,25 +17524,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnailSet:
@@ -17741,7 +17741,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -17757,7 +17757,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -18262,7 +18262,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -18553,13 +18553,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharedWithChannelTeamInfo:
@@ -18577,7 +18577,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTab:
@@ -18631,7 +18631,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -19104,13 +19104,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -19581,7 +19581,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -19672,13 +19672,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -19883,19 +19883,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -19927,7 +19927,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -19979,19 +19979,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -20195,7 +20195,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -20271,7 +20271,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -20311,7 +20311,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -20334,7 +20334,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceEnrollmentConfigurationType:
@@ -21728,7 +21728,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -21767,7 +21767,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -22017,7 +22017,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -22276,19 +22276,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -23269,7 +23269,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -23319,7 +23319,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -23701,13 +23701,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.volumeType:
@@ -24015,7 +24015,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -24115,13 +24115,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -24152,19 +24152,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -24172,7 +24172,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -24309,7 +24309,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.relationType:
@@ -25164,7 +25164,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -25210,7 +25210,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -25218,13 +25218,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -25365,7 +25365,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -27542,7 +27542,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -27693,30 +27693,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mediaSourceContentCategory:
@@ -27862,7 +27862,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -28584,13 +28584,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -28822,7 +28822,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -29835,7 +29835,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -31152,7 +31152,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:

--- a/openApiDocs/beta/CrossDeviceExperiences.yml
+++ b/openApiDocs/beta/CrossDeviceExperiences.yml
@@ -2790,7 +2790,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.activityHistoryItem:
@@ -3006,43 +3006,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.command:

--- a/openApiDocs/beta/DeviceManagement.Actions.yml
+++ b/openApiDocs/beta/DeviceManagement.Actions.yml
@@ -13550,7 +13550,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementComplianceActionItem'
               description: The list of scheduled action configurations for this compliance policy. This collection can contain a maximum of 100 elements.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Scheduled Action for Rule
@@ -13611,13 +13611,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationPolicyAssignment'
               description: Policy assignments
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSetting'
               description: Policy settings
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device Management Configuration Policy
@@ -13748,7 +13748,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceActionItem'
               description: The list of scheduled action configurations for this compliance policy. Compliance policy must have one and only one block scheduled action.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Scheduled Action for Rule
@@ -14067,7 +14067,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -14143,7 +14143,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyPresentationValue'
               description: The associated group policy presentation values with the definition value.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The definition value entity stores the value for a single group policy definition.
@@ -14345,25 +14345,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentAssignment'
               description: Collection of assignments
-              readOnly: true
+              x-ms-navigationProperty: true
             categories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentSettingCategory'
               description: Collection of setting categories within the intent
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceSettingStateSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentDeviceSettingStateSummary'
               description: Collection of settings and their states and counts of devices that belong to corresponding state for all settings within the intent
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentDeviceState'
               description: Collection of states of all devices that the intent is applied to
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStateSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentDeviceStateSummary'
             settings:
@@ -14371,13 +14371,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementSettingInstance'
               description: Collection of all settings to be applied
-              readOnly: true
+              x-ms-navigationProperty: true
             userStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentUserState'
               description: Collection of states of all users that the intent is applied to
-              readOnly: true
+              x-ms-navigationProperty: true
             userStateSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentUserStateSummary'
           additionalProperties:
@@ -14656,7 +14656,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementResourceAccessProfileAssignment'
               description: The list of assignments for the device configuration profile.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Base Profile Type for Resource Access
@@ -14710,7 +14710,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationPolicy'
               description: configuration policies referencing the current reusable setting. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Graph model for a reusable setting
@@ -14748,7 +14748,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleScopeTagAutoAssignment'
               description: The list of assignments for this Role Scope Tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Role Scope Tag
@@ -15253,7 +15253,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSettingDefinition'
               description: List of related Setting Definitions. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Setting instance within policy
@@ -15479,19 +15479,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationAssignment'
               description: The list of assignments for the device configuration profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceSettingStateSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.settingStateDeviceSummary'
               description: Device Configuration Setting State Device Summary
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationDeviceStatus'
               description: Device configuration installation status by device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatusOverview:
               $ref: '#/components/schemas/microsoft.graph.deviceConfigurationDeviceOverview'
             groupAssignments:
@@ -15499,13 +15499,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationGroupAssignment'
               description: The list of group assignments for the device configuration profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationUserStatus'
               description: Device configuration installation status by user.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatusOverview:
               $ref: '#/components/schemas/microsoft.graph.deviceConfigurationUserOverview'
           additionalProperties:
@@ -15778,7 +15778,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyPresentation'
               description: The group policy presentations associated with the definition.
-              readOnly: true
+              x-ms-navigationProperty: true
             previousVersionDefinition:
               $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinition'
           additionalProperties:
@@ -15860,7 +15860,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementSettingInstance'
               description: The settings this category contains
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Entity representing an intent setting category
@@ -17493,7 +17493,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyCategory'
               description: The children categories
-              readOnly: true
+              x-ms-navigationProperty: true
             definitionFile:
               $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinitionFile'
             definitions:
@@ -17501,7 +17501,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinition'
               description: The immediate GroupPolicyDefinition children of the category
-              readOnly: true
+              x-ms-navigationProperty: true
             parent:
               $ref: '#/components/schemas/microsoft.graph.groupPolicyCategory'
           additionalProperties:
@@ -17555,7 +17555,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinition'
               description: The group policy definitions associated with the file.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The entity represents an ADMX (Administrative Template) XML file. The ADMX file contains a collection of group policy definitions and their locations by category path. The group policy definition file also contains the languages supported as determined by the language dependent ADML (Administrative Template) language files.
@@ -17626,7 +17626,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementSettingDefinition'
               description: The setting definitions this category contains
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Entity representing a setting category

--- a/openApiDocs/beta/DeviceManagement.Administration.yml
+++ b/openApiDocs/beta/DeviceManagement.Administration.yml
@@ -17264,7 +17264,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyCategory'
               description: The children categories
-              readOnly: true
+              x-ms-navigationProperty: true
             definitionFile:
               $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinitionFile'
             definitions:
@@ -17272,7 +17272,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinition'
               description: The immediate GroupPolicyDefinition children of the category
-              readOnly: true
+              x-ms-navigationProperty: true
             parent:
               $ref: '#/components/schemas/microsoft.graph.groupPolicyCategory'
           additionalProperties:
@@ -17326,7 +17326,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinition'
               description: The group policy definitions associated with the file.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The entity represents an ADMX (Administrative Template) XML file. The ADMX file contains a collection of group policy definitions and their locations by category path. The group policy definition file also contains the languages supported as determined by the language dependent ADML (Administrative Template) language files.
@@ -17392,7 +17392,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyPresentation'
               description: The group policy presentations associated with the definition.
-              readOnly: true
+              x-ms-navigationProperty: true
             previousVersionDefinition:
               $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinition'
           additionalProperties:
@@ -17491,13 +17491,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicySettingMapping'
               description: A list of group policy settings to MDM/Intune mappings.
-              readOnly: true
+              x-ms-navigationProperty: true
             unsupportedGroupPolicyExtensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unsupportedGroupPolicyExtension'
               description: A list of unsupported group policy extensions inside the Group Policy Object.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Group Policy migration report.
@@ -17680,7 +17680,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyOperation'
               description: The list of operations on the uploaded ADMX file.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The entity represents an ADMX (Administrative Template) XML file uploaded by Administrator. The ADMX file contains a collection of group policy definitions and their locations by category path. The group policy definition file also contains the languages supported as determined by the language dependent ADML (Administrative Template) language files.
@@ -17833,7 +17833,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.intuneBrandingProfileAssignment'
               description: The list of group assignments for the branding profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: This entity contains data which is used in customizing the tenant level appearance of the Company Portal applications as well as the end user web portal.
@@ -18086,7 +18086,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleScopeTag'
               description: The set of Role Scope Tags defined on the Role Assignment.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Role Assignment resource. Role assignments tie together a role definition with members and scopes. There can be one or more role assignments per role. This applies to custom and built-in roles.
@@ -18113,7 +18113,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleScopeTagAutoAssignment'
               description: The list of assignments for this Role Scope Tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Role Scope Tag
@@ -18158,7 +18158,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleAssignment'
               description: List of Role assignments for this role definition.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: 'The Role Definition resource. The role definition is the foundation of role based access in Intune. The role combines an Intune resource such as a Mobile App and associated role permissions such as Create or Read for the resource. There are two types of roles, built-in and custom. Built-in roles cannot be modified. Both built-in roles and custom roles must have assignments to be enforced. Create custom roles if you want to define a role that allows any of the available resources and role permissions to be combined into a single role.'
@@ -18291,19 +18291,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditionsAcceptanceStatus'
               description: The list of acceptance statuses for this T&C policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditionsAssignment'
               description: The list of assignments for this T&C policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditionsGroupAssignment'
               description: The list of group assignments for this T&C policy.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A termsAndConditions entity represents the metadata and contents of a given Terms and Conditions (T&C) policy. T&C policies’ contents are presented to users upon their first attempt to enroll into Intune and subsequently upon edits where an administrator has required re-acceptance. They enable administrators to communicate the provisions to which a user must agree in order to have devices enrolled into Intune.
@@ -18432,13 +18432,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcAuditEvent'
               description: Cloud PC audit event.
-              readOnly: true
+              x-ms-navigationProperty: true
             cloudPCs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
               description: Cloud managed virtual desktops.
-              readOnly: true
+              x-ms-navigationProperty: true
             crossCloudGovernmentOrganizationMapping:
               $ref: '#/components/schemas/microsoft.graph.cloudPcCrossCloudGovernmentOrganizationMapping'
             deviceImages:
@@ -18446,25 +18446,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcDeviceImage'
               description: The image resource on Cloud PC.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalPartnerSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcExternalPartnerSetting'
               description: The external partner settings on a Cloud PC.
-              readOnly: true
+              x-ms-navigationProperty: true
             galleryImages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcGalleryImage'
               description: The gallery image resource on Cloud PC.
-              readOnly: true
+              x-ms-navigationProperty: true
             onPremisesConnections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcOnPremisesConnection'
               description: A defined collection of Azure resource information that can be used to establish on-premises network connectivity for Cloud PCs.
-              readOnly: true
+              x-ms-navigationProperty: true
             organizationSettings:
               $ref: '#/components/schemas/microsoft.graph.cloudPcOrganizationSettings'
             provisioningPolicies:
@@ -18472,7 +18472,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcProvisioningPolicy'
               description: Cloud PC provisioning policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             reports:
               $ref: '#/components/schemas/microsoft.graph.cloudPcReports'
             servicePlans:
@@ -18480,30 +18480,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcServicePlan'
               description: Cloud PC service plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedUseServicePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcSharedUseServicePlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             snapshots:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcSnapshot'
               description: Cloud PC snapshots.
-              readOnly: true
+              x-ms-navigationProperty: true
             supportedRegions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcSupportedRegion'
               description: Cloud PC supported regions.
-              readOnly: true
+              x-ms-navigationProperty: true
             userSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcUserSetting'
               description: Cloud PC user settings.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPcAuditEvent:
@@ -18938,7 +18938,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcProvisioningPolicyAssignment'
               description: A defined collection of provisioning policy assignments. Represents the set of Microsoft 365 groups and security groups in Azure AD that have provisioning policy assigned. Returned only on $expand. See an example of getting the assignments relationship.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPcProvisioningPolicyAssignment:
@@ -18962,7 +18962,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcExportJob'
               description: The export jobs created for downloading reports.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPcExportJob:
@@ -19148,7 +19148,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcUserSettingAssignment'
               description: 'Represents the set of Microsoft 365 groups and security groups in Azure Active Directory that have cloudPCUserSetting assigned. Returned only on $expand. For an example, see Get cloudPcUserSettingample.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPcUserSettingAssignment:

--- a/openApiDocs/beta/DeviceManagement.Enrollment.yml
+++ b/openApiDocs/beta/DeviceManagement.Enrollment.yml
@@ -9836,7 +9836,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appleEnrollmentProfileAssignment'
               description: The list of assignments for this profile.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The enrollmentProfile resource represents a collection of configurations which must be provided pre-enrollment to enable enrolling certain devices whose identities have been pre-staged. Pre-staged device identities are assigned to this type of profile to apply the profile's configurations at enrollment of the corresponding device.
@@ -9970,7 +9970,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementAutopilotPolicyStatusDetail'
               description: Policy and application status details for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Represents an Autopilot flow event.
@@ -10103,13 +10103,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentProfile'
               description: The enrollment profiles.
-              readOnly: true
+              x-ms-navigationProperty: true
             importedAppleDeviceIdentities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.importedAppleDeviceIdentity'
               description: The imported Apple device identities.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The depOnboardingSetting represents an instance of the Apple DEP service being onboarded to Intune. The onboarded service instance manages an Apple Token used to synchronize data between Apple and Intune.
@@ -10410,7 +10410,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -10607,13 +10607,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsAutopilotDeviceIdentity'
               description: The list of assigned devices for the profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsAutopilotDeploymentProfileAssignment'
               description: The list of group assignments for the profile.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Windows Autopilot Deployment Profile
@@ -10812,7 +10812,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsFeatureUpdateProfileAssignment'
               description: The list of group assignments of the profile.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Windows Feature Update Profile
@@ -10853,17 +10853,17 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRbacResourceNamespace'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignmentMultiple'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.unifiedRbacResourceNamespace:
@@ -10880,7 +10880,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRbacResourceAction'
               description: Operations that an authorized principal are allowed to perform.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.unifiedRbacResourceAction:
@@ -10973,19 +10973,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appScope'
               description: Read-only collection with details of the app specific scopes when the assignment scopes are app specific. Containment entity. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             directoryScopes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Read-only collection referencing the directory objects that are scope of the assignment. Provided so that callers can get the directory objects using $expand at the same time as getting the role assignment. Read-only.  Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             principals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Read-only collection referencing the assigned principals. Provided so that callers can get the principals using $expand at the same time as getting the role assignment. Read-only.  Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleDefinition:
               $ref: '#/components/schemas/microsoft.graph.unifiedRoleDefinition'
           additionalProperties:
@@ -11065,7 +11065,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleDefinition'
               description: Read-only collection of role definitions that the given role definition inherits from. Only Azure AD built-in roles support this attribute.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.entity:
@@ -11909,57 +11909,57 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRbacResourceNamespace'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignment'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignment'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignmentApprovals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignmentScheduleInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignmentScheduleInstance'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignmentScheduleRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignmentScheduleRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignmentSchedules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignmentSchedule'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleEligibilityScheduleInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleEligibilityScheduleInstance'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleEligibilityScheduleRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleEligibilityScheduleRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleEligibilitySchedules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleEligibilitySchedule'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.unifiedRbacApplication:
@@ -11972,22 +11972,22 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRbacResourceNamespace'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignment'
-              readOnly: true
+              x-ms-navigationProperty: true
             roleDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignment'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.unifiedRolePermission:
@@ -12488,7 +12488,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.unifiedRoleAssignmentScheduleInstance:

--- a/openApiDocs/beta/DeviceManagement.Functions.yml
+++ b/openApiDocs/beta/DeviceManagement.Functions.yml
@@ -3124,7 +3124,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleScopeTagAutoAssignment'
               description: The list of assignments for this Role Scope Tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Role Scope Tag

--- a/openApiDocs/beta/DeviceManagement.yml
+++ b/openApiDocs/beta/DeviceManagement.yml
@@ -45877,19 +45877,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.androidDeviceOwnerEnrollmentProfile'
               description: Android device owner enrollment profile entities.
-              readOnly: true
+              x-ms-navigationProperty: true
             androidForWorkAppConfigurationSchemas:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.androidForWorkAppConfigurationSchema'
               description: Android for Work app configuration schema entities.
-              readOnly: true
+              x-ms-navigationProperty: true
             androidForWorkEnrollmentProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.androidForWorkEnrollmentProfile'
               description: Android for Work enrollment profile entities.
-              readOnly: true
+              x-ms-navigationProperty: true
             androidForWorkSettings:
               $ref: '#/components/schemas/microsoft.graph.androidForWorkSettings'
             androidManagedStoreAccountEnterpriseSettings:
@@ -45899,37 +45899,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.androidManagedStoreAppConfigurationSchema'
               description: Android Enterprise app configuration schema entities.
-              readOnly: true
+              x-ms-navigationProperty: true
             auditEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.auditEvent'
               description: The Audit Events
-              readOnly: true
+              x-ms-navigationProperty: true
             assignmentFilters:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceAndAppManagementAssignmentFilter'
               description: The list of assignment filters
-              readOnly: true
+              x-ms-navigationProperty: true
             chromeOSOnboardingSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chromeOSOnboardingSettings'
               description: Collection of ChromeOSOnboardingSettings settings associated with account.
-              readOnly: true
+              x-ms-navigationProperty: true
             termsAndConditions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditions'
               description: The terms and conditions associated with device management of the company.
-              readOnly: true
+              x-ms-navigationProperty: true
             serviceNowConnections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceNowConnection'
               description: A list of ServiceNowConnections
-              readOnly: true
+              x-ms-navigationProperty: true
             advancedThreatProtectionOnboardingStateSummary:
               $ref: '#/components/schemas/microsoft.graph.advancedThreatProtectionOnboardingStateSummary'
             cartToClassAssociations:
@@ -45937,13 +45937,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cartToClassAssociation'
               description: The Cart To Class Associations.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicy'
               description: The device compliance policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyDeviceStateSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyDeviceStateSummary'
             deviceCompliancePolicySettingStateSummaries:
@@ -45951,13 +45951,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicySettingStateSummary'
               description: The summary states of compliance policy settings for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationConflictSummary:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationConflictSummary'
               description: Summary of policies in conflict state for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationDeviceStateSummaries:
               $ref: '#/components/schemas/microsoft.graph.deviceConfigurationDeviceStateSummary'
             deviceConfigurationRestrictedAppsViolations:
@@ -45965,19 +45965,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.restrictedAppsViolation'
               description: Restricted apps violations for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfiguration'
               description: The device configurations.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationsAllManagedDeviceCertificateStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAllDeviceCertificateState'
               description: Summary of all certificates for all devices.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationUserStateSummaries:
               $ref: '#/components/schemas/microsoft.graph.deviceConfigurationUserStateSummary'
             iosUpdateStatuses:
@@ -45985,25 +45985,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.iosUpdateDeviceStatus'
               description: The IOS software update installation statuses for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             macOSSoftwareUpdateAccountSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.macOSSoftwareUpdateAccountSummary'
               description: The MacOS software update account summaries for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceEncryptionStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceEncryptionState'
               description: Encryption report for devices in this account
-              readOnly: true
+              x-ms-navigationProperty: true
             ndesConnectors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ndesConnector'
               description: The collection of Ndes connectors for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareUpdateStatusSummary:
               $ref: '#/components/schemas/microsoft.graph.softwareUpdateStatusSummary'
             complianceCategories:
@@ -46011,67 +46011,67 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationCategory'
               description: List of all compliance categories
-              readOnly: true
+              x-ms-navigationProperty: true
             compliancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementCompliancePolicy'
               description: List of all compliance policies
-              readOnly: true
+              x-ms-navigationProperty: true
             complianceSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSettingDefinition'
               description: List of all ComplianceSettings
-              readOnly: true
+              x-ms-navigationProperty: true
             configurationCategories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationCategory'
               description: List of all Configuration Categories
-              readOnly: true
+              x-ms-navigationProperty: true
             configurationPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationPolicy'
               description: List of all Configuration policies
-              readOnly: true
+              x-ms-navigationProperty: true
             configurationPolicyTemplates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationPolicyTemplate'
               description: List of all templates
-              readOnly: true
+              x-ms-navigationProperty: true
             configurationSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSettingDefinition'
               description: List of all ConfigurationSettings
-              readOnly: true
+              x-ms-navigationProperty: true
             reusablePolicySettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementReusablePolicySetting'
               description: List of all reusable settings that can be referred in a policy
-              readOnly: true
+              x-ms-navigationProperty: true
             reusableSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSettingDefinition'
               description: List of all reusable settings
-              readOnly: true
+              x-ms-navigationProperty: true
             templateSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSettingTemplate'
               description: List of all TemplateSettings
-              readOnly: true
+              x-ms-navigationProperty: true
             complianceManagementPartners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.complianceManagementPartner'
               description: The list of Compliance Management Partners configured by the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             conditionalAccessSettings:
               $ref: '#/components/schemas/microsoft.graph.onPremisesConditionalAccessSettings'
             deviceCategories:
@@ -46079,31 +46079,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCategory'
               description: The list of device categories with the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceEnrollmentConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: The list of device enrollment configurations
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementPartners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementPartner'
               description: The list of Device Management Partners configured by the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             exchangeConnectors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementExchangeConnector'
               description: The list of Exchange Connectors configured by the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             exchangeOnPremisesPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementExchangeOnPremisesPolicy'
               description: The list of Exchange On Premisis policies configured by the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             exchangeOnPremisesPolicy:
               $ref: '#/components/schemas/microsoft.graph.deviceManagementExchangeOnPremisesPolicy'
             mobileThreatDefenseConnectors:
@@ -46111,31 +46111,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileThreatDefenseConnector'
               description: The list of Mobile threat Defense connectors configured by the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             categories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementSettingCategory'
               description: The available categories
-              readOnly: true
+              x-ms-navigationProperty: true
             intents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntent'
               description: The device management intents
-              readOnly: true
+              x-ms-navigationProperty: true
             settingDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementSettingDefinition'
               description: The device management intent setting definitions
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTemplate'
               description: The available templates
-              readOnly: true
+              x-ms-navigationProperty: true
             applePushNotificationCertificate:
               $ref: '#/components/schemas/microsoft.graph.applePushNotificationCertificate'
             cloudPCConnectivityIssues:
@@ -46143,61 +46143,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPCConnectivityIssue'
               description: The list of CloudPC Connectivity Issue.
-              readOnly: true
+              x-ms-navigationProperty: true
             comanagedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The list of co-managed devices report
-              readOnly: true
+              x-ms-navigationProperty: true
             comanagementEligibleDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.comanagementEligibleDevice'
               description: The list of co-management eligible devices report
-              readOnly: true
+              x-ms-navigationProperty: true
             dataSharingConsents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataSharingConsent'
               description: Data sharing consents.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: The list of detected apps associated with a device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceComplianceScripts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceScript'
               description: The list of device compliance scripts associated with the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCustomAttributeShellScripts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCustomAttributeShellScript'
               description: The list of device custom attribute shell scripts associated with the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceHealthScripts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScript'
               description: The list of device health scripts associated with the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementScripts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScript'
               description: The list of device management scripts associated with the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceShellScripts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceShellScript'
               description: The list of device shell scripts associated with the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceOverview:
               $ref: '#/components/schemas/microsoft.graph.managedDeviceOverview'
             managedDevices:
@@ -46205,25 +46205,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The list of managed devices.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The collection property of MobileAppTroubleshootingEvent.
-              readOnly: true
+              x-ms-navigationProperty: true
             oemWarrantyInformationOnboarding:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oemWarrantyInformationOnboarding'
               description: List of OEM Warranty Statuses
-              readOnly: true
+              x-ms-navigationProperty: true
             remoteActionAudits:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.remoteActionAudit'
               description: The list of device remote action audits with the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             tenantAttachRBAC:
               $ref: '#/components/schemas/microsoft.graph.tenantAttachRBAC'
             userExperienceAnalyticsAnomaly:
@@ -46231,67 +46231,67 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAnomaly'
               description: The user experience analytics anomaly entity contains anomaly details.
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAnomalyDevice:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAnomalyDevice'
               description: The user experience analytics anomaly entity contains device details.
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAppHealthApplicationPerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAppHealthApplicationPerformance'
               description: User experience analytics appHealth Application Performance
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersion:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersion'
               description: User experience analytics appHealth Application Performance by App Version
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDetails'
               description: User experience analytics appHealth Application Performance by App Version details
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAppHealthApplicationPerformanceByAppVersionDeviceId:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAppHealthAppPerformanceByAppVersionDeviceId'
               description: User experience analytics appHealth Application Performance by App Version Device Id
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAppHealthApplicationPerformanceByOSVersion:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAppHealthAppPerformanceByOSVersion'
               description: User experience analytics appHealth Application Performance by OS Version
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAppHealthDeviceModelPerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAppHealthDeviceModelPerformance'
               description: User experience analytics appHealth Model Performance
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAppHealthDevicePerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAppHealthDevicePerformance'
               description: User experience analytics appHealth Device Performance
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAppHealthDevicePerformanceDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAppHealthDevicePerformanceDetails'
               description: User experience analytics device performance details
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAppHealthOSVersionPerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsAppHealthOSVersionPerformance'
               description: User experience analytics appHealth OS version Performance
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsAppHealthOverview:
               $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsCategory'
             userExperienceAnalyticsBaselines:
@@ -46299,13 +46299,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsBaseline'
               description: User experience analytics baselines
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsBatteryHealthAppImpact:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsBatteryHealthAppImpact'
               description: User Experience Analytics Battery Health App Impact
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsBatteryHealthCapacityDetails:
               $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsBatteryHealthCapacityDetails'
             userExperienceAnalyticsBatteryHealthDeviceAppImpact:
@@ -46313,31 +46313,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsBatteryHealthDeviceAppImpact'
               description: User Experience Analytics Battery Health Device App Impact
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsBatteryHealthDevicePerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsBatteryHealthDevicePerformance'
               description: User Experience Analytics Battery Health Device Performance
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsBatteryHealthDeviceRuntimeHistory:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsBatteryHealthDeviceRuntimeHistory'
               description: User Experience Analytics Battery Health Device Runtime History
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsBatteryHealthModelPerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsBatteryHealthModelPerformance'
               description: User Experience Analytics Battery Health Model Performance
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsBatteryHealthOsPerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsBatteryHealthOsPerformance'
               description: User Experience Analytics Battery Health Os Performance
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsBatteryHealthRuntimeDetails:
               $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsBatteryHealthRuntimeDetails'
             userExperienceAnalyticsCategories:
@@ -46345,19 +46345,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsCategory'
               description: User experience analytics categories
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsDeviceMetricHistory:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsMetricHistory'
               description: User experience analytics device metric history
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsDevicePerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsDevicePerformance'
               description: User experience analytics device performance
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsDeviceScope:
               $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsDeviceScope'
             userExperienceAnalyticsDeviceScopes:
@@ -46365,67 +46365,67 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsDeviceScope'
               description: The user experience analytics device scope entity contains device scope configuration use to apply filtering on the endpoint analytics reports.
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsDeviceScores:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsDeviceScores'
               description: User experience analytics device scores
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsDeviceStartupHistory:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsDeviceStartupHistory'
               description: User experience analytics device Startup History
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsDeviceStartupProcesses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsDeviceStartupProcess'
               description: User experience analytics device Startup Processes
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsDeviceStartupProcessPerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsDeviceStartupProcessPerformance'
               description: User experience analytics device Startup Process Performance
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsDevicesWithoutCloudIdentity:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsDeviceWithoutCloudIdentity'
               description: User experience analytics devices without cloud identity.
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsDeviceTimelineEvent:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsDeviceTimelineEvent'
               description: The user experience analytics device events entity contains NRT device timeline event details.
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsImpactingProcess:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsImpactingProcess'
               description: User experience analytics impacting process
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsMetricHistory:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsMetricHistory'
               description: User experience analytics metric history
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsModelScores:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsModelScores'
               description: User experience analytics model scores
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsNotAutopilotReadyDevice:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsNotAutopilotReadyDevice'
               description: User experience analytics devices not Windows Autopilot ready.
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsOverview:
               $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsOverview'
             userExperienceAnalyticsRemoteConnection:
@@ -46433,19 +46433,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsRemoteConnection'
               description: User experience analytics remote connection
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsResourcePerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsResourcePerformance'
               description: User experience analytics resource performance
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsScoreHistory:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsScoreHistory'
               description: User experience analytics device Startup Score History
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric:
               $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsWorkFromAnywhereHardwareReadinessMetric'
             userExperienceAnalyticsWorkFromAnywhereMetrics:
@@ -46453,67 +46453,67 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsWorkFromAnywhereMetric'
               description: User experience analytics work from anywhere metrics.
-              readOnly: true
+              x-ms-navigationProperty: true
             userExperienceAnalyticsWorkFromAnywhereModelPerformance:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsWorkFromAnywhereModelPerformance'
               description: The user experience analytics work from anywhere model performance
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsMalwareInformation:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsMalwareInformation'
               description: The list of affected malware in the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             derivedCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementDerivedCredentialSettings'
               description: Collection of Derived credential settings associated with account.
-              readOnly: true
+              x-ms-navigationProperty: true
             resourceAccessProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementResourceAccessProfileBase'
               description: Collection of resource access settings associated with account.
-              readOnly: true
+              x-ms-navigationProperty: true
             appleUserInitiatedEnrollmentProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appleUserInitiatedEnrollmentProfile'
               description: Apple user initiated enrollment profiles
-              readOnly: true
+              x-ms-navigationProperty: true
             depOnboardingSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.depOnboardingSetting'
               description: This collections of multiple DEP tokens per-tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             importedDeviceIdentities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.importedDeviceIdentity'
               description: The imported device identities.
-              readOnly: true
+              x-ms-navigationProperty: true
             importedWindowsAutopilotDeviceIdentities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.importedWindowsAutopilotDeviceIdentity'
               description: Collection of imported Windows autopilot devices.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsAutopilotDeploymentProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsAutopilotDeploymentProfile'
               description: Windows auto pilot deployment profiles
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsAutopilotDeviceIdentities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsAutopilotDeviceIdentity'
               description: The Windows autopilot device identities contained collection.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsAutopilotSettings:
               $ref: '#/components/schemas/microsoft.graph.windowsAutopilotSettings'
             zebraFotaArtifacts:
@@ -46521,7 +46521,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.zebraFotaArtifact'
               description: The Collection of ZebraFotaArtifacts.
-              readOnly: true
+              x-ms-navigationProperty: true
             zebraFotaConnector:
               $ref: '#/components/schemas/microsoft.graph.zebraFotaConnector'
             zebraFotaDeployments:
@@ -46529,121 +46529,121 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.zebraFotaDeployment'
               description: Collection of ZebraFotaDeployments associated with account.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupPolicyMigrationReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyMigrationReport'
               description: A list of Group Policy migration reports.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupPolicyObjectFiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyObjectFile'
               description: A list of Group Policy Object files uploaded.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupPolicyCategories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyCategory'
               description: The available group policy categories for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupPolicyConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyConfiguration'
               description: The group policy configurations created by this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupPolicyDefinitionFiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinitionFile'
               description: The available group policy definition files for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupPolicyDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinition'
               description: The available group policy definitions for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupPolicyUploadedDefinitionFiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyUploadedDefinitionFile'
               description: The available group policy uploaded definition files for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftTunnelConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftTunnelConfiguration'
               description: Collection of MicrosoftTunnelConfiguration settings associated with account.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftTunnelHealthThresholds:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftTunnelHealthThreshold'
               description: Collection of MicrosoftTunnelHealthThreshold settings associated with account.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftTunnelServerLogCollectionResponses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftTunnelServerLogCollectionResponse'
               description: Collection of MicrosoftTunnelServerLogCollectionResponse settings associated with account.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftTunnelSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftTunnelSite'
               description: Collection of MicrosoftTunnelSite settings associated with account.
-              readOnly: true
+              x-ms-navigationProperty: true
             notificationMessageTemplates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notificationMessageTemplate'
               description: The Notification Message Templates.
-              readOnly: true
+              x-ms-navigationProperty: true
             domainJoinConnectors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementDomainJoinConnector'
               description: A list of connector objects.
-              readOnly: true
+              x-ms-navigationProperty: true
             configManagerCollections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.configManagerCollection'
               description: A list of ConfigManagerCollection
-              readOnly: true
+              x-ms-navigationProperty: true
             resourceOperations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceOperation'
               description: The Resource Operations.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceAndAppManagementRoleAssignment'
               description: The Role Assignments.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleDefinition'
               description: The Role Definitions.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleScopeTags:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleScopeTag'
               description: The Role Scope Tags.
-              readOnly: true
+              x-ms-navigationProperty: true
             remoteAssistancePartners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.remoteAssistancePartner'
               description: The remote assist partners.
-              readOnly: true
+              x-ms-navigationProperty: true
             remoteAssistanceSettings:
               $ref: '#/components/schemas/microsoft.graph.remoteAssistanceSettings'
             reports:
@@ -46653,79 +46653,79 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.embeddedSIMActivationCodePool'
               description: The embedded SIM activation code pools created by this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             telecomExpenseManagementPartners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.telecomExpenseManagementPartner'
               description: The telecom expense management partners.
-              readOnly: true
+              x-ms-navigationProperty: true
             autopilotEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementAutopilotEvent'
               description: The list of autopilot events for the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             troubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsDriverUpdateProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDriverUpdateProfile'
               description: A collection of windows driver update profiles
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsFeatureUpdateProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsFeatureUpdateProfile'
               description: A collection of windows feature update profiles
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsQualityUpdateProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsQualityUpdateProfile'
               description: A collection of windows quality update profiles
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsUpdateCatalogItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsUpdateCatalogItem'
               description: 'A collection of windows update catalog items (fetaure updates item , quality updates item)'
-              readOnly: true
+              x-ms-navigationProperty: true
             intuneBrandingProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.intuneBrandingProfile'
               description: Intune branding profiles targeted to AAD groups
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionAppLearningSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionAppLearningSummary'
               description: The windows information protection app learning summaries.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionNetworkLearningSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionNetworkLearningSummary'
               description: The windows information protection network learning summaries.
-              readOnly: true
+              x-ms-navigationProperty: true
             certificateConnectorDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.certificateConnectorDetails'
               description: 'Collection of certificate connector details, each associated with a corresponding Intune Certificate Connector.'
-              readOnly: true
+              x-ms-navigationProperty: true
             userPfxCertificates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userPFXCertificate'
               description: Collection of PFX certificates associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Singleton entity that acts as a container for all device management functionality.
@@ -46788,7 +46788,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.advancedThreatProtectionOnboardingDeviceSettingState'
               description: Not yet documented
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Windows defender advanced threat protection onboarding state summary across the account.
@@ -47052,7 +47052,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementSettingDefinition'
               description: The setting definitions this category contains
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Entity representing a setting category
@@ -47468,37 +47468,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -47506,19 +47506,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -47572,7 +47572,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -47876,7 +47876,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -48013,7 +48013,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -48119,19 +48119,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationPolicyAssignment'
               description: Policy assignments
-              readOnly: true
+              x-ms-navigationProperty: true
             scheduledActionsForRule:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementComplianceScheduledActionForRule'
               description: The list of scheduled action for this rule
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSetting'
               description: Policy settings
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device Management Compliance Policy
@@ -48167,7 +48167,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementComplianceActionItem'
               description: The list of scheduled action configurations for this compliance policy. This collection can contain a maximum of 100 elements.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Scheduled Action for Rule
@@ -48211,7 +48211,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSettingDefinition'
               description: List of related Setting Definitions. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Setting instance within policy
@@ -48345,13 +48345,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationPolicyAssignment'
               description: Policy assignments
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSetting'
               description: Policy settings
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device Management Configuration Policy
@@ -48407,7 +48407,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSettingTemplate'
               description: Setting templates
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device Management Configuration Policy Template
@@ -48424,7 +48424,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationSettingDefinition'
               description: List of related Setting Definitions
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Setting Template
@@ -48527,19 +48527,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyAssignment'
               description: The collection of assignments for this compliance policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceSettingStateSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.settingStateDeviceSummary'
               description: Compliance Setting State Device Summary
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceDeviceStatus'
               description: List of DeviceComplianceDeviceStatus.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatusOverview:
               $ref: '#/components/schemas/microsoft.graph.deviceComplianceDeviceOverview'
             scheduledActionsForRule:
@@ -48547,13 +48547,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceScheduledActionForRule'
               description: The list of scheduled action for this rule
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceUserStatus'
               description: List of DeviceComplianceUserStatus.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatusOverview:
               $ref: '#/components/schemas/microsoft.graph.deviceComplianceUserOverview'
           additionalProperties:
@@ -48753,7 +48753,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceActionItem'
               description: The list of scheduled action configurations for this compliance policy. Compliance policy must have one and only one block scheduled action.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Scheduled Action for Rule
@@ -48993,7 +48993,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceSettingState'
               description: Not yet documented
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device Compilance Policy Setting State summary across the account.
@@ -49177,19 +49177,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationAssignment'
               description: The list of assignments for the device configuration profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceSettingStateSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.settingStateDeviceSummary'
               description: Device Configuration Setting State Device Summary
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationDeviceStatus'
               description: Device configuration installation status by device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatusOverview:
               $ref: '#/components/schemas/microsoft.graph.deviceConfigurationDeviceOverview'
             groupAssignments:
@@ -49197,13 +49197,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationGroupAssignment'
               description: The list of group assignments for the device configuration profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationUserStatus'
               description: Device configuration installation status by user.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatusOverview:
               $ref: '#/components/schemas/microsoft.graph.deviceConfigurationUserOverview'
           additionalProperties:
@@ -49564,13 +49564,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptAssignment'
               description: The list of group assignments for the device health script
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceRunStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptDeviceState'
               description: List of run states for the device health script across all devices
-              readOnly: true
+              x-ms-navigationProperty: true
             runSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptRunSummary'
           additionalProperties:
@@ -49778,19 +49778,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptAssignment'
               description: The list of group assignments for the device management script.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceRunStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptDeviceState'
               description: List of run states for this script across all devices.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptGroupAssignment'
               description: The list of group assignments for the device management script.
-              readOnly: true
+              x-ms-navigationProperty: true
             runSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptRunSummary'
             userRunStates:
@@ -49798,7 +49798,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptUserState'
               description: List of run states for this script across all users.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Intune will provide customer the ability to run their Powershell scripts on the enrolled windows 10 Azure Active Directory joined devices. The script can be run once or periodically.
@@ -49918,7 +49918,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptDeviceState'
               description: List of run states for this script across all devices of specific user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Contains properties for user run state of the device management script.
@@ -49984,19 +49984,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptAssignment'
               description: The list of group assignments for the device management script.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceRunStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptDeviceState'
               description: List of run states for this script across all devices.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptGroupAssignment'
               description: The list of group assignments for the device management script.
-              readOnly: true
+              x-ms-navigationProperty: true
             runSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptRunSummary'
             userRunStates:
@@ -50004,7 +50004,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptUserState'
               description: List of run states for this script across all users.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Intune will provide customer the ability to run their Shell scripts on the enrolled Mac OS devices. The script can be run once or periodically.
@@ -50043,13 +50043,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.embeddedSIMActivationCodePoolAssignment'
               description: Navigational property to a list of targets to which this pool is assigned.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.embeddedSIMDeviceState'
               description: Navigational property to a list of device states for this pool.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A pool represents a group of embedded SIM activation codes.
@@ -50143,13 +50143,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyConfigurationAssignment'
               description: The list of group assignments for the configuration.
-              readOnly: true
+              x-ms-navigationProperty: true
             definitionValues:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinitionValue'
               description: The list of enabled or disabled group policy definition values for the configuration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The group policy configuration entity contains the configured values for one or more group policy definitions.
@@ -50197,7 +50197,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyPresentationValue'
               description: The associated group policy presentation values with the definition value.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The definition value entity stores the value for a single group policy definition.
@@ -50263,7 +50263,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyPresentation'
               description: The group policy presentations associated with the definition.
-              readOnly: true
+              x-ms-navigationProperty: true
             previousVersionDefinition:
               $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinition'
           additionalProperties:
@@ -50348,25 +50348,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentAssignment'
               description: Collection of assignments
-              readOnly: true
+              x-ms-navigationProperty: true
             categories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentSettingCategory'
               description: Collection of setting categories within the intent
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceSettingStateSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentDeviceSettingStateSummary'
               description: Collection of settings and their states and counts of devices that belong to corresponding state for all settings within the intent
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentDeviceState'
               description: Collection of states of all devices that the intent is applied to
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStateSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentDeviceStateSummary'
             settings:
@@ -50374,13 +50374,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementSettingInstance'
               description: Collection of all settings to be applied
-              readOnly: true
+              x-ms-navigationProperty: true
             userStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentUserState'
               description: Collection of states of all users that the intent is applied to
-              readOnly: true
+              x-ms-navigationProperty: true
             userStateSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceManagementIntentUserStateSummary'
           additionalProperties:
@@ -50408,7 +50408,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementSettingInstance'
               description: The settings this category contains
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Entity representing an intent setting category
@@ -50680,7 +50680,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.macOSSoftwareUpdateCategorySummary'
               description: Summary of the updates by category.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: MacOS software update account summary report for a device and user
@@ -50731,7 +50731,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.macOSSoftwareUpdateStateSummary'
               description: Summary of the update states.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: MacOS software update category summary report for a device and user
@@ -51056,7 +51056,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftTunnelServer'
               description: A list of MicrosoftTunnelServers that are registered to this MicrosoftTunnelSite
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Entity that represents a Microsoft Tunnel site
@@ -51116,7 +51116,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -51178,7 +51178,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.localizedNotificationMessage'
               description: The list of localized messages for this Notification Message Template.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Notification messages are messages that are sent to end users who are determined to be not-compliant with the compliance policies defined by the administrator. Administrators choose notifications and configure them in the Intune Admin Console using the compliance policy creation page under the “Actions for non-compliance” section. Use the notificationMessageTemplate object to create your own custom notifications for administrators to choose while configuring actions for non-compliance.
@@ -51292,7 +51292,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementResourceAccessProfileAssignment'
               description: The list of assignments for the device configuration profile.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Base Profile Type for Resource Access
@@ -51451,19 +51451,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTemplateSettingCategory'
               description: Collection of setting categories within the template
-              readOnly: true
+              x-ms-navigationProperty: true
             migratableTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTemplate'
               description: Collection of templates this template can migrate to
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementSettingInstance'
               description: Collection of all settings this template has
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Entity that represents a defined collection of device settings
@@ -51478,7 +51478,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementSettingInstance'
               description: The settings this category contains
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Entity representing a template setting category
@@ -52053,7 +52053,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsMetric'
               description: The metric values for the user experience analytics category.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The user experience analytics category entity contains the scores and insights for the various metrics of a category.
@@ -53186,7 +53186,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userExperienceAnalyticsWorkFromAnywhereDevice'
               description: The work from anywhere metric devices.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The user experience analytics metric for work from anywhere report
@@ -53450,7 +53450,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.malwareStateForWindowsDevice'
               description: List of devices affected by current malware with the malware state on each device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Malware information entity.
@@ -53960,13 +53960,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagement.alertRecord'
               description: The collection of records of alert events.
-              readOnly: true
+              x-ms-navigationProperty: true
             alertRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagement.alertRule'
               description: The collection of alert rules.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.virtualEndpoint:
@@ -53980,13 +53980,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcAuditEvent'
               description: Cloud PC audit event.
-              readOnly: true
+              x-ms-navigationProperty: true
             cloudPCs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
               description: Cloud managed virtual desktops.
-              readOnly: true
+              x-ms-navigationProperty: true
             crossCloudGovernmentOrganizationMapping:
               $ref: '#/components/schemas/microsoft.graph.cloudPcCrossCloudGovernmentOrganizationMapping'
             deviceImages:
@@ -53994,25 +53994,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcDeviceImage'
               description: The image resource on Cloud PC.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalPartnerSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcExternalPartnerSetting'
               description: The external partner settings on a Cloud PC.
-              readOnly: true
+              x-ms-navigationProperty: true
             galleryImages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcGalleryImage'
               description: The gallery image resource on Cloud PC.
-              readOnly: true
+              x-ms-navigationProperty: true
             onPremisesConnections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcOnPremisesConnection'
               description: A defined collection of Azure resource information that can be used to establish on-premises network connectivity for Cloud PCs.
-              readOnly: true
+              x-ms-navigationProperty: true
             organizationSettings:
               $ref: '#/components/schemas/microsoft.graph.cloudPcOrganizationSettings'
             provisioningPolicies:
@@ -54020,7 +54020,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcProvisioningPolicy'
               description: Cloud PC provisioning policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             reports:
               $ref: '#/components/schemas/microsoft.graph.cloudPcReports'
             servicePlans:
@@ -54028,30 +54028,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcServicePlan'
               description: Cloud PC service plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedUseServicePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcSharedUseServicePlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             snapshots:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcSnapshot'
               description: Cloud PC snapshots.
-              readOnly: true
+              x-ms-navigationProperty: true
             supportedRegions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcSupportedRegion'
               description: Cloud PC supported regions.
-              readOnly: true
+              x-ms-navigationProperty: true
             userSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcUserSetting'
               description: Cloud PC user settings.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.androidDeviceOwnerEnrollmentProfile:
@@ -54335,19 +54335,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditionsAcceptanceStatus'
               description: The list of acceptance statuses for this T&C policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditionsAssignment'
               description: The list of assignments for this T&C policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditionsGroupAssignment'
               description: The list of group assignments for this T&C policy.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A termsAndConditions entity represents the metadata and contents of a given Terms and Conditions (T&C) policy. T&C policies’ contents are presented to users upon their first attempt to enroll into Intune and subsequently upon edits where an administrator has required re-acceptance. They enable administrators to communicate the provisions to which a user must agree in order to have devices enrolled into Intune.
@@ -54728,7 +54728,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementConfigurationPolicy'
               description: configuration policies referencing the current reusable setting. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Graph model for a reusable setting
@@ -54862,7 +54862,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -55260,13 +55260,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptAssignment'
               description: The list of group assignments for the device compliance script
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceRunStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceScriptDeviceState'
               description: List of run states for the device compliance script across all devices
-              readOnly: true
+              x-ms-navigationProperty: true
             runSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceComplianceScriptRunSummary'
           additionalProperties:
@@ -55326,19 +55326,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptAssignment'
               description: The list of group assignments for the device management script.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceRunStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptDeviceState'
               description: List of run states for this script across all devices.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptGroupAssignment'
               description: The list of group assignments for the device management script.
-              readOnly: true
+              x-ms-navigationProperty: true
             runSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptRunSummary'
             userRunStates:
@@ -55346,7 +55346,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementScriptUserState'
               description: List of run states for this script across all users.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Represents a custom attribute script for macOS.
@@ -55424,7 +55424,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appleEnrollmentProfileAssignment'
               description: The list of assignments for this profile.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The enrollmentProfile resource represents a collection of configurations which must be provided pre-enrollment to enable enrolling certain devices whose identities have been pre-staged. Pre-staged device identities are assigned to this type of profile to apply the profile's configurations at enrollment of the corresponding device.
@@ -55497,13 +55497,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentProfile'
               description: The enrollment profiles.
-              readOnly: true
+              x-ms-navigationProperty: true
             importedAppleDeviceIdentities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.importedAppleDeviceIdentity'
               description: The imported Apple device identities.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The depOnboardingSetting represents an instance of the Apple DEP service being onboarded to Intune. The onboarded service instance manages an Apple Token used to synchronize data between Apple and Intune.
@@ -55640,13 +55640,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsAutopilotDeviceIdentity'
               description: The list of assigned devices for the profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsAutopilotDeploymentProfileAssignment'
               description: The list of group assignments for the profile.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Windows Autopilot Deployment Profile
@@ -55929,13 +55929,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicySettingMapping'
               description: A list of group policy settings to MDM/Intune mappings.
-              readOnly: true
+              x-ms-navigationProperty: true
             unsupportedGroupPolicyExtensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unsupportedGroupPolicyExtension'
               description: A list of unsupported group policy extensions inside the Group Policy Object.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Group Policy migration report.
@@ -56000,7 +56000,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyCategory'
               description: The children categories
-              readOnly: true
+              x-ms-navigationProperty: true
             definitionFile:
               $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinitionFile'
             definitions:
@@ -56008,7 +56008,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinition'
               description: The immediate GroupPolicyDefinition children of the category
-              readOnly: true
+              x-ms-navigationProperty: true
             parent:
               $ref: '#/components/schemas/microsoft.graph.groupPolicyCategory'
           additionalProperties:
@@ -56062,7 +56062,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyDefinition'
               description: The group policy definitions associated with the file.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The entity represents an ADMX (Administrative Template) XML file. The ADMX file contains a collection of group policy definitions and their locations by category path. The group policy definition file also contains the languages supported as determined by the language dependent ADML (Administrative Template) language files.
@@ -56098,7 +56098,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupPolicyOperation'
               description: The list of operations on the uploaded ADMX file.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The entity represents an ADMX (Administrative Template) XML file uploaded by Administrator. The ADMX file contains a collection of group policy definitions and their locations by category path. The group policy definition file also contains the languages supported as determined by the language dependent ADML (Administrative Template) language files.
@@ -56207,7 +56207,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleScopeTag'
               description: The set of Role Scope Tags defined on the Role Assignment.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Role Assignment resource. Role assignments tie together a role definition with members and scopes. There can be one or more role assignments per role. This applies to custom and built-in roles.
@@ -56252,7 +56252,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleAssignment'
               description: List of Role assignments for this role definition.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: 'The Role Definition resource. The role definition is the foundation of role based access in Intune. The role combines an Intune resource such as a Mobile App and associated role permissions such as Create or Read for the resource. There are two types of roles, built-in and custom. Built-in roles cannot be modified. Both built-in roles and custom roles must have assignments to be enforced. Create custom roles if you want to define a role that allows any of the available resources and role permissions to be combined into a single role.'
@@ -56279,7 +56279,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleScopeTagAutoAssignment'
               description: The list of assignments for this Role Scope Tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Role Scope Tag
@@ -56340,13 +56340,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementCachedReportConfiguration'
               description: Entity representing the configuration of a cached report
-              readOnly: true
+              x-ms-navigationProperty: true
             exportJobs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementExportJob'
               description: Entity representing a job to export a report
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Singleton entity that acts as a container for all reports functionality.
@@ -56497,7 +56497,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementAutopilotPolicyStatusDetail'
               description: Policy and application status details for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Represents an Autopilot flow event.
@@ -56559,13 +56559,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDriverUpdateProfileAssignment'
               description: The list of group assignments of the profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             driverInventories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDriverUpdateInventory'
               description: Driver inventories for this profile.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Windows Driver Update Profile
@@ -56618,7 +56618,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsFeatureUpdateProfileAssignment'
               description: The list of group assignments of the profile.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Windows Feature Update Profile
@@ -56666,7 +56666,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsQualityUpdateProfileAssignment'
               description: The list of group assignments of the profile.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Windows Quality Update Profile
@@ -56820,7 +56820,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.intuneBrandingProfileAssignment'
               description: The list of group assignments for the branding profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: This entity contains data which is used in customizing the tenant level appearance of the Company Portal applications as well as the end user web portal.
@@ -58770,43 +58770,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -58814,48 +58814,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -58863,56 +58863,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -58920,7 +58920,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -58928,40 +58928,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -58969,48 +58969,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -59025,24 +59025,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -59051,13 +59051,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -64688,7 +64688,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcProvisioningPolicyAssignment'
               description: A defined collection of provisioning policy assignments. Represents the set of Microsoft 365 groups and security groups in Azure AD that have provisioning policy assigned. Returned only on $expand. See an example of getting the assignments relationship.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPcReports:
@@ -64702,7 +64702,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcExportJob'
               description: The export jobs created for downloading reports.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPcServicePlan:
@@ -64846,7 +64846,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPcUserSettingAssignment'
               description: 'Represents the set of Microsoft 365 groups and security groups in Azure Active Directory that have cloudPCUserSetting assigned. Returned only on $expand. For an example, see Get cloudPcUserSettingample.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.androidDeviceOwnerEnrollmentMode:
@@ -67951,7 +67951,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -67967,7 +67967,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.usageRight:
@@ -67998,12 +67998,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -68012,7 +68012,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePrincipal:
@@ -68183,100 +68183,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -68471,31 +68471,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -68523,7 +68523,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -68653,38 +68653,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -68710,25 +68710,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -68863,13 +68863,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -68877,7 +68877,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -68891,7 +68891,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -69119,7 +69119,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -69127,61 +69127,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -69189,31 +69189,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -69221,25 +69221,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -69251,7 +69251,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -69304,36 +69304,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -69444,31 +69444,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -69482,22 +69482,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -69616,25 +69616,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -69644,7 +69644,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -69676,13 +69676,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -69690,49 +69690,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -69773,7 +69773,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -69786,7 +69786,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -69833,13 +69833,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -69847,7 +69847,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -69998,19 +69998,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -70118,36 +70118,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -70190,37 +70190,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -70255,115 +70255,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -70415,7 +70415,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -70586,43 +70586,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -70745,7 +70745,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -70755,7 +70755,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -70789,65 +70789,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -70891,7 +70891,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -70899,37 +70899,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -70997,13 +70997,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -71011,37 +71011,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -71051,7 +71051,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -71071,13 +71071,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -71091,7 +71091,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.securityBaselinePolicySourceType:
@@ -72751,13 +72751,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -72826,7 +72826,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -72888,7 +72888,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -72920,7 +72920,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -72952,7 +72952,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.passwordSingleSignOnSettings:
@@ -73215,7 +73215,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -73332,13 +73332,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -73931,7 +73931,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -73976,7 +73976,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -74013,7 +74013,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRule:
@@ -74178,19 +74178,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -74222,7 +74222,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -74274,19 +74274,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -74533,7 +74533,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -74541,7 +74541,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -74549,25 +74549,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -74591,17 +74591,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -74609,19 +74609,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deleted:
@@ -74681,7 +74681,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -74847,25 +74847,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -74934,7 +74934,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -75003,13 +75003,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appConsentRequestScope:
@@ -75188,7 +75188,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -75264,7 +75264,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -75304,7 +75304,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -75327,7 +75327,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mobileAppIdentifier:
@@ -75534,7 +75534,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -75542,7 +75542,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -75672,19 +75672,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -75779,13 +75779,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -75904,13 +75904,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -75934,7 +75934,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -76858,7 +76858,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -76908,7 +76908,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -77404,13 +77404,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAsyncOperation:
@@ -77686,25 +77686,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTag:
@@ -77739,7 +77739,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -77846,56 +77846,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -77938,13 +77938,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.ErrorDetails:
@@ -78233,7 +78233,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -78279,7 +78279,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -78287,13 +78287,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -78552,7 +78552,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -78919,32 +78919,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRuleActions:
@@ -79285,7 +79285,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -79293,7 +79293,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -79303,7 +79303,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.audio:
@@ -79802,7 +79802,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -79810,25 +79810,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -79987,7 +79987,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -80300,12 +80300,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -80472,7 +80472,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -80579,7 +80579,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -80613,7 +80613,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -80621,13 +80621,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.request:
@@ -81091,7 +81091,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -81895,7 +81895,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -82009,7 +82009,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -82344,7 +82344,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagType:
@@ -82686,30 +82686,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPcConnectivityEventResult:
@@ -83256,13 +83256,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -83538,7 +83538,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -83885,7 +83885,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -83985,13 +83985,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -84022,19 +84022,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -84042,7 +84042,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -84189,13 +84189,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -84322,7 +84322,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -84338,7 +84338,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -86537,7 +86537,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:
@@ -86931,7 +86931,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -87067,7 +87067,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.relationType:
@@ -87594,7 +87594,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/beta/Devices.CloudPrint.yml
+++ b/openApiDocs/beta/Devices.CloudPrint.yml
@@ -14089,23 +14089,23 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.printConnector'
           description: The list of available print connectors.
-          readOnly: true
+          x-ms-navigationProperty: true
         operations:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printOperation'
-          readOnly: true
+          x-ms-navigationProperty: true
         printers:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printer'
           description: The list of printers registered in the tenant.
-          readOnly: true
+          x-ms-navigationProperty: true
         printerShares:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
         reports:
           $ref: '#/components/schemas/microsoft.graph.reportRoot'
         services:
@@ -14113,18 +14113,18 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.printService'
           description: The list of available Universal Print service endpoints.
-          readOnly: true
+          x-ms-navigationProperty: true
         shares:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
           description: The list of printer shares registered in the tenant.
-          readOnly: true
+          x-ms-navigationProperty: true
         taskDefinitions:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printTaskDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.printConnector:
@@ -14209,7 +14209,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -14217,13 +14217,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerCapabilities:
@@ -14457,13 +14457,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -14496,7 +14496,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printCertificateSigningRequest:
@@ -14522,7 +14522,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.applicationSignInDetailedSummary'
               description: Represents a detailed summary of an application sign-in.
-              readOnly: true
+              x-ms-navigationProperty: true
             authenticationMethods:
               $ref: '#/components/schemas/microsoft.graph.authenticationMethodsRoot'
             credentialUserRegistrationDetails:
@@ -14530,58 +14530,58 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.credentialUserRegistrationDetails'
               description: Details of the usage of self-service password reset and multi-factor authentication (MFA) for all registered users.
-              readOnly: true
+              x-ms-navigationProperty: true
             userCredentialUsageDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userCredentialUsageDetails'
               description: Represents the self-service password reset (SSPR) usage for a given tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             dailyPrintUsage:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsage'
-              readOnly: true
+              x-ms-navigationProperty: true
             dailyPrintUsageByPrinter:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByPrinter'
-              readOnly: true
+              x-ms-navigationProperty: true
             dailyPrintUsageByUser:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByUser'
-              readOnly: true
+              x-ms-navigationProperty: true
             dailyPrintUsageSummariesByPrinter:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByPrinter'
-              readOnly: true
+              x-ms-navigationProperty: true
             dailyPrintUsageSummariesByUser:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByUser'
-              readOnly: true
+              x-ms-navigationProperty: true
             monthlyPrintUsageByPrinter:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByPrinter'
-              readOnly: true
+              x-ms-navigationProperty: true
             monthlyPrintUsageByUser:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByUser'
-              readOnly: true
+              x-ms-navigationProperty: true
             monthlyPrintUsageSummariesByPrinter:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByPrinter'
-              readOnly: true
+              x-ms-navigationProperty: true
             monthlyPrintUsageSummariesByUser:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByUser'
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.securityReportsRoot'
           additionalProperties:
@@ -14624,7 +14624,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userRegistrationDetails'
               description: 'Represents the state of a user''s authentication methods, including which methods are registered and which features the user is registered and capable of (such as multi-factor authentication, self-service password reset, and passwordless authentication).'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userRegistrationFeatureSummary:
@@ -15680,7 +15680,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printServiceEndpoint'
               description: Endpoints that can be used to access the service. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printServiceEndpoint:
@@ -15885,7 +15885,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printColorMode:
@@ -16282,7 +16282,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -16290,61 +16290,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -16352,31 +16352,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -16384,25 +16384,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -16414,7 +16414,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -16774,43 +16774,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -16818,48 +16818,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -16867,56 +16867,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -16924,7 +16924,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -16932,40 +16932,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -16973,48 +16973,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -17029,24 +17029,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -17055,13 +17055,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -17752,13 +17752,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryObject:
@@ -18067,31 +18067,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -18221,38 +18221,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversation:
@@ -18285,7 +18285,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -18330,7 +18330,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -18356,25 +18356,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -18384,7 +18384,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -18416,13 +18416,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -18430,49 +18430,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -18520,7 +18520,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -18534,37 +18534,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -18654,13 +18654,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -18668,37 +18668,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -18708,7 +18708,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -19018,7 +19018,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -19034,7 +19034,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -19153,12 +19153,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -19167,7 +19167,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePrincipal:
@@ -19338,100 +19338,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -19538,7 +19538,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -19564,25 +19564,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -19717,13 +19717,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -19731,7 +19731,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -19745,7 +19745,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -19796,36 +19796,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -19936,31 +19936,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -19974,22 +19974,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -20112,7 +20112,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -20125,7 +20125,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -20172,13 +20172,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -20186,7 +20186,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -20310,7 +20310,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -20673,37 +20673,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -20711,19 +20711,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -20805,19 +20805,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -20934,7 +20934,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -20986,36 +20986,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -21057,115 +21057,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -21217,7 +21217,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -21388,43 +21388,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -21547,7 +21547,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -21557,7 +21557,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -21591,65 +21591,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -21693,7 +21693,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -21701,37 +21701,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -21745,13 +21745,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -21765,7 +21765,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationMethodFeature:
@@ -23238,32 +23238,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.baseItem:
@@ -23485,7 +23485,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -23493,7 +23493,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -23501,25 +23501,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -23543,17 +23543,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -23561,19 +23561,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deleted:
@@ -23633,7 +23633,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -23799,25 +23799,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -23886,7 +23886,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -23955,13 +23955,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -23999,7 +23999,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -24007,7 +24007,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -24041,13 +24041,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -24166,13 +24166,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -24196,7 +24196,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -24398,25 +24398,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -24525,7 +24525,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -24632,56 +24632,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.automaticRepliesSetting:
@@ -24992,7 +24992,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -25054,7 +25054,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -25086,7 +25086,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -25118,7 +25118,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.passwordSingleSignOnSettings:
@@ -25381,7 +25381,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -25472,13 +25472,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -25767,19 +25767,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -25811,7 +25811,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -25863,19 +25863,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -26079,7 +26079,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -26155,7 +26155,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -26195,7 +26195,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -26218,7 +26218,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceEnrollmentConfigurationType:
@@ -27612,7 +27612,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -27651,7 +27651,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -27901,7 +27901,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -28270,19 +28270,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -29263,7 +29263,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -29313,7 +29313,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -29773,13 +29773,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -29862,13 +29862,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.ErrorDetails:
@@ -30284,7 +30284,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -30292,7 +30292,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -30302,7 +30302,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.audio:
@@ -30801,7 +30801,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -30809,25 +30809,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -30986,7 +30986,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -31299,12 +31299,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -31471,7 +31471,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -31578,7 +31578,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -31612,7 +31612,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -31620,13 +31620,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanContainer:
@@ -31692,7 +31692,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -31902,7 +31902,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsApp:
@@ -31926,7 +31926,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -32616,7 +32616,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -34937,7 +34937,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -35288,30 +35288,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attendeeType:
@@ -35609,7 +35609,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -35709,13 +35709,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -35746,19 +35746,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -35766,7 +35766,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -35913,13 +35913,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -36046,7 +36046,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -36062,7 +36062,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -36741,7 +36741,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -37922,7 +37922,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -38058,7 +38058,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.relationType:
@@ -38555,7 +38555,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/beta/Devices.CorporateManagement.yml
+++ b/openApiDocs/beta/Devices.CorporateManagement.yml
@@ -24155,37 +24155,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedEBookCategory'
               description: The mobile eBook categories.
-              readOnly: true
+              x-ms-navigationProperty: true
             enterpriseCodeSigningCertificates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.enterpriseCodeSigningCertificate'
               description: The Windows Enterprise Code Signing Certificate.
-              readOnly: true
+              x-ms-navigationProperty: true
             iosLobAppProvisioningConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.iosLobAppProvisioningConfiguration'
               description: The IOS Lob App Provisioning Configurations.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppCategories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppCategory'
               description: The mobile app categories.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfiguration'
               description: The Managed Device Mobile Application Configurations.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileApp'
               description: The mobile apps.
-              readOnly: true
+              x-ms-navigationProperty: true
             symantecCodeSigningCertificate:
               $ref: '#/components/schemas/microsoft.graph.symantecCodeSigningCertificate'
             managedEBooks:
@@ -24193,19 +24193,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedEBook'
               description: The Managed eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
             policySets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.policySet'
               description: The PolicySet of Policies and Applications
-              readOnly: true
+              x-ms-navigationProperty: true
             vppTokens:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.vppToken'
               description: List of Vpp tokens for this organization.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsManagementApp:
               $ref: '#/components/schemas/microsoft.graph.windowsManagementApp'
             androidManagedAppProtections:
@@ -24213,85 +24213,85 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.androidManagedAppProtection'
               description: Android managed app policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             defaultManagedAppProtections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.defaultManagedAppProtection'
               description: Default managed app policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             iosManagedAppProtections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.iosManagedAppProtection'
               description: iOS managed app policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Managed app policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: The managed app registrations.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppStatus'
               description: The managed app statuses.
-              readOnly: true
+              x-ms-navigationProperty: true
             mdmWindowsInformationProtectionPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mdmWindowsInformationProtectionPolicy'
               description: Windows information protection for apps running on devices which are MDM enrolled.
-              readOnly: true
+              x-ms-navigationProperty: true
             targetedManagedAppConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetedManagedAppConfiguration'
               description: Targeted managed app configurations.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Windows information protection device registrations that are not MDM enrolled.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionPolicy'
               description: Windows information protection for apps running on devices which are not MDM enrolled.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionWipeActions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionWipeAction'
               description: Windows information protection wipe actions.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsManagedAppProtections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsManagedAppProtection'
               description: Windows managed app policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceAppManagementTasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceAppManagementTask'
               description: Device app management tasks.
-              readOnly: true
+              x-ms-navigationProperty: true
             wdacSupplementalPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDefenderApplicationControlSupplementalPolicy'
               description: The collection of Windows Defender Application Control Supplemental Policies.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Singleton entity that acts as a container for all device app management functionality.
@@ -24443,7 +24443,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedMobileApp'
               description: List of apps to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             deploymentSummary:
               $ref: '#/components/schemas/microsoft.graph.managedAppPolicyDeploymentSummary'
           additionalProperties:
@@ -24714,7 +24714,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedMobileApp'
               description: List of apps to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             deploymentSummary:
               $ref: '#/components/schemas/microsoft.graph.managedAppPolicyDeploymentSummary'
           additionalProperties:
@@ -24888,25 +24888,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.iosLobAppProvisioningConfigurationAssignment'
               description: The associated group assignments for IosLobAppProvisioningConfiguration.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationDeviceStatus'
               description: The list of device installation states for this mobile app configuration.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppProvisioningConfigGroupAssignment'
               description: The associated group assignments.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationUserStatus'
               description: The list of user installation states for this mobile app configuration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: 'This topic provides descriptions of the declared methods, properties and relationships exposed by the iOS Lob App Provisioning Configuration resource.'
@@ -25084,7 +25084,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedMobileApp'
               description: List of apps to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             deploymentSummary:
               $ref: '#/components/schemas/microsoft.graph.managedAppPolicyDeploymentSummary'
           additionalProperties:
@@ -25202,19 +25202,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -25326,19 +25326,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedEBookAssignment'
               description: The list of assignments for this eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
             categories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedEBookCategory'
               description: The list of categories for this eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceInstallState'
               description: The list of installation states for this eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
             installSummary:
               $ref: '#/components/schemas/microsoft.graph.eBookInstallSummary'
             userStateSummary:
@@ -25346,7 +25346,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userInstallStateSummary'
               description: The list of installation states for this eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: An abstract class containing the base properties for Managed eBook.
@@ -25481,7 +25481,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceInstallState'
               description: The install state of the eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Contains properties for the installation state summary for a user.
@@ -25557,13 +25557,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationAssignment'
               description: The list of group assignemenets for app configration.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationDeviceStatus'
               description: List of ManagedDeviceMobileAppConfigurationDeviceStatus.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatusSummary:
               $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationDeviceSummary'
             userStatuses:
@@ -25571,7 +25571,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationUserStatus'
               description: List of ManagedDeviceMobileAppConfigurationUserStatus.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatusSummary:
               $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationUserSummary'
           additionalProperties:
@@ -25799,19 +25799,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppAssignment'
               description: The list of group assignments for this mobile app.
-              readOnly: true
+              x-ms-navigationProperty: true
             categories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppCategory'
               description: The list of categories for this app.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppInstallStatus'
               description: The list of installation states for this mobile app.
-              readOnly: true
+              x-ms-navigationProperty: true
             installSummary:
               $ref: '#/components/schemas/microsoft.graph.mobileAppInstallSummary'
             relationships:
@@ -25819,13 +25819,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppRelationship'
               description: List of relationships for this mobile app.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAppInstallStatus'
               description: The list of installation states for this mobile app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: An abstract class containing the base properties for Intune mobile apps.
@@ -26081,7 +26081,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppInstallStatus'
               description: The install state of the app on devices.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Contains properties for the installation status for a user.
@@ -26129,13 +26129,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.policySetAssignment'
               description: Assignments of the PolicySet.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.policySetItem'
               description: Items of the PolicySet with maximum count 100.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A class containing the properties used for PolicySet.
@@ -26264,13 +26264,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedMobileApp'
               description: List of apps to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetedManagedAppPolicyAssignment'
               description: Navigation property to list of inclusion and exclusion groups to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             deploymentSummary:
               $ref: '#/components/schemas/microsoft.graph.managedAppPolicyDeploymentSummary'
           additionalProperties:
@@ -26471,7 +26471,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDefenderApplicationControlSupplementalPolicyAssignment'
               description: The associated group assignments for this WindowsDefenderApplicationControl supplemental policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             deploySummary:
               $ref: '#/components/schemas/microsoft.graph.windowsDefenderApplicationControlSupplementalPolicyDeploymentSummary'
             deviceStatuses:
@@ -26479,7 +26479,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDefenderApplicationControlSupplementalPolicyDeploymentStatus'
               description: The list of device deployment states for this WindowsDefenderApplicationControl supplemental policy.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.windowsDefenderApplicationControlSupplementalPolicyAssignment:
@@ -26776,13 +26776,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedMobileApp'
               description: List of apps to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetedManagedAppPolicyAssignment'
               description: Navigation property to list of inclusion and exclusion groups to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Policy used to configure detailed management settings targeted to specific security groups and for a specified set of apps on a Windows device
@@ -26807,7 +26807,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsManagementAppHealthState'
               description: The list of health states for installed Windows management app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Windows management app entity.
@@ -26827,7 +26827,7 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.officeClientConfiguration'
           description: List of office Client configuration.
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.officeClientConfiguration:
@@ -26872,7 +26872,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.officeClientConfigurationAssignment'
               description: The list of group assignments for the policy.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeClientConfigurationAssignment:
@@ -26934,7 +26934,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -27343,37 +27343,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -27381,19 +27381,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -27447,7 +27447,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -27751,7 +27751,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -27888,7 +27888,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -27988,7 +27988,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -28067,7 +28067,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetedManagedAppPolicyAssignment'
               description: Navigation property to list of inclusion and exclusion groups to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Policy used to configure detailed management settings targeted to specific security groups
@@ -28663,19 +28663,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetedManagedAppPolicyAssignment'
               description: Navigation property to list of security groups targeted for policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             exemptAppLockerFiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionAppLockerFile'
               description: Another way to input exempt apps through xml files
-              readOnly: true
+              x-ms-navigationProperty: true
             protectedAppLockerFiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionAppLockerFile'
               description: Another way to input protected apps through xml files
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Policy for Windows information protection to configure detailed management settings
@@ -30989,43 +30989,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -31033,48 +31033,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -31082,56 +31082,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -31139,7 +31139,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -31147,40 +31147,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -31188,48 +31188,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -31244,24 +31244,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -31270,13 +31270,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -34115,7 +34115,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -34131,7 +34131,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -34250,12 +34250,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -34264,7 +34264,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePrincipal:
@@ -34435,100 +34435,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -34723,31 +34723,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -34775,7 +34775,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -34905,38 +34905,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -34962,25 +34962,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -35115,13 +35115,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -35129,7 +35129,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -35143,7 +35143,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -35371,7 +35371,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -35379,61 +35379,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -35441,31 +35441,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -35473,25 +35473,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -35503,7 +35503,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -35556,36 +35556,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -35696,31 +35696,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -35734,22 +35734,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -35868,25 +35868,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -35896,7 +35896,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -35928,13 +35928,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -35942,49 +35942,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -36025,7 +36025,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -36038,7 +36038,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -36085,13 +36085,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -36099,7 +36099,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -36222,36 +36222,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -36294,37 +36294,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -36359,115 +36359,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -36519,7 +36519,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -36690,43 +36690,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -36849,7 +36849,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -36859,7 +36859,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -36893,65 +36893,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -36995,7 +36995,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -37003,37 +37003,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -37101,13 +37101,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -37115,37 +37115,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -37155,7 +37155,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -37175,13 +37175,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -37195,7 +37195,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.securityBaselinePolicySourceType:
@@ -37417,13 +37417,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -37592,7 +37592,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -37654,7 +37654,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -37686,7 +37686,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -37718,7 +37718,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.passwordSingleSignOnSettings:
@@ -37981,7 +37981,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -38098,13 +38098,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -38697,7 +38697,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -38742,7 +38742,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -38779,7 +38779,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRule:
@@ -38944,19 +38944,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -38988,7 +38988,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -39040,19 +39040,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -39299,7 +39299,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -39307,7 +39307,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -39315,25 +39315,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -39357,17 +39357,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -39375,19 +39375,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deleted:
@@ -39447,7 +39447,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -39613,25 +39613,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -39700,7 +39700,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -39769,13 +39769,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appConsentRequestScope:
@@ -39954,7 +39954,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -40030,7 +40030,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -40070,7 +40070,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -40093,7 +40093,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.payloadTypes:
@@ -40179,7 +40179,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -40187,7 +40187,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -40317,19 +40317,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -40424,13 +40424,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -40549,13 +40549,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -40579,7 +40579,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -41503,7 +41503,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -41553,7 +41553,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -42049,13 +42049,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAsyncOperation:
@@ -42331,25 +42331,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTag:
@@ -42384,7 +42384,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -42491,56 +42491,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -42583,13 +42583,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.ErrorDetails:
@@ -42680,7 +42680,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -42726,7 +42726,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -42734,13 +42734,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -43046,7 +43046,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -43413,32 +43413,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRuleActions:
@@ -43779,7 +43779,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -43787,7 +43787,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -43797,7 +43797,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.audio:
@@ -44296,7 +44296,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -44304,25 +44304,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -44481,7 +44481,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -44794,12 +44794,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -44966,7 +44966,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -45073,7 +45073,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -45107,7 +45107,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -45115,13 +45115,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.request:
@@ -45494,7 +45494,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -46298,7 +46298,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -46412,7 +46412,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -46747,7 +46747,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagType:
@@ -47089,30 +47089,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerCapabilities:
@@ -47586,13 +47586,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -47876,7 +47876,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -48223,7 +48223,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -48323,13 +48323,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -48360,19 +48360,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -48380,7 +48380,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -48527,13 +48527,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -48660,7 +48660,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -48676,7 +48676,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -50875,7 +50875,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:
@@ -51269,7 +51269,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -51405,7 +51405,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.relationType:
@@ -51932,7 +51932,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/beta/Devices.ServiceAnnouncement.yml
+++ b/openApiDocs/beta/Devices.ServiceAnnouncement.yml
@@ -3891,13 +3891,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.browserSharedCookie'
               description: A collection of shared cookies defined for the site list.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.browserSite'
               description: A collection of sites defined for the site list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A singleton entity which is used to specify IE mode site list metadata
@@ -3912,19 +3912,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceHealth'
               description: 'A collection of service health information for tenant. This property is a contained navigation property, it is nullable and readonly.'
-              readOnly: true
+              x-ms-navigationProperty: true
             issues:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceHealthIssue'
               description: 'A collection of service issues for tenant. This property is a contained navigation property, it is nullable and readonly.'
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceUpdateMessage'
               description: 'A collection of service messages for tenant. This property is a contained navigation property, it is nullable and readonly.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.serviceHealth:
@@ -3943,7 +3943,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceHealthIssue'
               description: 'A collection of issues that happened on the service, with detailed information for each issue.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.serviceHealthIssue:
@@ -4031,7 +4031,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceAnnouncementAttachment'
               description: A collection of serviceAnnouncementAttachments.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.serviceAnnouncementAttachment:

--- a/openApiDocs/beta/Education.yml
+++ b/openApiDocs/beta/Education.yml
@@ -15259,24 +15259,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.educationSynchronizationProfile'
-          readOnly: true
+          x-ms-navigationProperty: true
         classes:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.educationClass'
-          readOnly: true
+          x-ms-navigationProperty: true
         me:
           $ref: '#/components/schemas/microsoft.graph.educationUser'
         schools:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.educationSchool'
-          readOnly: true
+          x-ms-navigationProperty: true
         users:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.educationUser'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.educationClass:
@@ -15328,7 +15328,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationCategory'
               description: All categories associated with this class. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignmentDefaults:
               $ref: '#/components/schemas/microsoft.graph.educationAssignmentDefaults'
             assignments:
@@ -15336,7 +15336,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationAssignment'
               description: All assignments associated with this class. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignmentSettings:
               $ref: '#/components/schemas/microsoft.graph.educationAssignmentSettings'
             group:
@@ -15346,19 +15346,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationUser'
               description: All users in the class. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             schools:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSchool'
               description: All schools that this class is associated with. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teachers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationUser'
               description: All teachers in the class. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.educationCategory:
@@ -15497,13 +15497,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationCategory'
               description: 'When set, enables users to easily find assignments of a given type.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationAssignmentResource'
               description: Learning objects that are associated with this assignment.  Only teachers can modify this list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             rubric:
               $ref: '#/components/schemas/microsoft.graph.educationRubric'
             submissions:
@@ -15511,7 +15511,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSubmission'
               description: 'Once published, there is a submission object for each student representing their work and grade.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.educationAssignmentResource:
@@ -15632,17 +15632,17 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationOutcome'
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSubmissionResource'
-              readOnly: true
+              x-ms-navigationProperty: true
             submittedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSubmissionResource'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.educationOutcome:
@@ -15912,7 +15912,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -15920,61 +15920,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -15982,31 +15982,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -16014,25 +16014,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -16044,7 +16044,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -16101,13 +16101,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationClass'
               description: Classes taught at the school. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationUser'
               description: Users in the school. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.educationUser:
@@ -16235,31 +16235,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationAssignment'
               description: List of assignments for the user. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             rubrics:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationRubric'
               description: 'When set, the grading rubric attached to the assignment.'
-              readOnly: true
+              x-ms-navigationProperty: true
             classes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationClass'
               description: Classes to which the user belongs. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             schools:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSchool'
               description: Schools to which the user belongs. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             taughtClasses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationClass'
               description: Classes for which the user is a teacher.
-              readOnly: true
+              x-ms-navigationProperty: true
             user:
               $ref: '#/components/schemas/microsoft.graph.user'
           additionalProperties:
@@ -16619,43 +16619,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -16663,48 +16663,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -16712,56 +16712,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -16769,7 +16769,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -16777,40 +16777,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -16818,48 +16818,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -16874,24 +16874,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -16900,13 +16900,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -16939,19 +16939,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Users and groups that are members of this administrative unit. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: Scoped-role members of this administrative unit.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for this administrative unit. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.educationSynchronizationProfile:
@@ -16989,7 +16989,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSynchronizationError'
               description: All errors associated with this synchronization profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             profileStatus:
               $ref: '#/components/schemas/microsoft.graph.educationSynchronizationProfileStatus'
           additionalProperties:
@@ -17593,31 +17593,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -17747,38 +17747,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversation:
@@ -17811,7 +17811,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -17856,7 +17856,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -17882,25 +17882,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -17910,7 +17910,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -17942,13 +17942,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -17956,49 +17956,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -18046,7 +18046,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -18060,37 +18060,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -18180,13 +18180,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -18194,37 +18194,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -18234,7 +18234,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -18685,7 +18685,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -18701,7 +18701,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -18820,12 +18820,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -18834,7 +18834,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePrincipal:
@@ -19005,100 +19005,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -19205,7 +19205,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -19231,25 +19231,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -19384,13 +19384,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -19398,7 +19398,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -19412,7 +19412,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -19463,36 +19463,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -19603,31 +19603,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -19641,22 +19641,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -19779,7 +19779,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -19792,7 +19792,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -19839,13 +19839,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -19853,7 +19853,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -19977,7 +19977,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -20340,37 +20340,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -20378,19 +20378,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -20472,19 +20472,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -20601,7 +20601,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -20653,36 +20653,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -20724,115 +20724,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -20884,7 +20884,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -21055,43 +21055,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -21214,7 +21214,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -21224,7 +21224,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -21258,65 +21258,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -21360,7 +21360,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -21368,37 +21368,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -21412,13 +21412,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -21432,7 +21432,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.educationSynchronizationDataProvider:
@@ -22095,32 +22095,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.baseItem:
@@ -22330,7 +22330,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -22338,7 +22338,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -22346,25 +22346,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -22388,17 +22388,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -22406,19 +22406,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deleted:
@@ -22478,7 +22478,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -22644,25 +22644,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -22731,7 +22731,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -22800,13 +22800,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -22844,7 +22844,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -22852,7 +22852,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -22886,13 +22886,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -23011,13 +23011,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -23041,7 +23041,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -23243,25 +23243,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -23370,7 +23370,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -23477,56 +23477,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.physicalAddressType:
@@ -23669,13 +23669,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -23897,7 +23897,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -23959,7 +23959,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -23991,7 +23991,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -24023,7 +24023,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.passwordSingleSignOnSettings:
@@ -24286,7 +24286,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -24377,13 +24377,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -24640,19 +24640,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -24684,7 +24684,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -24736,19 +24736,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -24952,7 +24952,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -25028,7 +25028,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -25068,7 +25068,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -25091,7 +25091,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceEnrollmentConfigurationType:
@@ -26485,7 +26485,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -26524,7 +26524,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -26774,7 +26774,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -27156,19 +27156,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -28149,7 +28149,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -28199,7 +28199,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -28659,13 +28659,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -28748,13 +28748,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.MainError:
@@ -29051,7 +29051,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -29059,7 +29059,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -29069,7 +29069,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.audio:
@@ -29568,7 +29568,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -29576,25 +29576,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -29753,7 +29753,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -30066,12 +30066,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -30238,7 +30238,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -30345,7 +30345,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -30379,7 +30379,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -30387,13 +30387,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanContainer:
@@ -30459,7 +30459,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -30669,7 +30669,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsApp:
@@ -30693,7 +30693,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -31102,7 +31102,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -31148,7 +31148,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -31156,13 +31156,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -31479,7 +31479,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -33808,7 +33808,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -34159,30 +34159,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.ErrorDetails:
@@ -34500,7 +34500,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -34600,13 +34600,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -34637,19 +34637,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -34657,7 +34657,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -34804,13 +34804,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -34937,7 +34937,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -34953,7 +34953,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -35870,13 +35870,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -36160,7 +36160,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -37341,7 +37341,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -37477,7 +37477,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.relationType:
@@ -38773,7 +38773,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:
@@ -39197,7 +39197,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/beta/Files.yml
+++ b/openApiDocs/beta/Files.yml
@@ -69781,25 +69781,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -69809,7 +69809,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityOLD:
@@ -69905,7 +69905,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -69913,7 +69913,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -69921,25 +69921,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -69959,7 +69959,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -69967,7 +69967,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -69977,7 +69977,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemAnalytics:
@@ -69992,7 +69992,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -70036,7 +70036,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivity:
@@ -70407,17 +70407,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -70425,19 +70425,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.columnDefinition:
@@ -70601,25 +70601,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.columnLink:
@@ -70674,7 +70674,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All driveItems contained in the sharing root. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             listItem:
@@ -70716,13 +70716,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -70730,49 +70730,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -71474,7 +71474,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -71482,25 +71482,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contentTypeInfo:
@@ -72019,12 +72019,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -72157,12 +72157,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -72171,7 +72171,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sitePage:
@@ -72215,7 +72215,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.store:
@@ -72237,13 +72237,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -72257,37 +72257,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.driveCollectionResponse:
@@ -72875,43 +72875,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -72919,48 +72919,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -72968,56 +72968,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -73025,7 +73025,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -73033,40 +73033,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -73074,48 +73074,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -73130,24 +73130,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -73156,13 +73156,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -73409,7 +73409,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -73509,13 +73509,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -73546,19 +73546,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -73566,7 +73566,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -73619,13 +73619,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -73661,7 +73661,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -73669,13 +73669,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.displayNameLocalization:
@@ -73753,7 +73753,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -73815,7 +73815,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -73847,7 +73847,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -73879,7 +73879,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pageLayoutType:
@@ -73976,7 +73976,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -74019,7 +74019,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -74053,13 +74053,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -74178,13 +74178,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -74208,7 +74208,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -74594,7 +74594,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -74610,7 +74610,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -74885,100 +74885,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -75173,31 +75173,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -75225,7 +75225,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -75355,38 +75355,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -75412,25 +75412,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -75565,13 +75565,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -75579,7 +75579,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -75593,7 +75593,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -75821,7 +75821,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -75829,61 +75829,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -75891,31 +75891,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -75923,25 +75923,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -75953,7 +75953,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -76006,36 +76006,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -76146,31 +76146,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -76184,22 +76184,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -76329,7 +76329,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -76342,7 +76342,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -76389,13 +76389,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -76403,7 +76403,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -76527,7 +76527,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -76890,37 +76890,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -76928,19 +76928,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -77022,19 +77022,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -77151,7 +77151,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -77203,36 +77203,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -77296,115 +77296,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -77456,7 +77456,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -77627,43 +77627,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -77786,7 +77786,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -77796,7 +77796,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -77830,65 +77830,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -77932,7 +77932,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -77940,37 +77940,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -78038,13 +78038,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -78052,37 +78052,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -78092,7 +78092,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -78112,13 +78112,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -78132,7 +78132,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mediaSourceContentCategory:
@@ -78283,7 +78283,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -78622,7 +78622,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -78638,7 +78638,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.termGroupScope:
@@ -78898,13 +78898,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -79375,7 +79375,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -79492,13 +79492,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -80077,7 +80077,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -80122,7 +80122,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -80159,7 +80159,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRule:
@@ -80324,19 +80324,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -80368,7 +80368,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -80420,19 +80420,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -80636,7 +80636,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -80712,7 +80712,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -80752,7 +80752,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -80775,7 +80775,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceEnrollmentConfigurationType:
@@ -82169,7 +82169,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -82208,7 +82208,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -82458,7 +82458,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -82748,7 +82748,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -82756,7 +82756,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -82886,19 +82886,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -83874,7 +83874,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -83924,7 +83924,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -84390,13 +84390,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAsyncOperation:
@@ -84672,25 +84672,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTag:
@@ -84725,7 +84725,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -84832,56 +84832,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -84924,13 +84924,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilter:
@@ -85076,7 +85076,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -85262,7 +85262,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.externalLink:
@@ -85351,7 +85351,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -85397,7 +85397,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -85405,13 +85405,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -85552,7 +85552,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -85919,32 +85919,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRuleActions:
@@ -87551,7 +87551,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -88237,7 +88237,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -88342,7 +88342,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -88677,7 +88677,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagType:
@@ -89011,30 +89011,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilterCriteria:
@@ -89672,13 +89672,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -89910,7 +89910,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -92631,7 +92631,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:

--- a/openApiDocs/beta/Financials.yml
+++ b/openApiDocs/beta/Financials.yml
@@ -31152,7 +31152,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.company'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.company:
@@ -31177,177 +31177,177 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.account'
-              readOnly: true
+              x-ms-navigationProperty: true
             agedAccountsPayable:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agedAccountsPayable'
-              readOnly: true
+              x-ms-navigationProperty: true
             agedAccountsReceivable:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agedAccountsReceivable'
-              readOnly: true
+              x-ms-navigationProperty: true
             companyInformation:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.companyInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             countriesRegions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.countryRegion'
-              readOnly: true
+              x-ms-navigationProperty: true
             currencies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.currency'
-              readOnly: true
+              x-ms-navigationProperty: true
             customerPaymentJournals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.customerPaymentJournal'
-              readOnly: true
+              x-ms-navigationProperty: true
             customerPayments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.customerPayment'
-              readOnly: true
+              x-ms-navigationProperty: true
             customers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.customer'
-              readOnly: true
+              x-ms-navigationProperty: true
             dimensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dimension'
-              readOnly: true
+              x-ms-navigationProperty: true
             dimensionValues:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dimensionValue'
-              readOnly: true
+              x-ms-navigationProperty: true
             employees:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.employee'
-              readOnly: true
+              x-ms-navigationProperty: true
             generalLedgerEntries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.generalLedgerEntry'
-              readOnly: true
+              x-ms-navigationProperty: true
             itemCategories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemCategory'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.item'
-              readOnly: true
+              x-ms-navigationProperty: true
             journalLines:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.journalLine'
-              readOnly: true
+              x-ms-navigationProperty: true
             journals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.journal'
-              readOnly: true
+              x-ms-navigationProperty: true
             paymentMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.paymentMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             paymentTerms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.paymentTerm'
-              readOnly: true
+              x-ms-navigationProperty: true
             picture:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.picture'
-              readOnly: true
+              x-ms-navigationProperty: true
             purchaseInvoiceLines:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.purchaseInvoiceLine'
-              readOnly: true
+              x-ms-navigationProperty: true
             purchaseInvoices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.purchaseInvoice'
-              readOnly: true
+              x-ms-navigationProperty: true
             salesCreditMemoLines:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesCreditMemoLine'
-              readOnly: true
+              x-ms-navigationProperty: true
             salesCreditMemos:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesCreditMemo'
-              readOnly: true
+              x-ms-navigationProperty: true
             salesInvoiceLines:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesInvoiceLine'
-              readOnly: true
+              x-ms-navigationProperty: true
             salesInvoices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesInvoice'
-              readOnly: true
+              x-ms-navigationProperty: true
             salesOrderLines:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesOrderLine'
-              readOnly: true
+              x-ms-navigationProperty: true
             salesOrders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesOrder'
-              readOnly: true
+              x-ms-navigationProperty: true
             salesQuoteLines:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesQuoteLine'
-              readOnly: true
+              x-ms-navigationProperty: true
             salesQuotes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesQuote'
-              readOnly: true
+              x-ms-navigationProperty: true
             shipmentMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shipmentMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             taxAreas:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.taxArea'
-              readOnly: true
+              x-ms-navigationProperty: true
             taxGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.taxGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             unitsOfMeasure:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unitOfMeasure'
-              readOnly: true
+              x-ms-navigationProperty: true
             vendors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.vendor'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.account:
@@ -31598,7 +31598,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.customerPayment'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.customerPayment:
@@ -31746,7 +31746,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.picture'
-              readOnly: true
+              x-ms-navigationProperty: true
             shipmentMethod:
               $ref: '#/components/schemas/microsoft.graph.shipmentMethod'
           additionalProperties:
@@ -31869,7 +31869,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dimensionValue'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dimensionValue:
@@ -31959,7 +31959,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.picture'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.generalLedgerEntry:
@@ -32094,7 +32094,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.picture'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.journalLine:
@@ -32181,7 +32181,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.journalLine'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.purchaseInvoiceLine:
@@ -32385,7 +32385,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.purchaseInvoiceLine'
-              readOnly: true
+              x-ms-navigationProperty: true
             vendor:
               $ref: '#/components/schemas/microsoft.graph.vendor'
           additionalProperties:
@@ -32459,7 +32459,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.picture'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.salesCreditMemoLine:
@@ -32683,7 +32683,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesCreditMemoLine'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.salesInvoiceLine:
@@ -32923,7 +32923,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesInvoiceLine'
-              readOnly: true
+              x-ms-navigationProperty: true
             shipmentMethod:
               $ref: '#/components/schemas/microsoft.graph.shipmentMethod'
           additionalProperties:
@@ -33171,7 +33171,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesOrderLine'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.salesQuoteLine:
@@ -33400,7 +33400,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.salesQuoteLine'
-              readOnly: true
+              x-ms-navigationProperty: true
             shipmentMethod:
               $ref: '#/components/schemas/microsoft.graph.shipmentMethod'
           additionalProperties:

--- a/openApiDocs/beta/Groups.yml
+++ b/openApiDocs/beta/Groups.yml
@@ -43332,7 +43332,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -43340,61 +43340,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -43402,31 +43402,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -43434,25 +43434,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -43464,7 +43464,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -43678,38 +43678,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarRoleType:
@@ -43777,7 +43777,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -43822,7 +43822,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.post:
@@ -43865,32 +43865,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attachment:
@@ -44115,7 +44115,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityLabelAssignmentMethod:
@@ -44237,7 +44237,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -44245,7 +44245,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -44253,25 +44253,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.driveItemUploadableProperties:
@@ -44389,25 +44389,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -44427,7 +44427,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -44435,7 +44435,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -44445,7 +44445,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.endpoint:
@@ -44944,13 +44944,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -44958,49 +44958,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -45169,13 +45169,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.provisionChannelEmailResult:
@@ -45486,31 +45486,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -45536,25 +45536,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -45564,7 +45564,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerGroup:
@@ -45578,7 +45578,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -45592,37 +45592,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -45690,13 +45690,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -45704,37 +45704,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -45744,7 +45744,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -46724,7 +46724,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -46732,25 +46732,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityOLD:
@@ -46783,7 +46783,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -46931,12 +46931,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -47427,12 +47427,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -47441,7 +47441,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -47465,17 +47465,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -47483,19 +47483,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -47564,7 +47564,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.store:
@@ -47586,13 +47586,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publicError:
@@ -48228,7 +48228,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -48236,7 +48236,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -48270,13 +48270,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenotePage:
@@ -48373,13 +48373,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -48403,7 +48403,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -48597,25 +48597,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -49023,43 +49023,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -49067,48 +49067,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -49116,56 +49116,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -49173,7 +49173,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -49181,40 +49181,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -49222,48 +49222,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -49278,24 +49278,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -49304,13 +49304,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -49349,7 +49349,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -49456,56 +49456,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attendeeBase:
@@ -49853,7 +49853,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -49953,13 +49953,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -49990,19 +49990,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -50010,7 +50010,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActionSet:
@@ -50536,7 +50536,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -50598,7 +50598,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -50630,7 +50630,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -50662,7 +50662,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listInfo:
@@ -50807,7 +50807,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -50843,7 +50843,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -50877,7 +50877,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -50885,13 +50885,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publicErrorDetail:
@@ -51123,7 +51123,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -51395,7 +51395,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTab:
@@ -51449,7 +51449,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -51837,7 +51837,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -51853,7 +51853,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -52128,100 +52128,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -52328,7 +52328,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -52354,25 +52354,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -52507,13 +52507,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -52521,7 +52521,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -52535,7 +52535,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -52586,36 +52586,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -52726,31 +52726,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -52764,22 +52764,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -52902,7 +52902,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -52915,7 +52915,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -52962,13 +52962,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -52976,7 +52976,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -53100,7 +53100,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -53463,37 +53463,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -53501,19 +53501,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -53595,19 +53595,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -53724,7 +53724,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -53776,36 +53776,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -53847,115 +53847,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -54007,7 +54007,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -54178,43 +54178,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -54337,7 +54337,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -54347,7 +54347,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -54381,65 +54381,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -54483,7 +54483,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -54491,37 +54491,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -54535,13 +54535,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -54555,7 +54555,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagType:
@@ -54978,7 +54978,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -55156,13 +55156,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -55521,7 +55521,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -55537,7 +55537,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.termGroupScope:
@@ -56076,13 +56076,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -56553,7 +56553,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -56644,13 +56644,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -56855,19 +56855,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -56899,7 +56899,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -56951,19 +56951,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -57167,7 +57167,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -57243,7 +57243,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -57283,7 +57283,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -57306,7 +57306,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceEnrollmentConfigurationType:
@@ -58700,7 +58700,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -58739,7 +58739,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -58989,7 +58989,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -59235,19 +59235,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -60223,7 +60223,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -60273,7 +60273,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -60655,13 +60655,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequest:
@@ -60918,7 +60918,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -61120,7 +61120,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.relationType:
@@ -61247,7 +61247,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -61293,7 +61293,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -61301,13 +61301,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -61448,7 +61448,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -63625,7 +63625,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -63776,30 +63776,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequestActor:
@@ -64504,13 +64504,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -64742,7 +64742,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -66913,7 +66913,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:

--- a/openApiDocs/beta/Identity.DirectoryManagement.yml
+++ b/openApiDocs/beta/Identity.DirectoryManagement.yml
@@ -18946,19 +18946,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Users and groups that are members of this administrative unit. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: Scoped-role members of this administrative unit.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for this administrative unit. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.extension:
@@ -19071,7 +19071,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The contact's direct reports. (The users and contacts that have their manager property set to this contact.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -19079,18 +19079,18 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups that this contact is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a contact. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contract:
@@ -19283,43 +19283,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.command:
@@ -19388,68 +19388,68 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.impactedResource'
-              readOnly: true
+              x-ms-navigationProperty: true
             recommendations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.recommendation'
               description: List of recommended improvements to improve tenant posture.
-              readOnly: true
+              x-ms-navigationProperty: true
             administrativeUnits:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.administrativeUnit'
               description: Conceptual container for user and group directory objects.
-              readOnly: true
+              x-ms-navigationProperty: true
             attributeSets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attributeSet'
               description: Group of related custom security attribute definitions.
-              readOnly: true
+              x-ms-navigationProperty: true
             customSecurityAttributeDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeDefinition'
               description: Schema of a custom security attributes (key-value pairs).
-              readOnly: true
+              x-ms-navigationProperty: true
             deletedItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             federationConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityProviderBase'
               description: Configure domain federation with organizations whose identity provider (IdP) supports either the SAML or WS-Fed protocol.
-              readOnly: true
+              x-ms-navigationProperty: true
             inboundSharedUserProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.inboundSharedUserProfile'
-              readOnly: true
+              x-ms-navigationProperty: true
             onPremisesSynchronization:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onPremisesDirectorySynchronization'
               description: A container for on-premises directory synchronization functionalities that are available for the organization.
-              readOnly: true
+              x-ms-navigationProperty: true
             outboundSharedUserProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outboundSharedUserProfile'
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedEmailDomains:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedEmailDomain'
-              readOnly: true
+              x-ms-navigationProperty: true
             featureRolloutPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.featureRolloutPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attributeSet:
@@ -19509,7 +19509,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.allowedValue'
               description: 'Values that are predefined for this custom security attribute.This navigation property is not returned by default and must be specified in an $expand query. For example, /directory/customSecurityAttributeDefinitions?$expand=allowedValues.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.allowedValue:
@@ -19550,7 +19550,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Nullable. Specifies a list of directoryObjects that feature is enabled for.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.identityProviderBase:
@@ -19664,7 +19664,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.tenantReference'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.tenantReference:
@@ -19716,13 +19716,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Users that are members of this directory role. HTTP Methods: GET, POST, DELETE. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: Members of this directory role that are scoped to administrative units. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryRoleTemplate:
@@ -19816,30 +19816,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The objects such as users and groups that reference the domain ID. Read-only, Nullable. Supports $expand and $filter by the OData type of objects returned. For example /domains/{domainId}/domainNameReferences/microsoft.graph.user and /domains/{domainId}/domainNameReferences/microsoft.graph.group.'
-              readOnly: true
+              x-ms-navigationProperty: true
             federationConfiguration:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.internalDomainFederation'
               description: Domain settings configured by customer when federated with Azure AD. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             serviceConfigurationRecords:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.domainDnsRecord'
               description: 'DNS records the customer adds to the DNS zone file of the domain before the domain can be used by Microsoft Online services. Read-only, Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedEmailDomainInvitations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedEmailDomainInvitation'
-              readOnly: true
+              x-ms-navigationProperty: true
             verificationDnsRecords:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.domainDnsRecord'
               description: 'DNS records that the customer adds to the DNS zone file of the domain before the customer can complete domain ownership verification with Azure AD. Read-only, Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.internalDomainFederation:
@@ -20035,13 +20035,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.certificateBasedAuthConfiguration'
               description: Navigation property to manage certificate-based authentication configuration. Only a single instance of certificateBasedAuthConfiguration can be created in the collection.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the organization resource. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               $ref: '#/components/schemas/microsoft.graph.organizationSettings'
           additionalProperties:
@@ -20057,7 +20057,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.organizationalBrandingLocalization'
               description: Add different branding based on a locale.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.organizationalBrandingLocalization:
@@ -20086,7 +20086,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profileCardProperty'
               description: Contains a collection of the properties an administrator has defined as visible on the Microsoft 365 profile card. Get organization settings returns the properties configured for profile cards for the organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.insightsSettings:
@@ -20617,7 +20617,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.impactedResource'
               description: The list of directory objects associated with the recommendation.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.settingTemplateValue:

--- a/openApiDocs/beta/Identity.SignIns.yml
+++ b/openApiDocs/beta/Identity.SignIns.yml
@@ -28385,46 +28385,46 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.identityApiConnector'
           description: Represents entry point for API connectors.
-          readOnly: true
+          x-ms-navigationProperty: true
         authenticationEventListeners:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.authenticationEventListener'
-          readOnly: true
+          x-ms-navigationProperty: true
         b2cUserFlows:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.b2cIdentityUserFlow'
           description: Represents entry point for B2C identity userflows.
-          readOnly: true
+          x-ms-navigationProperty: true
         b2xUserFlows:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.b2xIdentityUserFlow'
           description: Represents entry point for B2X and self-service sign-up identity userflows.
-          readOnly: true
+          x-ms-navigationProperty: true
         customAuthenticationExtensions:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.customAuthenticationExtension'
-          readOnly: true
+          x-ms-navigationProperty: true
         identityProviders:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.identityProviderBase'
           description: Represents entry point for identity provider base.
-          readOnly: true
+          x-ms-navigationProperty: true
         userFlowAttributes:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.identityUserFlowAttribute'
           description: Represents entry point for identity userflow attributes.
-          readOnly: true
+          x-ms-navigationProperty: true
         userFlows:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.identityUserFlow'
-          readOnly: true
+          x-ms-navigationProperty: true
         conditionalAccess:
           $ref: '#/components/schemas/microsoft.graph.conditionalAccessRoot'
         continuousAccessEvaluationPolicy:
@@ -28486,24 +28486,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityProvider'
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userFlowLanguageConfiguration'
               description: The languages supported for customization within the user flow. Language customization is not enabled by default in B2C user flows.
-              readOnly: true
+              x-ms-navigationProperty: true
             userAttributeAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityUserFlowAttributeAssignment'
               description: The user attribute assignments included in the user flow.
-              readOnly: true
+              x-ms-navigationProperty: true
             userFlowIdentityProviders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityProviderBase'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userFlowLanguageConfiguration:
@@ -28524,13 +28524,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userFlowLanguagePage'
               description: Collection of pages with the default content to display in a user flow for a specified language. This collection does not allow any kind of modification.
-              readOnly: true
+              x-ms-navigationProperty: true
             overridesPages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userFlowLanguagePage'
               description: 'Collection of pages with the overrides messages to display in a user flow for a specified language. This collection only allows to modify the content of the page, any other modification is not allowed (creation or deletion of pages).'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userFlowLanguagePage:
@@ -28623,24 +28623,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityProvider'
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userFlowLanguageConfiguration'
               description: The languages supported for customization within the user flow. Language customization is enabled by default in self-service sign up user flow. You cannot create custom languages in self-service sign up user flows.
-              readOnly: true
+              x-ms-navigationProperty: true
             userAttributeAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityUserFlowAttributeAssignment'
               description: The user attribute assignments included in the user flow.
-              readOnly: true
+              x-ms-navigationProperty: true
             userFlowIdentityProviders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityProviderBase'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.identityProvider:
@@ -28682,25 +28682,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationContextClassReference'
               description: Read-only. Nullable. Returns a collection of the specified authentication context class references.
-              readOnly: true
+              x-ms-navigationProperty: true
             namedLocations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.namedLocation'
               description: Read-only. Nullable. Returns a collection of the specified named locations.
-              readOnly: true
+              x-ms-navigationProperty: true
             policies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conditionalAccessPolicy'
               description: Read-only. Nullable. Returns a collection of the specified Conditional Access policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conditionalAccessTemplate'
               description: Read-only. Nullable. Returns a collection of the specified Conditional Access templates.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationContextClassReference:
@@ -28743,13 +28743,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethodModeDetail'
               description: Names and descriptions of all valid authentication method modes in the system.
-              readOnly: true
+              x-ms-navigationProperty: true
             policies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationStrengthPolicy'
               description: 'A collection of authentication strength policies that exist for this tenant, including both built-in and custom policies.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationMethodModeDetail:
@@ -28802,7 +28802,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationCombinationConfiguration'
               description: Settings that may be used to require specific types or instances of an authentication method to be used when authenticating with a specified combination of authentication methods.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationCombinationConfiguration:
@@ -28873,12 +28873,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.conditionalAccessPolicy'
-          readOnly: true
+          x-ms-navigationProperty: true
         none:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.conditionalAccessPolicy'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.namedLocation:
@@ -29040,25 +29040,25 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.riskDetection'
           description: Risk detection in Azure AD Identity Protection and the associated information about the detection.
-          readOnly: true
+          x-ms-navigationProperty: true
         riskyServicePrincipals:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.riskyServicePrincipal'
           description: Azure AD service principals that are at risk.
-          readOnly: true
+          x-ms-navigationProperty: true
         riskyUsers:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.riskyUser'
           description: Users that are flagged as at-risk by Azure AD Identity Protection.
-          readOnly: true
+          x-ms-navigationProperty: true
         servicePrincipalRiskDetections:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.servicePrincipalRiskDetection'
           description: Represents information about detected at-risk service principals in an Azure AD tenant.
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.riskDetection:
@@ -29182,7 +29182,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.riskyServicePrincipalHistoryItem'
               description: Represents the risk history of Azure AD service principals.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.riskyServicePrincipalHistoryItem:
@@ -29241,7 +29241,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.riskyUserHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.riskyUserHistoryItem:
@@ -29356,12 +29356,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -29370,7 +29370,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.bitlocker:
@@ -29384,7 +29384,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.bitlockerRecoveryKey:
@@ -29506,7 +29506,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.informationProtectionLabel:
@@ -29684,7 +29684,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.discoveredSensitiveType:
@@ -29782,7 +29782,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentResult:
@@ -30202,43 +30202,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -30246,48 +30246,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -30295,56 +30295,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -30352,7 +30352,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -30360,40 +30360,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -30401,48 +30401,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -30457,24 +30457,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -30483,13 +30483,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -30558,7 +30558,7 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.authenticationStrengthPolicy'
           description: The authentication method combinations that are to be used in scenarios defined by Azure AD Conditional Access.
-          readOnly: true
+          x-ms-navigationProperty: true
         authenticationFlowsPolicy:
           $ref: '#/components/schemas/microsoft.graph.authenticationFlowsPolicy'
         b2cAuthenticationMethodsPolicy:
@@ -30570,25 +30570,25 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.activityBasedTimeoutPolicy'
           description: The policy that controls the idle time out for web sessions for applications.
-          readOnly: true
+          x-ms-navigationProperty: true
         appManagementPolicies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
           description: 'The policies that enforce app management restrictions for specific applications and service principals, overriding the defaultAppManagementPolicy.'
-          readOnly: true
+          x-ms-navigationProperty: true
         authorizationPolicy:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.authorizationPolicy'
           description: The policy that controls Azure AD authorization settings.
-          readOnly: true
+          x-ms-navigationProperty: true
         claimsMappingPolicies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
           description: 'The claim-mapping policies for WS-Fed, SAML, OAuth 2.0, and OpenID Connect protocols, for tokens issued to a specific application.'
-          readOnly: true
+          x-ms-navigationProperty: true
         crossTenantAccessPolicy:
           $ref: '#/components/schemas/microsoft.graph.crossTenantAccessPolicy'
         defaultAppManagementPolicy:
@@ -30600,36 +30600,36 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
           description: The policy to control Azure AD authentication behavior for federated users.
-          readOnly: true
+          x-ms-navigationProperty: true
         permissionGrantPolicies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.permissionGrantPolicy'
           description: The policy that specifies the conditions under which consent can be granted.
-          readOnly: true
+          x-ms-navigationProperty: true
         servicePrincipalCreationPolicies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.servicePrincipalCreationPolicy'
-          readOnly: true
+          x-ms-navigationProperty: true
         tokenIssuancePolicies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
           description: The policy that specifies the characteristics of SAML tokens issued by Azure AD.
-          readOnly: true
+          x-ms-navigationProperty: true
         tokenLifetimePolicies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
           description: 'The policy that controls the lifetime of a JWT access token, an ID token, or a SAML 1.1/2.0 token issued by Azure AD.'
-          readOnly: true
+          x-ms-navigationProperty: true
         featureRolloutPolicies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.featureRolloutPolicy'
           description: The feature rollout policy associated with a directory object.
-          readOnly: true
+          x-ms-navigationProperty: true
         accessReviewPolicy:
           $ref: '#/components/schemas/microsoft.graph.accessReviewPolicy'
         adminConsentRequestPolicy:
@@ -30641,7 +30641,7 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.conditionalAccessPolicy'
           description: The custom rules that define an access scenario.
-          readOnly: true
+          x-ms-navigationProperty: true
         identitySecurityDefaultsEnforcementPolicy:
           $ref: '#/components/schemas/microsoft.graph.identitySecurityDefaultsEnforcementPolicy'
         mobileAppManagementPolicies:
@@ -30649,24 +30649,24 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.mobilityManagementPolicy'
           description: The policy that defines auto-enrollment configuration for a mobility management (MDM or MAM) application.
-          readOnly: true
+          x-ms-navigationProperty: true
         mobileDeviceManagementPolicies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.mobilityManagementPolicy'
-          readOnly: true
+          x-ms-navigationProperty: true
         roleManagementPolicies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.unifiedRoleManagementPolicy'
           description: Represents the role management policies.
-          readOnly: true
+          x-ms-navigationProperty: true
         roleManagementPolicyAssignments:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.unifiedRoleManagementPolicyAssignment'
           description: Represents the role management policy assignments.
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.accessReviewPolicy:
@@ -30742,7 +30742,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryObject:
@@ -30817,7 +30817,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethodConfiguration'
               description: Represents the settings for each authentication method. Automatically expanded on GET /policies/authenticationMethodsPolicy.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationMethodConfiguration:
@@ -30884,7 +30884,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.defaultUserRoleOverride'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.defaultUserRoleOverride:
@@ -30944,7 +30944,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.crossTenantAccessPolicyConfigurationPartner'
               description: Defines partner-specific configurations for external Azure Active Directory organizations.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.crossTenantAccessPolicyConfigurationDefault:
@@ -31110,7 +31110,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Nullable. Specifies a list of directoryObjects that feature is enabled for.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.homeRealmDiscoveryPolicy:
@@ -31168,7 +31168,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: Azure AD groups under the scope of the mobility management application if appliesTo is selected
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionGrantPolicy:
@@ -31182,13 +31182,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permissionGrantConditionSet'
               description: Condition sets which are excluded in this permission grant policy. Automatically expanded on GET.
-              readOnly: true
+              x-ms-navigationProperty: true
             includes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permissionGrantConditionSet'
               description: Condition sets which are included in this permission grant policy. Automatically expanded on GET.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionGrantConditionSet:
@@ -31276,13 +31276,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleManagementPolicyRule'
               description: 'The list of effective rules like approval rules and expiration rules evaluated based on inherited referenced rules. For example, if there is a tenant-wide policy to enforce enabling an approval rule, the effective rule will be to enable approval even if the policy has a rule to disable approval. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             rules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleManagementPolicyRule'
               description: The collection of rules like approval rules and expiration rules. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.unifiedRoleManagementPolicyRule:
@@ -31331,12 +31331,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipalCreationConditionSet'
-              readOnly: true
+              x-ms-navigationProperty: true
             includes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipalCreationConditionSet'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePrincipalCreationConditionSet:
@@ -31390,12 +31390,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.trustFrameworkKeySet'
-          readOnly: true
+          x-ms-navigationProperty: true
         policies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.trustFrameworkPolicy'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.trustFrameworkKeySet:
@@ -31503,65 +31503,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -31813,43 +31813,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.longRunningOperation:
@@ -33071,7 +33071,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -33087,7 +33087,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -33362,100 +33362,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -33612,31 +33612,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -33664,7 +33664,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -33794,38 +33794,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -33851,25 +33851,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -34004,13 +34004,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -34018,7 +34018,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -34032,7 +34032,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -34260,7 +34260,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -34268,61 +34268,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -34330,31 +34330,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -34362,25 +34362,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -34392,7 +34392,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -34445,36 +34445,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -34585,31 +34585,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -34623,22 +34623,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -34757,25 +34757,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -34785,7 +34785,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -34817,13 +34817,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -34831,49 +34831,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -34914,7 +34914,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -34927,7 +34927,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -34974,13 +34974,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -34988,7 +34988,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -35112,7 +35112,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -35475,37 +35475,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -35513,19 +35513,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -35607,19 +35607,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -35736,7 +35736,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -35788,36 +35788,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -35860,37 +35860,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -35925,115 +35925,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -36085,7 +36085,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -36208,7 +36208,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -36218,7 +36218,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -36282,7 +36282,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -36290,37 +36290,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -36388,13 +36388,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -36402,37 +36402,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -36442,7 +36442,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -36462,13 +36462,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -36482,7 +36482,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.certificateAuthority:
@@ -36531,7 +36531,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewReviewerScope:
@@ -36932,7 +36932,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.directoryObject'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.attestationLevel:
@@ -37968,7 +37968,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.authenticationConditionApplication'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.conditionalAccessApplications:
@@ -38423,13 +38423,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -38972,13 +38972,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -39549,7 +39549,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -39594,7 +39594,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -39631,7 +39631,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRule:
@@ -39796,19 +39796,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -39840,7 +39840,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -39892,19 +39892,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -40139,7 +40139,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -40147,7 +40147,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -40155,25 +40155,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -40197,17 +40197,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -40215,19 +40215,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deleted:
@@ -40287,7 +40287,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -40453,25 +40453,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -40540,7 +40540,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -40609,13 +40609,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appConsentRequestScope:
@@ -40774,7 +40774,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -40850,7 +40850,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -40890,7 +40890,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -40913,7 +40913,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceEnrollmentConfigurationType:
@@ -42307,7 +42307,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -42346,7 +42346,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -42596,7 +42596,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -42873,7 +42873,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -42881,7 +42881,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -43011,19 +43011,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -43118,13 +43118,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -43243,13 +43243,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -43273,7 +43273,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -44142,7 +44142,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -44192,7 +44192,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -44444,13 +44444,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAsyncOperation:
@@ -44726,25 +44726,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTag:
@@ -44779,7 +44779,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -44886,56 +44886,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -44978,13 +44978,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.keyCredentialConfiguration:
@@ -45392,7 +45392,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -45438,7 +45438,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -45446,13 +45446,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -45922,32 +45922,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRuleActions:
@@ -46288,7 +46288,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -46296,7 +46296,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -46306,7 +46306,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.audio:
@@ -46784,7 +46784,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -46792,25 +46792,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -46969,7 +46969,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -47282,12 +47282,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -47454,7 +47454,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -47561,7 +47561,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -47595,7 +47595,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -47603,13 +47603,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.request:
@@ -48920,7 +48920,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -49712,7 +49712,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -49784,7 +49784,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -50119,7 +50119,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagType:
@@ -50461,30 +50461,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:
@@ -51089,13 +51089,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -51289,7 +51289,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -51636,7 +51636,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -51736,13 +51736,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -51773,19 +51773,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -51793,7 +51793,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -51940,13 +51940,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -52073,7 +52073,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -52089,7 +52089,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -54728,7 +54728,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.synchronizationScheduleState:
@@ -55106,7 +55106,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -55242,7 +55242,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.relationType:
@@ -55782,7 +55782,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/beta/Mail.yml
+++ b/openApiDocs/beta/Mail.yml
@@ -8928,7 +8928,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassificationOverride:
@@ -8991,36 +8991,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRule:
@@ -9168,31 +9168,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attachment:

--- a/openApiDocs/beta/ManagedTenants.yml
+++ b/openApiDocs/beta/ManagedTenants.yml
@@ -10438,193 +10438,193 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.aggregatedPolicyCompliance'
               description: Aggregate view of device compliance policies across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             auditEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.auditEvent'
               description: The collection of audit events across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             cloudPcConnections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.cloudPcConnection'
               description: The collection of cloud PC connections across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             cloudPcDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.cloudPcDevice'
               description: The collection of cloud PC devices across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             cloudPcsOverview:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.cloudPcOverview'
               description: Overview of cloud PC information across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             conditionalAccessPolicyCoverages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.conditionalAccessPolicyCoverage'
               description: Aggregate view of conditional access policy coverage across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             credentialUserRegistrationsSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.credentialUserRegistrationsSummary'
               description: Summary information for user registration for multi-factor authentication and self service password reset across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicySettingStateSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.deviceCompliancePolicySettingStateSummary'
               description: Summary information for device compliance policy setting states across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceCompliances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedDeviceCompliance'
               description: The collection of compliance for managed devices across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceComplianceTrends:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedDeviceComplianceTrend'
               description: Trend insights for device compliance across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedTenantAlertLogs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantAlertLog'
-              readOnly: true
+              x-ms-navigationProperty: true
             managedTenantAlertRuleDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantAlertRuleDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             managedTenantAlertRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantAlertRule'
-              readOnly: true
+              x-ms-navigationProperty: true
             managedTenantAlerts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantAlert'
-              readOnly: true
+              x-ms-navigationProperty: true
             managedTenantApiNotifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantApiNotification'
-              readOnly: true
+              x-ms-navigationProperty: true
             managedTenantEmailNotifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantEmailNotification'
-              readOnly: true
+              x-ms-navigationProperty: true
             managedTenantTicketingEndpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantTicketingEndpoint'
-              readOnly: true
+              x-ms-navigationProperty: true
             managementActions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementAction'
               description: The collection of baseline management actions across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             managementActionTenantDeploymentStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementActionTenantDeploymentStatus'
               description: The tenant level status of management actions across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             managementIntents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementIntent'
               description: The collection of baseline management intents across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             managementTemplateCollections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplateCollection'
-              readOnly: true
+              x-ms-navigationProperty: true
             managementTemplateCollectionTenantSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplateCollectionTenantSummary'
-              readOnly: true
+              x-ms-navigationProperty: true
             managementTemplates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplate'
               description: The collection of baseline management templates across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             managementTemplateSteps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplateStep'
-              readOnly: true
+              x-ms-navigationProperty: true
             managementTemplateStepTenantSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplateStepTenantSummary'
-              readOnly: true
+              x-ms-navigationProperty: true
             managementTemplateStepVersions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplateStepVersion'
-              readOnly: true
+              x-ms-navigationProperty: true
             myRoles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.myRole'
               description: The collection of role assignments to a signed-in user for a managed tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             tenantGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.tenantGroup'
               description: The collection of a logical grouping of managed tenants used by the multi-tenant management platform.
-              readOnly: true
+              x-ms-navigationProperty: true
             tenants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.tenant'
               description: The collection of tenants associated with the managing entity.
-              readOnly: true
+              x-ms-navigationProperty: true
             tenantsCustomizedInformation:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.tenantCustomizedInformation'
               description: The collection of tenant level customized information across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             tenantsDetailedInformation:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.tenantDetailedInformation'
               description: The collection tenant level detailed information across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             tenantTags:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.tenantTag'
               description: The collection of tenant tags across managed tenants.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsDeviceMalwareStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.windowsDeviceMalwareState'
               description: 'The state of malware for Windows devices, registered with Microsoft Endpoint Manager, across managed tenants.'
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.windowsProtectionState'
               description: 'The protection state for Windows devices, registered with Microsoft Endpoint Manager, across managed tenants.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.managedTenants.aggregatedPolicyCompliance:
@@ -11373,19 +11373,19 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantAlertLog'
-              readOnly: true
+              x-ms-navigationProperty: true
             alertRule:
               $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantAlertRule'
             apiNotifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantApiNotification'
-              readOnly: true
+              x-ms-navigationProperty: true
             emailNotifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantEmailNotification'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.managedTenants.managedTenantAlertRuleDefinition:
@@ -11419,7 +11419,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantAlertRule'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.managedTenants.managedTenantAlertRule:
@@ -11480,7 +11480,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantAlert'
-              readOnly: true
+              x-ms-navigationProperty: true
             ruleDefinition:
               $ref: '#/components/schemas/microsoft.graph.managedTenants.managedTenantAlertRuleDefinition'
           additionalProperties:
@@ -11696,7 +11696,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplate'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.managedTenants.managementTemplate:
@@ -11765,12 +11765,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplateCollection'
-              readOnly: true
+              x-ms-navigationProperty: true
             managementTemplateSteps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplateStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.managedTenants.managementTemplateCollectionTenantSummary:
@@ -11903,7 +11903,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplateStepVersion'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.managedTenants.managementTemplateStepVersion:
@@ -11949,7 +11949,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplateStepDeployment'
-              readOnly: true
+              x-ms-navigationProperty: true
             templateStep:
               $ref: '#/components/schemas/microsoft.graph.managedTenants.managementTemplateStep'
           additionalProperties:

--- a/openApiDocs/beta/Notes.yml
+++ b/openApiDocs/beta/Notes.yml
@@ -21973,37 +21973,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -22037,13 +22037,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sectionGroup:
@@ -22069,13 +22069,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -22099,7 +22099,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:

--- a/openApiDocs/beta/People.yml
+++ b/openApiDocs/beta/People.yml
@@ -6234,7 +6234,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.activityStatistics:
@@ -6369,115 +6369,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userAccountInformation:

--- a/openApiDocs/beta/PersonalContacts.yml
+++ b/openApiDocs/beta/PersonalContacts.yml
@@ -6392,25 +6392,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -6545,13 +6545,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -6559,7 +6559,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.extension:

--- a/openApiDocs/beta/Planner.yml
+++ b/openApiDocs/beta/Planner.yml
@@ -13119,7 +13119,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -13157,7 +13157,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -13165,7 +13165,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerBucket:
@@ -13192,7 +13192,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -13394,25 +13394,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Returns a collection of the specified buckets
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns a collection of the specified plans
-              readOnly: true
+              x-ms-navigationProperty: true
             rosters:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerRoster'
               description: Read-only. Nullable. Returns a collection of the specified rosters
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns a collection of the specified tasks
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerRoster:
@@ -13426,13 +13426,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerRosterMember'
               description: Retrieves the members of the plannerRoster.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Retrieves the plans contained by the plannerRoster.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerRosterMember:
@@ -13471,36 +13471,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerDelta:

--- a/openApiDocs/beta/Reports.yml
+++ b/openApiDocs/beta/Reports.yml
@@ -10255,22 +10255,22 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.directoryAudit'
-          readOnly: true
+          x-ms-navigationProperty: true
         directoryProvisioning:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.provisioningObjectSummary'
-          readOnly: true
+          x-ms-navigationProperty: true
         provisioning:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.provisioningObjectSummary'
-          readOnly: true
+          x-ms-navigationProperty: true
         signIns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.signIn'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.directoryAudit:
@@ -10648,13 +10648,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementCachedReportConfiguration'
               description: Entity representing the configuration of a cached report
-              readOnly: true
+              x-ms-navigationProperty: true
             exportJobs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementExportJob'
               description: Entity representing a job to export a report
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Singleton entity that acts as a container for all reports functionality.
@@ -10760,7 +10760,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.applicationSignInDetailedSummary'
               description: Represents a detailed summary of an application sign-in.
-              readOnly: true
+              x-ms-navigationProperty: true
             authenticationMethods:
               $ref: '#/components/schemas/microsoft.graph.authenticationMethodsRoot'
             credentialUserRegistrationDetails:
@@ -10768,58 +10768,58 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.credentialUserRegistrationDetails'
               description: Details of the usage of self-service password reset and multi-factor authentication (MFA) for all registered users.
-              readOnly: true
+              x-ms-navigationProperty: true
             userCredentialUsageDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userCredentialUsageDetails'
               description: Represents the self-service password reset (SSPR) usage for a given tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             dailyPrintUsage:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsage'
-              readOnly: true
+              x-ms-navigationProperty: true
             dailyPrintUsageByPrinter:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByPrinter'
-              readOnly: true
+              x-ms-navigationProperty: true
             dailyPrintUsageByUser:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByUser'
-              readOnly: true
+              x-ms-navigationProperty: true
             dailyPrintUsageSummariesByPrinter:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByPrinter'
-              readOnly: true
+              x-ms-navigationProperty: true
             dailyPrintUsageSummariesByUser:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByUser'
-              readOnly: true
+              x-ms-navigationProperty: true
             monthlyPrintUsageByPrinter:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByPrinter'
-              readOnly: true
+              x-ms-navigationProperty: true
             monthlyPrintUsageByUser:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByUser'
-              readOnly: true
+              x-ms-navigationProperty: true
             monthlyPrintUsageSummariesByPrinter:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByPrinter'
-              readOnly: true
+              x-ms-navigationProperty: true
             monthlyPrintUsageSummariesByUser:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printUsageByUser'
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.securityReportsRoot'
           additionalProperties:
@@ -10862,7 +10862,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userRegistrationDetails'
               description: 'Represents the state of a user''s authentication methods, including which methods are registered and which features the user is registered and capable of (such as multi-factor authentication, self-service password reset, and passwordless authentication).'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userRegistrationFeatureSummary:

--- a/openApiDocs/beta/Search.yml
+++ b/openApiDocs/beta/Search.yml
@@ -2817,7 +2817,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.externalConnectors.externalConnection'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.externalConnectors.externalConnection:
@@ -2859,17 +2859,17 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalConnectors.externalGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalConnectors.externalItem'
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalConnectors.connectionOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             quota:
               $ref: '#/components/schemas/microsoft.graph.externalConnectors.connectionQuota'
             schema:
@@ -2895,7 +2895,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalConnectors.identity'
               description: 'A member added to an externalGroup. You can add Azure Active Directory users, Azure Active Directory groups, or other externalGroups as members.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.externalConnectors.identity:
@@ -2928,7 +2928,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalConnectors.externalActivity'
               description: Write-only property. Returns results.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.externalConnectors.externalActivity:
@@ -3010,19 +3010,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.search.acronym'
               description: Administrative answer in Microsoft Search results to define common acronyms in a organization.
-              readOnly: true
+              x-ms-navigationProperty: true
             bookmarks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.search.bookmark'
               description: Administrative answer in Microsoft Search results for common search queries in an organization.
-              readOnly: true
+              x-ms-navigationProperty: true
             qnas:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.search.qna'
               description: Administrative answer in Microsoft Search results which provide answers for specific search keywords in an organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.search.acronym:

--- a/openApiDocs/beta/Security.yml
+++ b/openApiDocs/beta/Security.yml
@@ -17244,7 +17244,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subjectRightsRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             cases:
               $ref: '#/components/schemas/microsoft.graph.security.casesRoot'
             informationProtection:
@@ -17254,13 +17254,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.alert'
               description: A collection of alerts in Microsoft 365 Defender.
-              readOnly: true
+              x-ms-navigationProperty: true
             incidents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.incident'
               description: 'A collection of incidents in Microsoft 365 Defender, each of which is a set of correlated alerts and associated metadata that reflects the story of an attack.'
-              readOnly: true
+              x-ms-navigationProperty: true
             attackSimulation:
               $ref: '#/components/schemas/microsoft.graph.attackSimulationRoot'
             labels:
@@ -17276,63 +17276,63 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.alert'
               description: Notifications for suspicious or potential security issues in a customer’s tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             cloudAppSecurityProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudAppSecurityProfile'
-              readOnly: true
+              x-ms-navigationProperty: true
             domainSecurityProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.domainSecurityProfile'
-              readOnly: true
+              x-ms-navigationProperty: true
             fileSecurityProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fileSecurityProfile'
-              readOnly: true
+              x-ms-navigationProperty: true
             hostSecurityProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.hostSecurityProfile'
-              readOnly: true
+              x-ms-navigationProperty: true
             ipSecurityProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.ipSecurityProfile'
-              readOnly: true
+              x-ms-navigationProperty: true
             providerTenantSettings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.providerTenantSetting'
-              readOnly: true
+              x-ms-navigationProperty: true
             secureScoreControlProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.secureScoreControlProfile'
-              readOnly: true
+              x-ms-navigationProperty: true
             secureScores:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.secureScore'
               description: Measurements of tenants’ security posture to help protect them from threats.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityActions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityAction'
-              readOnly: true
+              x-ms-navigationProperty: true
             tiIndicators:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tiIndicator'
-              readOnly: true
+              x-ms-navigationProperty: true
             userSecurityProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userSecurityProfile'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.alert:
@@ -17659,25 +17659,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attackSimulationOperation'
               description: Represents an attack simulation training operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             payloads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.payload'
               description: Represents an attack simulation training campaign payload in a tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             simulationAutomations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.simulationAutomation'
               description: Represents simulation automation created to run on a tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             simulations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.simulation'
               description: Represents an attack simulation training campaign in a tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attackSimulationOperation:
@@ -17828,7 +17828,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.simulationAutomationRun'
               description: A collection of simulation automation runs.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.simulationAutomationRun:
@@ -17942,7 +17942,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryCase'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.ediscoveryCase:
@@ -17968,37 +17968,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryCustodian'
               description: Returns a list of case ediscoveryCustodian objects for this case.
-              readOnly: true
+              x-ms-navigationProperty: true
             legalHolds:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryHoldPolicy'
               description: Returns a list of case eDiscoveryHoldPolicy objects for this case.
-              readOnly: true
+              x-ms-navigationProperty: true
             noncustodialDataSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryNoncustodialDataSource'
               description: Returns a list of case ediscoveryNoncustodialDataSource objects for this case.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.caseOperation'
               description: Returns a list of case caseOperation objects for this case.
-              readOnly: true
+              x-ms-navigationProperty: true
             reviewSets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewSet'
               description: Returns a list of eDiscoveryReviewSet objects in the case.
-              readOnly: true
+              x-ms-navigationProperty: true
             searches:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoverySearch'
               description: Returns a list of eDiscoverySearch objects associated with this case.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               $ref: '#/components/schemas/microsoft.graph.security.ediscoveryCaseSettings'
             tags:
@@ -18006,7 +18006,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewTag'
               description: Returns a list of ediscoveryReviewTag objects associated to this case.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.ediscoveryCustodian:
@@ -18032,19 +18032,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.siteSource'
               description: Data source entity for SharePoint sites associated with the custodian.
-              readOnly: true
+              x-ms-navigationProperty: true
             unifiedGroupSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.unifiedGroupSource'
               description: Data source entity for groups associated with the custodian.
-              readOnly: true
+              x-ms-navigationProperty: true
             userSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.userSource'
               description: Data source entity for a custodian. This is the container for a custodian's mailbox and OneDrive for Business site.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.ediscoveryIndexOperation:
@@ -18093,13 +18093,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -18107,49 +18107,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -18393,7 +18393,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -18401,61 +18401,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -18463,31 +18463,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -18495,25 +18495,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -18525,7 +18525,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -18572,13 +18572,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.siteSource'
               description: Data sources that represent SharePoint sites.
-              readOnly: true
+              x-ms-navigationProperty: true
             userSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.userSource'
               description: Data sources that represent Exchange mailboxes.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.ediscoveryNoncustodialDataSource:
@@ -18661,13 +18661,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryFile'
               description: Represents files within the review set.
-              readOnly: true
+              x-ms-navigationProperty: true
             queries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewSetQuery'
               description: Represents queries within the review set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.ediscoveryFile:
@@ -18683,7 +18683,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewTag'
               description: Tags associated with the file.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.ediscoveryReviewTag:
@@ -18699,7 +18699,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewTag'
               description: Returns the tags that are a child of a tag.
-              readOnly: true
+              x-ms-navigationProperty: true
             parent:
               $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewTag'
           additionalProperties:
@@ -18717,7 +18717,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.dataSource'
               description: Adds an additional source to the eDiscovery search.
-              readOnly: true
+              x-ms-navigationProperty: true
             addToReviewSetOperation:
               $ref: '#/components/schemas/microsoft.graph.security.ediscoveryAddToReviewSetOperation'
             custodianSources:
@@ -18725,7 +18725,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.dataSource'
               description: Custodian sources that are included in the eDiscovery search.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastEstimateStatisticsOperation:
               $ref: '#/components/schemas/microsoft.graph.security.ediscoveryEstimateOperation'
             noncustodialSources:
@@ -18733,7 +18733,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryNoncustodialDataSource'
               description: noncustodialDataSource sources that are included in the eDiscovery search
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.additionalDataOptions:
@@ -19179,7 +19179,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.alert'
               description: The list of related alerts. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.informationProtection:
@@ -19195,7 +19195,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.informationProtectionPolicySetting:
@@ -19431,7 +19431,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.retentionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.retentionLabel:
@@ -19491,7 +19491,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.dispositionReviewStage'
               description: Review stages during which reviewers are notified to determine whether a document must be deleted or retained.
-              readOnly: true
+              x-ms-navigationProperty: true
             retentionEventType:
               $ref: '#/components/schemas/microsoft.graph.security.retentionEventType'
           additionalProperties:
@@ -19906,7 +19906,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.authoredNote'
               description: List of notes associated with the request.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -19994,13 +19994,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -20008,37 +20008,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -20048,7 +20048,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -20067,22 +20067,22 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.emailThreatSubmission'
-              readOnly: true
+              x-ms-navigationProperty: true
             emailThreatSubmissionPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.emailThreatSubmissionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             fileThreats:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.fileThreatSubmission'
-              readOnly: true
+              x-ms-navigationProperty: true
             urlThreats:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.urlThreatSubmission'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.emailThreatSubmission:
@@ -20459,7 +20459,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.retentionEvent'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.retentionEvent:
@@ -20529,7 +20529,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.retentionEventType'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSecurityProfile:
@@ -21784,12 +21784,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -21798,7 +21798,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemAnalytics:
@@ -21813,7 +21813,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -21979,25 +21979,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -22023,25 +22023,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -22051,7 +22051,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -22075,17 +22075,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -22093,19 +22093,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -22174,7 +22174,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -22243,13 +22243,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -22263,37 +22263,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.sourceType:
@@ -22609,31 +22609,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -22763,38 +22763,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversation:
@@ -22827,7 +22827,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -22872,7 +22872,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.extension:
@@ -22916,7 +22916,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -23940,25 +23940,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -24390,43 +24390,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -24434,48 +24434,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -24483,56 +24483,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -24540,7 +24540,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -24548,40 +24548,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -24589,48 +24589,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -24645,24 +24645,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -24671,13 +24671,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -24716,7 +24716,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -24823,56 +24823,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.threatSubmission:
@@ -26014,7 +26014,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -26076,7 +26076,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -26108,7 +26108,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -26140,7 +26140,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityStat:
@@ -26182,7 +26182,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -26495,12 +26495,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -26678,7 +26678,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -26686,7 +26686,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -26694,25 +26694,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listInfo:
@@ -26750,7 +26750,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -26758,7 +26758,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -26768,7 +26768,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -26970,7 +26970,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -27077,7 +27077,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -27111,7 +27111,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -27119,13 +27119,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -27159,13 +27159,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -27284,13 +27284,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -27314,7 +27314,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -27694,32 +27694,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -27757,7 +27757,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -27765,7 +27765,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.policyStatus:
@@ -28000,13 +28000,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharedWithChannelTeamInfo:
@@ -28024,7 +28024,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTab:
@@ -28078,7 +28078,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -28466,7 +28466,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -28482,7 +28482,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -28757,100 +28757,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -28957,7 +28957,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -28983,25 +28983,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -29136,13 +29136,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -29150,7 +29150,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -29164,7 +29164,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -29215,36 +29215,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -29355,31 +29355,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -29393,22 +29393,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -29531,7 +29531,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -29544,7 +29544,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -29591,13 +29591,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -29605,7 +29605,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -29729,7 +29729,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -30092,37 +30092,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -30130,19 +30130,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -30224,19 +30224,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -30353,7 +30353,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -30405,36 +30405,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -30476,115 +30476,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -30636,7 +30636,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -30807,43 +30807,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -30966,7 +30966,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -30976,7 +30976,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -31010,65 +31010,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -31112,7 +31112,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -31120,37 +31120,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -31164,13 +31164,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -31184,7 +31184,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagType:
@@ -32000,13 +32000,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -32566,7 +32566,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -32574,25 +32574,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnailSet:
@@ -32782,7 +32782,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -32798,7 +32798,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -33297,7 +33297,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -33793,13 +33793,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -34270,7 +34270,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -34361,13 +34361,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -34572,19 +34572,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -34616,7 +34616,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -34668,19 +34668,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -34884,7 +34884,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -34960,7 +34960,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -35000,7 +35000,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -36401,7 +36401,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -36440,7 +36440,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -36690,7 +36690,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -36936,19 +36936,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -37929,7 +37929,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -37979,7 +37979,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -38361,13 +38361,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequest:
@@ -39105,7 +39105,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -39205,13 +39205,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -39242,19 +39242,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -39262,7 +39262,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -39399,7 +39399,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.relationType:
@@ -39889,7 +39889,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -39935,7 +39935,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -39943,13 +39943,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -40090,7 +40090,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -42199,7 +42199,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -42350,30 +42350,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequestActor:
@@ -42586,7 +42586,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -43171,13 +43171,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -43409,7 +43409,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -44439,7 +44439,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -45730,7 +45730,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:

--- a/openApiDocs/beta/Sites.yml
+++ b/openApiDocs/beta/Sites.yml
@@ -74614,13 +74614,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -74628,49 +74628,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -74689,7 +74689,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -74855,25 +74855,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.columnLink:
@@ -74911,25 +74911,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -74939,7 +74939,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.informationProtection:
@@ -74954,12 +74954,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -74968,7 +74968,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.bitlocker:
@@ -74982,7 +74982,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.bitlockerRecoveryKey:
@@ -75028,7 +75028,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.informationProtectionLabel:
@@ -75114,7 +75114,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -75165,7 +75165,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentResult:
@@ -75252,17 +75252,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -75270,19 +75270,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityOLD:
@@ -75320,7 +75320,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -75328,7 +75328,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -75338,7 +75338,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.driveItem:
@@ -75416,7 +75416,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -75424,7 +75424,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -75432,25 +75432,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.documentSetVersion:
@@ -75601,37 +75601,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -75665,13 +75665,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sectionGroup:
@@ -75697,13 +75697,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -75727,7 +75727,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -75868,7 +75868,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.canvasLayout:
@@ -75882,7 +75882,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -75902,7 +75902,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.horizontalSectionColumn:
@@ -75923,7 +75923,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.webPart:
@@ -75946,7 +75946,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -76015,13 +76015,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.group:
@@ -76055,7 +76055,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -76089,7 +76089,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -76097,13 +76097,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.term:
@@ -76144,13 +76144,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -76479,7 +76479,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenotePatchContentCommand:
@@ -77009,12 +77009,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -77591,43 +77591,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -77635,48 +77635,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -77684,56 +77684,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -77741,7 +77741,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -77749,40 +77749,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -77790,48 +77790,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -77846,24 +77846,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -77872,13 +77872,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -78448,7 +78448,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -78456,25 +78456,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnailSet:
@@ -80023,7 +80023,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -80039,7 +80039,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -80314,100 +80314,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -80602,31 +80602,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -80654,7 +80654,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -80784,38 +80784,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -80841,25 +80841,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -80994,13 +80994,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -81008,7 +81008,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -81022,7 +81022,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -81250,7 +81250,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -81258,61 +81258,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -81320,31 +81320,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -81352,25 +81352,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -81382,7 +81382,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -81435,36 +81435,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -81575,31 +81575,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -81613,22 +81613,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -81758,7 +81758,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -81771,7 +81771,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -81818,13 +81818,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -81832,7 +81832,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -81956,7 +81956,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -82319,37 +82319,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -82357,19 +82357,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -82451,19 +82451,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -82580,7 +82580,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -82632,36 +82632,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -82725,115 +82725,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -82885,7 +82885,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -83056,43 +83056,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -83215,7 +83215,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -83225,7 +83225,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -83259,65 +83259,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -83361,7 +83361,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -83369,37 +83369,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -83467,13 +83467,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -83481,37 +83481,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -83521,7 +83521,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -83541,13 +83541,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -83561,7 +83561,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.commentAction:
@@ -83780,7 +83780,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -83880,13 +83880,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -83917,19 +83917,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -83937,7 +83937,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -84302,13 +84302,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -84779,7 +84779,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -84896,13 +84896,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -85481,7 +85481,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -85526,7 +85526,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -85563,7 +85563,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRule:
@@ -85728,19 +85728,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -85772,7 +85772,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -85824,19 +85824,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -86040,7 +86040,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -86116,7 +86116,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -86156,7 +86156,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -86179,7 +86179,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceEnrollmentConfigurationType:
@@ -87573,7 +87573,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -87612,7 +87612,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -87862,7 +87862,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -88139,7 +88139,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -88147,7 +88147,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -88277,19 +88277,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -89270,7 +89270,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -89320,7 +89320,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -89786,13 +89786,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAsyncOperation:
@@ -90068,25 +90068,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTag:
@@ -90121,7 +90121,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -90228,56 +90228,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -90320,13 +90320,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mediaSourceContentCategory:
@@ -90472,7 +90472,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -90729,7 +90729,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -90775,7 +90775,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -90783,13 +90783,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -90930,7 +90930,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -91297,32 +91297,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRuleActions:
@@ -92929,7 +92929,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -93615,7 +93615,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -93720,7 +93720,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -94055,7 +94055,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagType:
@@ -94389,30 +94389,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilter:
@@ -94558,7 +94558,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -95119,13 +95119,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -95357,7 +95357,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -98178,7 +98178,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:

--- a/openApiDocs/beta/Teams.yml
+++ b/openApiDocs/beta/Teams.yml
@@ -61922,7 +61922,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -62051,7 +62051,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -62059,37 +62059,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -62260,13 +62260,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chatMessageHostedContent:
@@ -62516,13 +62516,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -62530,37 +62530,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -62570,7 +62570,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -62627,25 +62627,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.driveItem:
@@ -62723,7 +62723,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -62731,7 +62731,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -62739,25 +62739,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharedWithChannelTeamInfo:
@@ -62775,7 +62775,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -63003,7 +63003,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -63011,61 +63011,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -63073,31 +63073,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -63105,25 +63105,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -63135,7 +63135,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -63495,43 +63495,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -63539,48 +63539,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -63588,56 +63588,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -63645,7 +63645,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -63653,40 +63653,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -63694,48 +63694,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -63750,24 +63750,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -63776,13 +63776,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -63863,56 +63863,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.offerShiftRequest:
@@ -64151,7 +64151,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagMember:
@@ -64264,19 +64264,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workforceIntegration'
               description: A workforce integration with shifts.
-              readOnly: true
+              x-ms-navigationProperty: true
             deletedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deletedTeam'
               description: A collection of deleted teams.
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkDevice'
               description: The Teams devices provisioned for the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamsAppSettings:
               $ref: '#/components/schemas/microsoft.graph.teamsAppSettings'
             teamTemplates:
@@ -64284,7 +64284,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamTemplate'
               description: The templates associated with a team.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deletedTeam:
@@ -64298,7 +64298,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The channels those are either shared with this deleted team or created in this deleted team.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkDevice:
@@ -64352,7 +64352,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkDeviceOperation'
               description: The async operations on the device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkDeviceActivity:
@@ -64534,7 +64534,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamTemplateDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workforceIntegration:
@@ -64583,13 +64583,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -65742,7 +65742,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -65750,25 +65750,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityOLD:
@@ -65801,7 +65801,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -65823,7 +65823,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -65831,7 +65831,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -65841,7 +65841,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -66272,31 +66272,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -66426,38 +66426,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversation:
@@ -66490,7 +66490,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -66535,7 +66535,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -66561,25 +66561,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -66589,7 +66589,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -66621,13 +66621,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -66635,49 +66635,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -66725,7 +66725,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -66739,37 +66739,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.signInActivity:
@@ -67073,7 +67073,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -67089,7 +67089,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -67208,12 +67208,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -67222,7 +67222,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePrincipal:
@@ -67393,100 +67393,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -67593,7 +67593,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -67619,25 +67619,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -67772,13 +67772,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -67786,7 +67786,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -67800,7 +67800,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -67851,36 +67851,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -67991,31 +67991,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -68029,22 +68029,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -68167,7 +68167,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -68180,7 +68180,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -68227,13 +68227,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -68241,7 +68241,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -68365,7 +68365,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -68728,37 +68728,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -68766,19 +68766,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -68860,19 +68860,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -68989,7 +68989,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -69041,36 +69041,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -69112,115 +69112,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -69272,7 +69272,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -69443,43 +69443,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -69602,7 +69602,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -69612,7 +69612,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -69646,65 +69646,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -69718,7 +69718,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.operationStatus:
@@ -70040,7 +70040,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.teamworkPeripheral'
-          readOnly: true
+          x-ms-navigationProperty: true
         defaultContentCamera:
           $ref: '#/components/schemas/microsoft.graph.teamworkPeripheral'
       additionalProperties:
@@ -70101,7 +70101,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.teamworkPeripheral'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.teamworkDeviceSoftwareVersions:
@@ -70150,7 +70150,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.teamworkPeripheral'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.teamworkSystemConfiguration:
@@ -71087,7 +71087,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -71187,13 +71187,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -71224,19 +71224,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -71244,7 +71244,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActionSet:
@@ -71335,7 +71335,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contentTypeInfo:
@@ -71886,32 +71886,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.quota:
@@ -71972,17 +71972,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -71990,19 +71990,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.siteSettings:
@@ -72196,25 +72196,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -72283,7 +72283,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.store:
@@ -72305,13 +72305,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -72349,7 +72349,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -72357,7 +72357,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -72391,13 +72391,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -72516,13 +72516,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -72546,7 +72546,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -72665,13 +72665,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -72893,7 +72893,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -72955,7 +72955,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -72987,7 +72987,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -73019,7 +73019,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.passwordSingleSignOnSettings:
@@ -73282,7 +73282,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -73373,13 +73373,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -73668,19 +73668,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -73712,7 +73712,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -73764,19 +73764,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -73980,7 +73980,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -74056,7 +74056,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -74096,7 +74096,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -74119,7 +74119,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceEnrollmentConfigurationType:
@@ -75513,7 +75513,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -75552,7 +75552,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -75802,7 +75802,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -76171,19 +76171,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -77164,7 +77164,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -77214,7 +77214,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -77533,13 +77533,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequestActor:
@@ -78025,7 +78025,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -78735,12 +78735,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -78882,7 +78882,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -78925,7 +78925,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -78959,7 +78959,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -78967,13 +78967,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanContainer:
@@ -79039,7 +79039,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -79242,7 +79242,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -79288,7 +79288,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -79296,13 +79296,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -79619,7 +79619,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -81930,7 +81930,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -82080,30 +82080,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleEntityTheme:
@@ -82330,7 +82330,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -82469,13 +82469,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -82561,7 +82561,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -82577,7 +82577,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.termGroupScope:
@@ -83247,13 +83247,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -83537,7 +83537,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -84717,7 +84717,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.relationType:
@@ -85946,7 +85946,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:

--- a/openApiDocs/beta/Users.Actions.yml
+++ b/openApiDocs/beta/Users.Actions.yml
@@ -34592,7 +34592,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -34804,7 +34804,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -34812,7 +34812,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -34820,25 +34820,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.driveItemUploadableProperties:
@@ -34956,25 +34956,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dlpEvaluationInput:
@@ -35315,31 +35315,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -35390,36 +35390,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceLogCollectionRequest:
@@ -36011,7 +36011,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -36021,7 +36021,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -36073,19 +36073,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presenceStatusMessage:
@@ -37147,7 +37147,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -37155,25 +37155,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityOLD:
@@ -37206,7 +37206,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -37228,7 +37228,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -37236,7 +37236,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -37246,7 +37246,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -37392,12 +37392,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -38263,7 +38263,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -38313,7 +38313,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -38854,43 +38854,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -38898,48 +38898,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -38947,56 +38947,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -39004,7 +39004,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -39012,40 +39012,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -39053,48 +39053,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -39109,24 +39109,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -39135,13 +39135,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -39450,7 +39450,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -39550,13 +39550,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -39587,19 +39587,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -39607,7 +39607,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActionSet:
@@ -39698,7 +39698,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contentTypeInfo:
@@ -40514,7 +40514,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -40993,7 +40993,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -41009,7 +41009,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -41128,12 +41128,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -41142,7 +41142,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePrincipal:
@@ -41313,100 +41313,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -41601,31 +41601,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -41653,7 +41653,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -41783,38 +41783,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -41840,25 +41840,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -41993,13 +41993,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -42007,7 +42007,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -42021,7 +42021,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -42249,7 +42249,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -42257,61 +42257,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -42319,31 +42319,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -42351,25 +42351,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -42381,7 +42381,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -42397,22 +42397,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -42531,25 +42531,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -42559,7 +42559,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -42591,13 +42591,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -42605,49 +42605,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -42681,7 +42681,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -42694,7 +42694,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -42741,13 +42741,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -42755,7 +42755,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -43189,37 +43189,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -43227,19 +43227,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -43321,19 +43321,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -43450,7 +43450,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -43502,36 +43502,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -43574,37 +43574,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -43639,115 +43639,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -43799,7 +43799,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -43970,43 +43970,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -44040,65 +44040,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -44142,7 +44142,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -44150,37 +44150,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -44248,13 +44248,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -44262,37 +44262,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -44302,7 +44302,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -44322,13 +44322,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -44342,7 +44342,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingTimeSuggestion:
@@ -44582,7 +44582,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -44833,13 +44833,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -44875,7 +44875,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -44883,13 +44883,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.displayNameLocalization:
@@ -45264,13 +45264,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -45478,7 +45478,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -45540,7 +45540,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -45572,7 +45572,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -45604,7 +45604,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.passwordSingleSignOnSettings:
@@ -45867,7 +45867,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -45984,13 +45984,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -46358,7 +46358,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -46403,7 +46403,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -46440,7 +46440,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookCategory:
@@ -46486,19 +46486,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -46530,7 +46530,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -46616,17 +46616,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -46634,19 +46634,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.siteSettings:
@@ -46745,7 +46745,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.store:
@@ -46767,13 +46767,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appConsentRequestScope:
@@ -46952,7 +46952,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -47028,7 +47028,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -47068,7 +47068,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -47091,7 +47091,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chassisType:
@@ -48407,7 +48407,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -48446,7 +48446,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -48644,7 +48644,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -48921,7 +48921,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -48929,7 +48929,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -49059,19 +49059,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -49166,13 +49166,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenotePage:
@@ -49269,13 +49269,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -49299,7 +49299,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -50425,13 +50425,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAsyncOperation:
@@ -50707,25 +50707,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTag:
@@ -50760,7 +50760,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -50867,56 +50867,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -50959,13 +50959,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attendeeAvailability:
@@ -51121,7 +51121,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -51296,7 +51296,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.classificationInnerError:
@@ -51436,7 +51436,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -51482,7 +51482,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -51490,13 +51490,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -51783,7 +51783,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -51998,32 +51998,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.categoryColor:
@@ -52178,7 +52178,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -53524,7 +53524,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -54209,7 +54209,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -54544,7 +54544,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagType:
@@ -54878,30 +54878,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilterCriteria:
@@ -55552,13 +55552,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -55805,7 +55805,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -55889,7 +55889,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -55905,7 +55905,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.decisionItemPrincipalResourceMembershipType:
@@ -58458,7 +58458,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:
@@ -58756,7 +58756,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.settingSourceType:

--- a/openApiDocs/beta/Users.Functions.yml
+++ b/openApiDocs/beta/Users.Functions.yml
@@ -18285,7 +18285,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.consentRequestFilterByCurrentUserOptions:
@@ -18335,7 +18335,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approvalFilterByCurrentUserOptions:
@@ -18356,7 +18356,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -18486,38 +18486,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarRoleType:
@@ -18630,13 +18630,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPcConnectivityEvent:
@@ -18829,13 +18829,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -18843,7 +18843,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -18869,25 +18869,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -19058,43 +19058,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityStat:
@@ -19136,7 +19136,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.driveItem:
@@ -19214,7 +19214,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -19222,7 +19222,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -19230,25 +19230,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contentType:
@@ -19314,25 +19314,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -19352,7 +19352,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -19360,7 +19360,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -19370,7 +19370,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -19598,7 +19598,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -19606,61 +19606,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -19668,31 +19668,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -19700,25 +19700,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -19730,7 +19730,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -19843,31 +19843,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -19918,36 +19918,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPcRemoteActionResult:
@@ -20323,7 +20323,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -20371,7 +20371,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstanceFilterByCurrentUserOptions:
@@ -20424,13 +20424,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -20438,7 +20438,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerDelta:
@@ -20507,30 +20507,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todoTaskList:
@@ -20556,13 +20556,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.user:
@@ -20920,43 +20920,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -20964,48 +20964,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -21013,56 +21013,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -21070,7 +21070,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -21078,40 +21078,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -21119,48 +21119,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -21175,24 +21175,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -21201,13 +21201,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -21684,31 +21684,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.extension:
@@ -22837,7 +22837,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -22845,25 +22845,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityOLD:
@@ -22896,7 +22896,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -23077,12 +23077,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -23576,7 +23576,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -23621,7 +23621,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -23647,25 +23647,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -23675,7 +23675,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -23707,13 +23707,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -23721,49 +23721,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -23804,7 +23804,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -23818,37 +23818,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -23916,13 +23916,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -23930,37 +23930,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -23970,7 +23970,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -24412,7 +24412,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.taskStatus:
@@ -24771,7 +24771,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -24787,7 +24787,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -24890,12 +24890,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -24904,7 +24904,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePrincipal:
@@ -25075,100 +25075,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -25275,7 +25275,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -25289,7 +25289,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -25303,22 +25303,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -25535,7 +25535,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -25898,37 +25898,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -25936,19 +25936,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -26030,19 +26030,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -26159,7 +26159,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -26211,36 +26211,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -26282,115 +26282,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -26513,7 +26513,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -26523,7 +26523,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -26557,65 +26557,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -26659,7 +26659,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -26667,37 +26667,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -26711,13 +26711,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -26731,7 +26731,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.ODataError:
@@ -27370,7 +27370,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -27470,13 +27470,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -27507,19 +27507,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -27527,7 +27527,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActionSet:
@@ -28051,32 +28051,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.quota:
@@ -28137,17 +28137,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -28155,19 +28155,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.siteSettings:
@@ -28266,7 +28266,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.store:
@@ -28288,13 +28288,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -28332,7 +28332,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -28340,7 +28340,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -28374,13 +28374,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -28499,13 +28499,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -28529,7 +28529,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -28731,25 +28731,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -28858,7 +28858,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -28965,56 +28965,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRuleActions:
@@ -29494,13 +29494,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -29660,7 +29660,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -29722,7 +29722,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -29754,7 +29754,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -29786,7 +29786,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.passwordSingleSignOnSettings:
@@ -30049,7 +30049,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -30140,13 +30140,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePlanInfo:
@@ -30228,19 +30228,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTaskGroup:
@@ -30272,7 +30272,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookTask:
@@ -30324,19 +30324,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rankedEmailAddress:
@@ -30384,7 +30384,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceEnrollmentConfigurationType:
@@ -31778,7 +31778,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -31817,7 +31817,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -32067,7 +32067,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -32393,19 +32393,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userInsightsSettings:
@@ -33251,7 +33251,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -33301,7 +33301,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -33978,7 +33978,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -34168,13 +34168,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -34210,7 +34210,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -34218,13 +34218,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.displayNameLocalization:
@@ -34388,7 +34388,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -34431,7 +34431,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanContainer:
@@ -34497,7 +34497,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -34707,7 +34707,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsApp:
@@ -34731,7 +34731,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -35179,7 +35179,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -35225,7 +35225,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -35233,13 +35233,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -35545,7 +35545,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -37278,7 +37278,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -37582,7 +37582,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -37815,7 +37815,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -37831,7 +37831,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.termGroupScope:
@@ -38696,13 +38696,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -38978,7 +38978,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -39969,7 +39969,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequestActor:
@@ -41259,7 +41259,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:

--- a/openApiDocs/beta/Users.yml
+++ b/openApiDocs/beta/Users.yml
@@ -13334,43 +13334,43 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
-              readOnly: true
+              x-ms-navigationProperty: true
             usageRights:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a user has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             informationProtection:
               $ref: '#/components/schemas/microsoft.graph.informationProtection'
             appRoleAssignedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.servicePrincipal'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -13378,48 +13378,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, directory roles and administrative units that the user is a member of. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: The scoped-role administrative unit memberships for this user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The transitive reports for a user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -13427,56 +13427,56 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             joinedGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
-              readOnly: true
+              x-ms-navigationProperty: true
             mailFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -13484,7 +13484,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: 'Read-only. The most relevant people to the user. The collection is ordered by their relevance to the user, which is determined by the user''s communication, collaboration and business relationships. A person is an aggregation of information from across mail, contacts and social networks.'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -13492,40 +13492,40 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             appConsentRequestsForApproval:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             approvals:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
-              readOnly: true
+              x-ms-navigationProperty: true
             pendingAccessReviewInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: Navigation property to get list of access reviews pending approval by reviewer.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             security:
               $ref: '#/components/schemas/microsoft.graph.security.security'
             deviceEnrollmentConfigurations:
@@ -13533,48 +13533,48 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: Get enrollment configurations targeted to the user
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionDeviceRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionDeviceRegistration'
               description: Zero or more WIP device registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppIntentAndStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppIntentAndState'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppTroubleshootingEvent'
               description: The list of mobile app troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             notifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notification'
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -13589,24 +13589,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             profile:
               $ref: '#/components/schemas/microsoft.graph.profile'
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
-              readOnly: true
+              x-ms-navigationProperty: true
             devices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.device'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -13615,13 +13615,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
               description: The Microsoft Teams teams that the user is a member of. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -13755,22 +13755,22 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             taskFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookCategory:
@@ -13816,19 +13816,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTask'
               description: The tasks in this task folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.multiValueLegacyExtendedProperty:
@@ -13906,19 +13906,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the task.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the task. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attachment:
@@ -13981,7 +13981,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookTaskFolder'
               description: The collection of task folders in the task group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -14100,7 +14100,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todoTaskList:
@@ -14126,13 +14126,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todoTask:
@@ -14194,30 +14194,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of smaller subtasks linked to the more complex parent task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attachmentBase:
@@ -14668,7 +14668,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.userAnalytics:
@@ -14684,7 +14684,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityStatistics'
               description: The collection of work activities that a user spent time on during and outside of working hours. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudPC:
@@ -14803,12 +14803,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.dataLossPreventionPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
             sensitivityPolicySettings:
               $ref: '#/components/schemas/microsoft.graph.sensitivityPolicySettings'
             policy:
@@ -14817,7 +14817,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.servicePrincipal:
@@ -14988,100 +14988,100 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
               description: The appManagementPolicy applied to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignedTo:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals.Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
               description: The permission classifications for delegated permissions exposed by the app that this service principal represents. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints available for discovery. Services like Sharepoint populate this property with a tenant specific SharePoint endpoints that other applications can discover and use in their experiences.
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             synchronization:
               $ref: '#/components/schemas/microsoft.graph.synchronization'
           additionalProperties:
@@ -15215,31 +15215,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -15267,7 +15267,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -15397,38 +15397,38 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             exceptionOccurrences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -15454,25 +15454,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -15607,13 +15607,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -15621,7 +15621,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -15635,7 +15635,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -15863,7 +15863,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             endpoints:
@@ -15871,61 +15871,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
               description: Endpoints for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups and administrative units that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Direct members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group who can be users or service principals. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1); Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permissions that have been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directorySetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -15933,31 +15933,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -15965,25 +15965,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -15995,7 +15995,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -16048,36 +16048,36 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             userConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -16188,31 +16188,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
               description: 'A collection of mentions in the message, ordered by the createdDateTime from the newest to the oldest. By default, a GET /messages does not return this property unless you apply $expand on the property.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -16331,25 +16331,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place under this drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             bundles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -16359,7 +16359,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -16391,13 +16391,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -16405,49 +16405,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions available in the site that are referenced from the sites in the parent hierarchy of the current site.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sitePage'
               description: The collection of pages in the SitePages list in this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             onenote:
@@ -16481,7 +16481,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approval:
@@ -16494,7 +16494,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStep'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -16541,13 +16541,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             definition:
               $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
             stages:
@@ -16555,7 +16555,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -16679,7 +16679,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -17042,37 +17042,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignmentFilterEvaluationStatusDetails'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceMobileAppConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationState'
               description: Managed device mobile app configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             securityBaselineStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineState'
               description: Security baseline states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             detectedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: All applications currently installed on the device
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             deviceHealthScriptStates:
@@ -17080,19 +17080,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceHealthScriptPolicyState'
               description: Results of device health scripts that ran for this device. Default is empty list. This property is read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             logCollectionRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceLogCollectionResponse'
               description: List of log collection requests
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsProtectionState:
               $ref: '#/components/schemas/microsoft.graph.windowsProtectionState'
           additionalProperties:
@@ -17174,19 +17174,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -17303,7 +17303,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appLogCollectionRequest'
               description: The collection property of AppLogUploadRequest.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Event representing a users device application install status.
@@ -17321,36 +17321,36 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerDelta'
-              readOnly: true
+              x-ms-navigationProperty: true
             favoritePlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that the user marked as favorites.
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
-              readOnly: true
+              x-ms-navigationProperty: true
             recentPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans that have been recently viewed by the user in apps that support recent plans.
-              readOnly: true
+              x-ms-navigationProperty: true
             rosterPlans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans contained by the plannerRosters the user is a member.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemInsights:
@@ -17371,37 +17371,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profile:
@@ -17414,115 +17414,115 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userAccountInformation'
-              readOnly: true
+              x-ms-navigationProperty: true
             addresses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemAddress'
               description: Represents details of addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             anniversaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnualEvent'
               description: Represents the details of meaningful dates associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             awards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAward'
               description: Represents the details of awards or honors associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             certifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personCertification'
               description: Represents the details of certifications associated with a person.
-              readOnly: true
+              x-ms-navigationProperty: true
             educationalActivities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationalActivity'
               description: 'Represents data that a user has supplied related to undergraduate, graduate, postgraduate or other educational activities.'
-              readOnly: true
+              x-ms-navigationProperty: true
             emails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemEmail'
               description: Represents detailed information about email addresses associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             interests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personInterest'
               description: Provides detailed information about interests the user has associated with themselves in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.languageProficiency'
               description: Represents detailed information about languages that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personName'
               description: Represents the names a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             notes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personAnnotation'
               description: Represents notes that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             patents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPatent'
               description: Represents patents that a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             phones:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPhone'
               description: Represents detailed information about phone numbers associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             positions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workPosition'
               description: Represents detailed information about work positions associated with a user's profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             projects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.projectParticipation'
               description: Represents detailed information about projects associated with a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             publications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemPublication'
               description: Represents details of any publications a user has added to their profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             skills:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.skillProficiency'
               description: Represents detailed information about skills associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
             webAccounts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.webAccount'
               description: Represents web accounts the user has indicated they use or has added to their user profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             websites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.personWebsite'
               description: Represents detailed information about websites associated with a user in various services.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -17574,7 +17574,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.device:
@@ -17745,43 +17745,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.usageRight'
               description: Represents the usage rights a device has been granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             commands:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.command'
               description: Set of commands sent to this device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -17904,7 +17904,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             meetingAttendanceReport:
               $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
             registration:
@@ -17914,7 +17914,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callTranscript'
               description: The transcripts of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -17948,65 +17948,65 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: Represents the email addresses registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordlessMicrosoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordlessMicrosoftAuthenticatorAuthenticationMethod'
               description: Represents the Microsoft Authenticator Passwordless Phone Sign-in methods registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: Represents the details of the password authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: Represents the phone registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -18050,7 +18050,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -18058,37 +18058,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: A collection of all the Teams async operations that ran or are running on the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps for the chat.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -18156,13 +18156,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -18170,37 +18170,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: 'The list of this team''s owners. Currently, when creating a team using application permissions, exactly one owner must be specified. When using user delegated permissions, no owner can be specified (the current user is the owner). Owner must be specified as an object ID (GUID), not a UPN.'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: A collection of permissions granted to apps to access the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -18210,7 +18210,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             templateDefinition:
@@ -18230,13 +18230,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.entity:
@@ -18915,13 +18915,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -19143,7 +19143,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.dataLossPreventionPolicy:
@@ -19205,7 +19205,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sensitivityLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sensitivityPolicySettings:
@@ -19237,7 +19237,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.informationProtectionLabel'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentRequest:
@@ -19269,7 +19269,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.passwordSingleSignOnSettings:
@@ -19532,7 +19532,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.claimsMappingPolicy:
@@ -19649,13 +19649,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
               description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
               description: Pre-configured synchronization settings for a particular application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.identity:
@@ -20089,7 +20089,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -20134,7 +20134,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -20171,7 +20171,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRule:
@@ -20537,7 +20537,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             children:
@@ -20545,7 +20545,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -20553,25 +20553,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -20595,17 +20595,17 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The recent activities that took place within this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -20613,19 +20613,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long running operations for the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deleted:
@@ -20685,7 +20685,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -20851,25 +20851,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -20938,7 +20938,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: Collection of webparts on the SharePoint page
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -21007,13 +21007,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appConsentRequestScope:
@@ -21192,7 +21192,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.governanceInsight'
               description: Insights are recommendations to reviewers on whether to approve or deny a decision. There can be multiple insights associated with an accessReviewInstanceDecisionItem.
-              readOnly: true
+              x-ms-navigationProperty: true
             instance:
               $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
           additionalProperties:
@@ -21268,7 +21268,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'Set of access reviews instances for this access review series. Access reviews that do not recur will only have one instance; otherwise, there is an instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStage:
@@ -21308,7 +21308,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -21331,7 +21331,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.sensitivityLabel'
               description: Read the Microsoft Purview Information Protection labels for the user or organization.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.deviceEnrollmentConfigurationType:
@@ -22725,7 +22725,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityBaselineSettingState'
               description: The security baseline state for different settings for a device
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Security baseline state for a device.
@@ -22764,7 +22764,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -23014,7 +23014,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsDeviceMalwareState'
               description: Device malware list
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device protection status entity.
@@ -23273,7 +23273,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Collection of buckets in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -23281,7 +23281,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Collection of tasks in the plan. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -23411,19 +23411,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: Access this property from the derived type itemInsights.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -23457,13 +23457,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -23582,13 +23582,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -23612,7 +23612,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -24536,7 +24536,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -24586,7 +24586,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callTranscript:
@@ -25082,13 +25082,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAsyncOperation:
@@ -25364,25 +25364,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTag:
@@ -25417,7 +25417,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -25524,56 +25524,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeCards:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeCard'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -25803,7 +25803,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShareViewpoint:
@@ -25849,7 +25849,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             share:
               $ref: '#/components/schemas/microsoft.graph.printerShare'
             shares:
@@ -25857,13 +25857,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.analyticsActivityType:
@@ -26180,7 +26180,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionClassificationType:
@@ -26476,32 +26476,32 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of fileAttachment, itemAttachment, and referenceAttachment attachments for the post. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             mentions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mention'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRuleActions:
@@ -26808,7 +26808,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityOLD'
               description: The list of recent activities that took place on this item.
-              readOnly: true
+              x-ms-navigationProperty: true
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             documentSetVersions:
@@ -26816,7 +26816,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -26826,7 +26826,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.audio:
@@ -27325,7 +27325,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -27333,25 +27333,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of Workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -27510,7 +27510,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -27823,12 +27823,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -27995,7 +27995,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSection'
               description: Collection of horizontal sections on the SharePoint page.
-              readOnly: true
+              x-ms-navigationProperty: true
             verticalSection:
               $ref: '#/components/schemas/microsoft.graph.verticalSection'
           additionalProperties:
@@ -28102,7 +28102,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -28136,7 +28136,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -28144,13 +28144,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.request:
@@ -29517,7 +29517,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -30225,7 +30225,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrantBase'
               description: Registrants of the online meeting.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingSpeaker:
@@ -30339,7 +30339,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -30674,7 +30674,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagType:
@@ -31466,13 +31466,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printConnector:
@@ -31756,7 +31756,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
               description: Contains the collection of directories and all of their objects.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.metadataEntry:
@@ -32077,7 +32077,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -32177,13 +32177,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -32214,19 +32214,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -32234,7 +32234,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -32381,13 +32381,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -32514,7 +32514,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.horizontalSectionColumn'
               description: The set of vertical columns in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.verticalSection:
@@ -32530,7 +32530,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -35024,7 +35024,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appKeyCredentialRestrictionType:
@@ -35418,7 +35418,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -35554,7 +35554,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The collection of WebParts in this column.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.relationType:
@@ -36094,7 +36094,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/beta/WindowsUpdates.yml
+++ b/openApiDocs/beta/WindowsUpdates.yml
@@ -5339,13 +5339,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.browserSharedCookie'
               description: A collection of shared cookies defined for the site list.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.browserSite'
               description: A collection of sites defined for the site list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A singleton entity which is used to specify IE mode site list metadata
@@ -5372,31 +5372,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsUpdates.deploymentAudience'
               description: The set of updatableAsset resources to which a deployment can apply.
-              readOnly: true
+              x-ms-navigationProperty: true
             deployments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsUpdates.deployment'
               description: Deployments created using the deployment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             resourceConnections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsUpdates.resourceConnection'
               description: Service connections to external resources such as analytics workspaces.
-              readOnly: true
+              x-ms-navigationProperty: true
             updatableAssets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsUpdates.updatableAsset'
               description: Assets registered with the deployment service that can receive updates.
-              readOnly: true
+              x-ms-navigationProperty: true
             updatePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsUpdates.updatePolicy'
               description: A collection of policies for approving the deployment of different content to an audience over time.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.windowsUpdates.catalog:
@@ -5410,7 +5410,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsUpdates.catalogEntry'
               description: Lists the content that you can approve for deployment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.windowsUpdates.catalogEntry:
@@ -5452,13 +5452,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsUpdates.updatableAsset'
               description: Specifies the assets to exclude from the audience.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsUpdates.updatableAsset'
               description: Specifies the assets to include in the audience.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.windowsUpdates.updatableAsset:
@@ -5538,7 +5538,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsUpdates.complianceChange'
               description: Compliance changes like content approvals which result in the automatic creation of deployments using the audience and deploymentSettings of the policy.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.windowsUpdates.complianceChange:

--- a/openApiDocs/v1.0/Applications.yml
+++ b/openApiDocs/v1.0/Applications.yml
@@ -7608,34 +7608,34 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extensionProperty'
               description: 'Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0).'
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
               description: 'Federated identities for applications. Supports $expand and $filter (startsWith, /$count eq 0, /$count ne 0).'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of the application. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryObject:
@@ -8049,88 +8049,88 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignments for this app or service, granted to users, groups, and other service principals. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             appRoleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: 'App role assignment for another app or service, granted to this service principal. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             claimsMappingPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: The claimsMappingPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects created by this service principal. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             delegatedPermissionClassifications:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.delegatedPermissionClassification'
-              readOnly: true
+              x-ms-navigationProperty: true
             endpoints:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.endpoint'
-              readOnly: true
+              x-ms-navigationProperty: true
             federatedIdentityCredentials:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
               description: 'Federated identities for a specific type of service principal - managed identity. Supports $expand and $filter (/$count eq 0, /$count ne 0).'
-              readOnly: true
+              x-ms-navigationProperty: true
             homeRealmDiscoveryPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The homeRealmDiscoveryPolicies assigned to this service principal. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
               description: Delegated permission grants authorizing this service principal to access an API on behalf of a signed-in user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owned by this service principal. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Directory objects that are owners of this servicePrincipal. The owners are a set of non-admin users or servicePrincipals who are allowed to modify this object. Read-only. Nullable.  Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The tokenIssuancePolicies assigned to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: The tokenLifetimePolicies assigned to this service principal.
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.delegatedPermissionClassification:
@@ -8554,7 +8554,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionScope:

--- a/openApiDocs/v1.0/Bookings.yml
+++ b/openApiDocs/v1.0/Bookings.yml
@@ -2444,12 +2444,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.bookingBusiness'
-          readOnly: true
+          x-ms-navigationProperty: true
         bookingCurrencies:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.bookingCurrency'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.bookingBusiness:
@@ -2509,37 +2509,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingAppointment'
               description: All the appointments of this business. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingAppointment'
               description: The set of appointments of this business in a specified date range. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             customers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingCustomerBase'
               description: All the customers of this business. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             customQuestions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingCustomQuestion'
               description: All the custom questions of this business. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             services:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingService'
               description: All the services offered by this business. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             staffMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.bookingStaffMemberBase'
               description: All the staff members that provide services in this business. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Represents a Microsot Bookings Business.

--- a/openApiDocs/v1.0/Calendar.yml
+++ b/openApiDocs/v1.0/Calendar.yml
@@ -43198,31 +43198,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarPermission:
@@ -43369,7 +43369,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -43377,25 +43377,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attachment:
@@ -43506,7 +43506,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.entity:

--- a/openApiDocs/v1.0/CloudCommunications.yml
+++ b/openApiDocs/v1.0/CloudCommunications.yml
@@ -5429,22 +5429,22 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.call'
-              readOnly: true
+              x-ms-navigationProperty: true
             callRecords:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.callRecords.callRecord'
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presences:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.presence'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callRecords.callRecord:
@@ -5495,7 +5495,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callRecords.session'
               description: 'List of sessions involved in the call. Peer-to-peer calls typically only have one session, whereas group calls typically have at least one session per participant. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callRecords.session:
@@ -5530,7 +5530,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.callRecords.segment'
               description: The list of segments involved in the session. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.callRecords.segment:
@@ -5628,22 +5628,22 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.audioRoutingGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             contentSharingSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentSharingSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.commsOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             participants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.participant'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.audioRoutingGroup:
@@ -6062,7 +6062,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingAttendanceReport:
@@ -6095,7 +6095,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attendanceRecord:

--- a/openApiDocs/v1.0/CrossDeviceExperiences.yml
+++ b/openApiDocs/v1.0/CrossDeviceExperiences.yml
@@ -739,7 +739,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.activityHistoryItem:

--- a/openApiDocs/v1.0/DeviceManagement.Actions.yml
+++ b/openApiDocs/v1.0/DeviceManagement.Actions.yml
@@ -2269,7 +2269,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceActionItem'
               description: The list of scheduled action configurations for this compliance policy. Compliance policy must have one and only one block scheduled action.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Scheduled Action for Rule

--- a/openApiDocs/v1.0/DeviceManagement.Administration.yml
+++ b/openApiDocs/v1.0/DeviceManagement.Administration.yml
@@ -4024,7 +4024,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleAssignment'
               description: List of Role assignments for this role definition.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: 'The Role Definition resource. The role definition is the foundation of role based access in Intune. The role combines an Intune resource such as a Mobile App and associated role permissions such as Create or Read for the resource. There are two types of roles, built-in and custom. Built-in roles cannot be modified. Both built-in roles and custom roles must have assignments to be enforced. Create custom roles if you want to define a role that allows any of the available resources and role permissions to be combined into a single role.'
@@ -4127,13 +4127,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditionsAcceptanceStatus'
               description: The list of acceptance statuses for this T&C policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditionsAssignment'
               description: The list of assignments for this T&C policy.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A termsAndConditions entity represents the metadata and contents of a given Terms and Conditions (T&C) policy. T&C policies’ contents are presented to users upon their first attempt to enroll into Intune and subsequently upon edits where an administrator has required re-acceptance. They enable administrators to communicate the provisions to which a user must agree in order to have devices enrolled into Intune.

--- a/openApiDocs/v1.0/DeviceManagement.Enrollment.yml
+++ b/openApiDocs/v1.0/DeviceManagement.Enrollment.yml
@@ -1147,7 +1147,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -1356,49 +1356,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignment'
               description: Resource to grant access to users or groups.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleDefinition'
               description: Resource representing the roles allowed by RBAC providers and the permissions assigned to the roles.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignmentScheduleInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignmentScheduleInstance'
               description: Instances for active role assignments.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignmentScheduleRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignmentScheduleRequest'
               description: Requests for active role assignments to principals through PIM.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignmentSchedules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignmentSchedule'
               description: Schedules for active role assignment operations.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleEligibilityScheduleInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleEligibilityScheduleInstance'
               description: Instances for role eligibility requests.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleEligibilityScheduleRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleEligibilityScheduleRequest'
               description: Requests for role eligibilities for principals through PIM.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleEligibilitySchedules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleEligibilitySchedule'
               description: Schedules for role eligibility operations.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.ODataError:
@@ -1570,7 +1570,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleDefinition'
               description: Read-only collection of role definitions that the given role definition inherits from. Only Azure AD built-in roles (isBuiltIn is true) support this attribute. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.unifiedRoleAssignmentScheduleInstance:

--- a/openApiDocs/v1.0/DeviceManagement.yml
+++ b/openApiDocs/v1.0/DeviceManagement.yml
@@ -7634,19 +7634,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditions'
               description: The terms and conditions associated with device management of the company.
-              readOnly: true
+              x-ms-navigationProperty: true
             auditEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.auditEvent'
               description: The Audit Events
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicy'
               description: The device compliance policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCompliancePolicyDeviceStateSummary:
               $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyDeviceStateSummary'
             deviceCompliancePolicySettingStateSummaries:
@@ -7654,7 +7654,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicySettingStateSummary'
               description: The summary states of compliance policy settings for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationDeviceStateSummaries:
               $ref: '#/components/schemas/microsoft.graph.deviceConfigurationDeviceStateSummary'
             deviceConfigurations:
@@ -7662,13 +7662,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfiguration'
               description: The device configurations.
-              readOnly: true
+              x-ms-navigationProperty: true
             iosUpdateStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.iosUpdateDeviceStatus'
               description: The IOS software update installation statuses for this account.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareUpdateStatusSummary:
               $ref: '#/components/schemas/microsoft.graph.softwareUpdateStatusSummary'
             complianceManagementPartners:
@@ -7676,7 +7676,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.complianceManagementPartner'
               description: The list of Compliance Management Partners configured by the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             conditionalAccessSettings:
               $ref: '#/components/schemas/microsoft.graph.onPremisesConditionalAccessSettings'
             deviceCategories:
@@ -7684,31 +7684,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCategory'
               description: The list of device categories with the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceEnrollmentConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceEnrollmentConfiguration'
               description: The list of device enrollment configurations
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementPartners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementPartner'
               description: The list of Device Management Partners configured by the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             exchangeConnectors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementExchangeConnector'
               description: The list of Exchange Connectors configured by the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileThreatDefenseConnectors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileThreatDefenseConnector'
               description: The list of Mobile threat Defense connectors configured by the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             applePushNotificationCertificate:
               $ref: '#/components/schemas/microsoft.graph.applePushNotificationCertificate'
             detectedApps:
@@ -7716,7 +7716,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.detectedApp'
               description: The list of detected apps associated with a device.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDeviceOverview:
               $ref: '#/components/schemas/microsoft.graph.managedDeviceOverview'
             managedDevices:
@@ -7724,49 +7724,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The list of managed devices.
-              readOnly: true
+              x-ms-navigationProperty: true
             importedWindowsAutopilotDeviceIdentities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.importedWindowsAutopilotDeviceIdentity'
               description: Collection of imported Windows autopilot devices.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsAutopilotDeviceIdentities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsAutopilotDeviceIdentity'
               description: The Windows autopilot device identities contained collection.
-              readOnly: true
+              x-ms-navigationProperty: true
             notificationMessageTemplates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.notificationMessageTemplate'
               description: The Notification Message Templates.
-              readOnly: true
+              x-ms-navigationProperty: true
             resourceOperations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceOperation'
               description: The Resource Operations.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceAndAppManagementRoleAssignment'
               description: The Role Assignments.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleDefinition'
               description: The Role Definitions.
-              readOnly: true
+              x-ms-navigationProperty: true
             remoteAssistancePartners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.remoteAssistancePartner'
               description: The remote assist partners.
-              readOnly: true
+              x-ms-navigationProperty: true
             reports:
               $ref: '#/components/schemas/microsoft.graph.deviceManagementReports'
             telecomExpenseManagementPartners:
@@ -7774,25 +7774,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.telecomExpenseManagementPartner'
               description: The telecom expense management partners.
-              readOnly: true
+              x-ms-navigationProperty: true
             troubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for the tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionAppLearningSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionAppLearningSummary'
               description: The windows information protection app learning summaries.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionNetworkLearningSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionNetworkLearningSummary'
               description: The windows information protection network learning summaries.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Singleton entity that acts as a container for all device management functionality.
@@ -7831,7 +7831,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The devices that have the discovered application installed
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A managed or unmanaged app that is installed on a managed device. Unmanaged apps will only appear for devices marked as corporate owned.
@@ -8083,13 +8083,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -8097,7 +8097,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -8152,19 +8152,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyAssignment'
               description: The collection of assignments for this compliance policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceSettingStateSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.settingStateDeviceSummary'
               description: Compliance Setting State Device Summary
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceDeviceStatus'
               description: List of DeviceComplianceDeviceStatus.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatusOverview:
               $ref: '#/components/schemas/microsoft.graph.deviceComplianceDeviceOverview'
             scheduledActionsForRule:
@@ -8172,13 +8172,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceScheduledActionForRule'
               description: The list of scheduled action per rule for this compliance policy. This is a required property when creating any individual per-platform compliance policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceUserStatus'
               description: List of DeviceComplianceUserStatus.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatusOverview:
               $ref: '#/components/schemas/microsoft.graph.deviceComplianceUserOverview'
           additionalProperties:
@@ -8354,7 +8354,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceActionItem'
               description: The list of scheduled action configurations for this compliance policy. Compliance policy must have one and only one block scheduled action.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Scheduled Action for Rule
@@ -8588,7 +8588,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceComplianceSettingState'
               description: Not yet documented
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Device Compilance Policy Setting State summary across the account.
@@ -8728,19 +8728,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationAssignment'
               description: The list of assignments for the device configuration profile.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceSettingStateSummaries:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.settingStateDeviceSummary'
               description: Device Configuration Setting State Device Summary
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationDeviceStatus'
               description: Device configuration installation status by device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatusOverview:
               $ref: '#/components/schemas/microsoft.graph.deviceConfigurationDeviceOverview'
             userStatuses:
@@ -8748,7 +8748,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationUserStatus'
               description: Device configuration installation status by user.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatusOverview:
               $ref: '#/components/schemas/microsoft.graph.deviceConfigurationUserOverview'
           additionalProperties:
@@ -9056,7 +9056,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.localizedNotificationMessage'
               description: The list of localized messages for this Notification Message Template.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Notification messages are messages that are sent to end users who are determined to be not-compliant with the compliance policies defined by the administrator. Administrators choose notifications and configure them in the Intune Admin Console using the compliance policy creation page under the “Actions for non-compliance” section. Use the notificationMessageTemplate object to create your own custom notifications for administrators to choose while configuring actions for non-compliance.
@@ -9404,13 +9404,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditionsAcceptanceStatus'
               description: The list of acceptance statuses for this T&C policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termsAndConditionsAssignment'
               description: The list of assignments for this T&C policy.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: A termsAndConditions entity represents the metadata and contents of a given Terms and Conditions (T&C) policy. T&C policies’ contents are presented to users upon their first attempt to enroll into Intune and subsequently upon edits where an administrator has required re-acceptance. They enable administrators to communicate the provisions to which a user must agree in order to have devices enrolled into Intune.
@@ -9632,7 +9632,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.enrollmentConfigurationAssignment'
               description: The list of group assignments for the device configuration profile
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The Base Class of Device Enrollment Configuration
@@ -9997,7 +9997,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.roleAssignment'
               description: List of Role assignments for this role definition.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: 'The Role Definition resource. The role definition is the foundation of role based access in Intune. The role combines an Intune resource such as a Mobile App and associated role permissions such as Create or Read for the resource. There are two types of roles, built-in and custom. Built-in roles cannot be modified. Both built-in roles and custom roles must have assignments to be enforced. Create custom roles if you want to define a role that allows any of the available resources and role permissions to be combined into a single role.'
@@ -10036,7 +10036,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementExportJob'
               description: Entity representing a job to export a report
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Singleton entity that acts as a container for all reports functionality.
@@ -11003,25 +11003,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -11029,41 +11029,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -11071,37 +11071,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -11109,13 +11109,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -11123,7 +11123,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -11131,42 +11131,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -11181,18 +11181,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -11201,12 +11201,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -12886,31 +12886,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -12938,7 +12938,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -13060,7 +13060,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -13068,25 +13068,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -13108,25 +13108,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -13260,13 +13260,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -13274,7 +13274,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -13288,7 +13288,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -13335,31 +13335,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -13460,25 +13460,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -13492,7 +13492,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -13604,19 +13604,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -13626,7 +13626,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -13654,13 +13654,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -13668,42 +13668,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -13711,7 +13711,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -13845,19 +13845,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -13872,13 +13872,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -13892,19 +13892,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -13932,37 +13932,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -14047,7 +14047,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -14141,7 +14141,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -14171,61 +14171,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -14269,7 +14269,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -14277,25 +14277,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -14357,13 +14357,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -14371,25 +14371,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -14399,7 +14399,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -14417,13 +14417,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -14437,7 +14437,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.settingSource:
@@ -15436,7 +15436,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -15444,25 +15444,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -15486,13 +15486,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -15500,19 +15500,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publicError:
@@ -15573,7 +15573,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -15739,25 +15739,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -15851,13 +15851,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -15973,7 +15973,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -15981,7 +15981,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -16201,13 +16201,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -16328,13 +16328,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -16358,7 +16358,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -16617,7 +16617,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -17035,13 +17035,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -17255,25 +17255,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -17451,7 +17451,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -17459,55 +17459,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -17515,31 +17515,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -17547,25 +17547,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -17577,7 +17577,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -17652,7 +17652,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -17712,51 +17712,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -17799,13 +17799,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.settingSourceType:
@@ -18824,7 +18824,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -18832,25 +18832,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -18870,7 +18870,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -18880,7 +18880,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -19077,7 +19077,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -19390,12 +19390,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -19535,7 +19535,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -19569,7 +19569,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -19577,13 +19577,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanContainer:
@@ -19624,7 +19624,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -20185,31 +20185,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.longRunningOperationStatus:
@@ -20278,7 +20278,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -20509,7 +20509,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.assignedLabel:
@@ -20614,7 +20614,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -20659,7 +20659,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -20696,7 +20696,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.operationError:
@@ -21022,30 +21022,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attendeeType:
@@ -21206,7 +21206,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -21306,13 +21306,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -21343,19 +21343,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -21363,7 +21363,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.documentSetVersion:
@@ -21557,13 +21557,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -22046,13 +22046,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -22060,13 +22060,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequest:
@@ -22428,7 +22428,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -22744,7 +22744,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/v1.0/Devices.CloudPrint.yml
+++ b/openApiDocs/v1.0/Devices.CloudPrint.yml
@@ -3876,37 +3876,37 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.printConnector'
           description: The list of available print connectors.
-          readOnly: true
+          x-ms-navigationProperty: true
         operations:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printOperation'
           description: The list of print long running operations.
-          readOnly: true
+          x-ms-navigationProperty: true
         printers:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printer'
           description: The list of printers registered in the tenant.
-          readOnly: true
+          x-ms-navigationProperty: true
         services:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printService'
           description: The list of available Universal Print service endpoints.
-          readOnly: true
+          x-ms-navigationProperty: true
         shares:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printerShare'
           description: The list of printer shares registered in the tenant.
-          readOnly: true
+          x-ms-navigationProperty: true
         taskDefinitions:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printTaskDefinition'
           description: List of abstract definition for a task that can be triggered when various events occur within Universal Print.
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.printConnector:
@@ -3979,19 +3979,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printConnector'
               description: The connectors that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             shares:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printerShare'
               description: 'The list of printerShares that are associated with the printer. Currently, only one printerShare can be associated with the printer. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             taskTriggers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTaskTrigger'
               description: A list of task triggers that are associated with the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printerShare:
@@ -4013,13 +4013,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose users have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             allowedUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The users who have access to print using the printer.
-              readOnly: true
+              x-ms-navigationProperty: true
             printer:
               $ref: '#/components/schemas/microsoft.graph.printer'
           additionalProperties:
@@ -4052,7 +4052,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of tasks that have been created based on this definition. The list includes currently running tasks and recently completed tasks. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printCertificateSigningRequest:
@@ -4078,7 +4078,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printServiceEndpoint'
               description: Endpoints that can be used to access the service. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printServiceEndpoint:
@@ -4259,7 +4259,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.printJob'
               description: The list of jobs that are queued for printing by the printer/printerShare.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -4437,7 +4437,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -4445,55 +4445,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -4501,31 +4501,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -4533,25 +4533,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -4563,7 +4563,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -4899,25 +4899,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -4925,41 +4925,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -4967,37 +4967,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -5005,13 +5005,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -5019,7 +5019,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -5027,42 +5027,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -5077,18 +5077,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -5097,12 +5097,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -5608,13 +5608,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printDocument'
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.printTask'
               description: A list of printTasks that were triggered by this print job.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryObject:
@@ -5847,31 +5847,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -5993,7 +5993,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -6001,25 +6001,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversation:
@@ -6052,7 +6052,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -6097,7 +6097,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -6123,19 +6123,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -6145,7 +6145,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -6173,13 +6173,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -6187,42 +6187,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -6230,7 +6230,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -6276,7 +6276,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -6290,37 +6290,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -6404,13 +6404,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -6418,25 +6418,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -6446,7 +6446,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -6778,7 +6778,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -6800,25 +6800,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -6952,13 +6952,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -6966,7 +6966,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -6980,7 +6980,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -7027,31 +7027,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -7152,25 +7152,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -7184,7 +7184,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -7583,13 +7583,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -7597,7 +7597,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -7661,19 +7661,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -7706,13 +7706,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -7726,19 +7726,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -7815,7 +7815,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -7909,7 +7909,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -7939,61 +7939,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -8037,7 +8037,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -8045,25 +8045,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -8077,13 +8077,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -8097,7 +8097,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.printTaskProcessingState:
@@ -9566,13 +9566,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -9580,13 +9580,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.baseItem:
@@ -9789,7 +9789,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -9797,25 +9797,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -9839,13 +9839,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -9853,19 +9853,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publicError:
@@ -9926,7 +9926,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -10092,25 +10092,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -10204,13 +10204,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -10240,7 +10240,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -10248,7 +10248,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -10282,13 +10282,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -10409,13 +10409,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -10439,7 +10439,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -10627,25 +10627,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -10754,7 +10754,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -10814,51 +10814,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.automaticRepliesSetting:
@@ -12327,7 +12327,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -12709,13 +12709,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -12788,13 +12788,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.ErrorDetails:
@@ -13573,7 +13573,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -13581,25 +13581,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -13619,7 +13619,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -13629,7 +13629,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -13826,7 +13826,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -14139,12 +14139,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -14284,7 +14284,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -14318,7 +14318,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -14326,13 +14326,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanContainer:
@@ -14373,7 +14373,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -14540,7 +14540,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsApp:
@@ -14564,7 +14564,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -15754,31 +15754,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.longRunningOperationStatus:
@@ -16070,30 +16070,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attendeeType:
@@ -16219,7 +16219,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -16319,13 +16319,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -16356,19 +16356,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -16376,7 +16376,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.documentSetVersion:
@@ -16570,13 +16570,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -17417,7 +17417,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -17739,7 +17739,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/v1.0/Devices.CorporateManagement.yml
+++ b/openApiDocs/v1.0/Devices.CorporateManagement.yml
@@ -11141,85 +11141,85 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedEBook'
               description: The Managed eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppCategories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppCategory'
               description: The mobile app categories.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileAppConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfiguration'
               description: The Managed Device Mobile Application Configurations.
-              readOnly: true
+              x-ms-navigationProperty: true
             mobileApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileApp'
               description: The mobile apps.
-              readOnly: true
+              x-ms-navigationProperty: true
             vppTokens:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.vppToken'
               description: List of Vpp tokens for this organization.
-              readOnly: true
+              x-ms-navigationProperty: true
             androidManagedAppProtections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.androidManagedAppProtection'
               description: Android managed app policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             defaultManagedAppProtections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.defaultManagedAppProtection'
               description: Default managed app policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             iosManagedAppProtections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.iosManagedAppProtection'
               description: iOS managed app policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Managed app policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: The managed app registrations.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppStatus'
               description: The managed app statuses.
-              readOnly: true
+              x-ms-navigationProperty: true
             mdmWindowsInformationProtectionPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mdmWindowsInformationProtectionPolicy'
               description: Windows information protection for apps running on devices which are MDM enrolled.
-              readOnly: true
+              x-ms-navigationProperty: true
             targetedManagedAppConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetedManagedAppConfiguration'
               description: Targeted managed app configurations.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsInformationProtectionPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionPolicy'
               description: Windows information protection for apps running on devices which are not MDM enrolled.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Singleton entity that acts as a container for all device app management functionality.
@@ -11265,7 +11265,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedMobileApp'
               description: List of apps to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             deploymentSummary:
               $ref: '#/components/schemas/microsoft.graph.managedAppPolicyDeploymentSummary'
           additionalProperties:
@@ -11367,7 +11367,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedMobileApp'
               description: List of apps to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             deploymentSummary:
               $ref: '#/components/schemas/microsoft.graph.managedAppPolicyDeploymentSummary'
           additionalProperties:
@@ -11403,7 +11403,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedMobileApp'
               description: List of apps to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             deploymentSummary:
               $ref: '#/components/schemas/microsoft.graph.managedAppPolicyDeploymentSummary'
           additionalProperties:
@@ -11499,19 +11499,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -11605,13 +11605,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedEBookAssignment'
               description: The list of assignments for this eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceInstallState'
               description: The list of installation states for this eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
             installSummary:
               $ref: '#/components/schemas/microsoft.graph.eBookInstallSummary'
             userStateSummary:
@@ -11619,7 +11619,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userInstallStateSummary'
               description: The list of installation states for this eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: An abstract class containing the base properties for Managed eBook.
@@ -11754,7 +11754,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceInstallState'
               description: The install state of the eBook.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Contains properties for the installation state summary for a user.
@@ -11824,13 +11824,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationAssignment'
               description: The list of group assignemenets for app configration.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatuses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationDeviceStatus'
               description: List of ManagedDeviceMobileAppConfigurationDeviceStatus.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceStatusSummary:
               $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationDeviceSummary'
             userStatuses:
@@ -11838,7 +11838,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationUserStatus'
               description: List of ManagedDeviceMobileAppConfigurationUserStatus.
-              readOnly: true
+              x-ms-navigationProperty: true
             userStatusSummary:
               $ref: '#/components/schemas/microsoft.graph.managedDeviceMobileAppConfigurationUserSummary'
           additionalProperties:
@@ -12082,13 +12082,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppAssignment'
               description: The list of group assignments for this mobile app.
-              readOnly: true
+              x-ms-navigationProperty: true
             categories:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.mobileAppCategory'
               description: The list of categories for this app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: An abstract class containing the base properties for Intune mobile apps.
@@ -12127,13 +12127,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedMobileApp'
               description: List of apps to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetedManagedAppPolicyAssignment'
               description: Navigation property to list of inclusion and exclusion groups to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
             deploymentSummary:
               $ref: '#/components/schemas/microsoft.graph.managedAppPolicyDeploymentSummary'
           additionalProperties:
@@ -12551,13 +12551,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -12565,7 +12565,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -12675,7 +12675,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetedManagedAppPolicyAssignment'
               description: Navigation property to list of inclusion and exclusion groups to which the policy is deployed.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Policy used to configure detailed management settings targeted to specific security groups
@@ -13039,19 +13039,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetedManagedAppPolicyAssignment'
               description: Navigation property to list of security groups targeted for policy.
-              readOnly: true
+              x-ms-navigationProperty: true
             exemptAppLockerFiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionAppLockerFile'
               description: Another way to input exempt apps through xml files
-              readOnly: true
+              x-ms-navigationProperty: true
             protectedAppLockerFiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsInformationProtectionAppLockerFile'
               description: Another way to input protected apps through xml files
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Policy for Windows information protection to configure detailed management settings
@@ -14082,25 +14082,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -14108,41 +14108,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -14150,37 +14150,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -14188,13 +14188,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -14202,7 +14202,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -14210,42 +14210,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -14260,18 +14260,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -14280,12 +14280,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -15574,31 +15574,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -15626,7 +15626,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -15748,7 +15748,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -15756,25 +15756,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -15796,25 +15796,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -15948,13 +15948,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -15962,7 +15962,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -15976,7 +15976,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -16023,31 +16023,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -16148,25 +16148,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -16180,7 +16180,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -16292,19 +16292,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -16314,7 +16314,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -16342,13 +16342,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -16356,42 +16356,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -16399,7 +16399,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -16484,13 +16484,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -16504,19 +16504,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -16544,37 +16544,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -16659,7 +16659,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -16753,7 +16753,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -16783,61 +16783,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -16881,7 +16881,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -16889,25 +16889,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -16969,13 +16969,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -16983,25 +16983,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -17011,7 +17011,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -17029,13 +17029,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -17049,7 +17049,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.settingSource:
@@ -17930,7 +17930,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -17938,25 +17938,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -17980,13 +17980,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -17994,19 +17994,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publicError:
@@ -18067,7 +18067,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -18233,25 +18233,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -18345,13 +18345,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -18388,7 +18388,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -18396,7 +18396,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -18616,13 +18616,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -18743,13 +18743,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -18773,7 +18773,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -19032,7 +19032,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -19450,13 +19450,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -19670,25 +19670,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -19866,7 +19866,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -19874,55 +19874,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -19930,31 +19930,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -19962,25 +19962,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -19992,7 +19992,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -20067,7 +20067,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -20127,51 +20127,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -20214,13 +20214,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.settingSourceType:
@@ -21239,7 +21239,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -21247,25 +21247,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -21285,7 +21285,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -21295,7 +21295,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -21492,7 +21492,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -21805,12 +21805,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -21950,7 +21950,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -21984,7 +21984,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -21992,13 +21992,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanContainer:
@@ -22039,7 +22039,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -22600,31 +22600,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.longRunningOperationStatus:
@@ -22693,7 +22693,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -22924,7 +22924,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.assignedLabel:
@@ -23029,7 +23029,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -23074,7 +23074,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -23111,7 +23111,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.operationError:
@@ -23437,30 +23437,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attendeeType:
@@ -23621,7 +23621,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -23721,13 +23721,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -23758,19 +23758,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -23778,7 +23778,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.documentSetVersion:
@@ -23972,13 +23972,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -24461,13 +24461,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -24475,13 +24475,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequest:
@@ -24843,7 +24843,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -25159,7 +25159,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/v1.0/Devices.ServiceAnnouncement.yml
+++ b/openApiDocs/v1.0/Devices.ServiceAnnouncement.yml
@@ -1807,19 +1807,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceHealth'
               description: 'A collection of service health information for tenant. This property is a contained navigation property, it is nullable and readonly.'
-              readOnly: true
+              x-ms-navigationProperty: true
             issues:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceHealthIssue'
               description: 'A collection of service issues for tenant. This property is a contained navigation property, it is nullable and readonly.'
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceUpdateMessage'
               description: 'A collection of service messages for tenant. This property is a contained navigation property, it is nullable and readonly.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.serviceHealth:
@@ -1838,7 +1838,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceHealthIssue'
               description: 'A collection of issues that happened on the service, with detailed information for each issue.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.serviceHealthIssue:
@@ -1926,7 +1926,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.serviceAnnouncementAttachment'
               description: A collection of serviceAnnouncementAttachments.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.serviceAnnouncementAttachment:

--- a/openApiDocs/v1.0/Education.yml
+++ b/openApiDocs/v1.0/Education.yml
@@ -14411,19 +14411,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.educationClass'
-          readOnly: true
+          x-ms-navigationProperty: true
         me:
           $ref: '#/components/schemas/microsoft.graph.educationUser'
         schools:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.educationSchool'
-          readOnly: true
+          x-ms-navigationProperty: true
         users:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.educationUser'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.educationClass:
@@ -14475,7 +14475,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationCategory'
               description: All categories associated with this class. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignmentDefaults:
               $ref: '#/components/schemas/microsoft.graph.educationAssignmentDefaults'
             assignments:
@@ -14483,7 +14483,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationAssignment'
               description: All assignments associated with this class. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignmentSettings:
               $ref: '#/components/schemas/microsoft.graph.educationAssignmentSettings'
             group:
@@ -14493,19 +14493,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationUser'
               description: All users in the class. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             schools:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSchool'
               description: All schools that this class is associated with. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             teachers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationUser'
               description: All teachers in the class. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.educationCategory:
@@ -14644,13 +14644,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationCategory'
               description: 'When set, enables users to easily find assignments of a given type.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationAssignmentResource'
               description: Learning objects that are associated with this assignment.  Only teachers can modify this list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             rubric:
               $ref: '#/components/schemas/microsoft.graph.educationRubric'
             submissions:
@@ -14658,7 +14658,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSubmission'
               description: 'Once published, there is a submission object for each student representing their work and grade.  Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.educationAssignmentResource:
@@ -14774,17 +14774,17 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationOutcome'
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSubmissionResource'
-              readOnly: true
+              x-ms-navigationProperty: true
             submittedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSubmissionResource'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.educationOutcome:
@@ -15004,7 +15004,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -15012,55 +15012,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -15068,31 +15068,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -15100,25 +15100,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -15130,7 +15130,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -15187,13 +15187,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationClass'
               description: Classes taught at the school. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             users:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationUser'
               description: Users in the school. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.educationUser:
@@ -15322,31 +15322,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationAssignment'
               description: Assignments belonging to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             rubrics:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationRubric'
               description: 'When set, the grading rubric attached to the assignment.'
-              readOnly: true
+              x-ms-navigationProperty: true
             classes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationClass'
               description: Classes to which the user belongs. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             schools:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationSchool'
               description: Schools to which the user belongs. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             taughtClasses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.educationClass'
               description: Classes for which the user is a teacher.
-              readOnly: true
+              x-ms-navigationProperty: true
             user:
               $ref: '#/components/schemas/microsoft.graph.user'
           additionalProperties:
@@ -15682,25 +15682,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -15708,41 +15708,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -15750,37 +15750,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -15788,13 +15788,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -15802,7 +15802,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -15810,42 +15810,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -15860,18 +15860,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -15880,12 +15880,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -15915,19 +15915,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Users and groups that are members of this administrative unit. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: Scoped-role members of this administrative unit.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for this administrative unit. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.entity:
@@ -16372,31 +16372,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -16518,7 +16518,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -16526,25 +16526,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversation:
@@ -16577,7 +16577,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -16622,7 +16622,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -16648,19 +16648,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -16670,7 +16670,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -16698,13 +16698,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -16712,42 +16712,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -16755,7 +16755,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -16801,7 +16801,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -16815,37 +16815,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -16929,13 +16929,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -16943,25 +16943,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -16971,7 +16971,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -17434,7 +17434,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -17456,25 +17456,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -17608,13 +17608,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -17622,7 +17622,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -17636,7 +17636,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -17683,31 +17683,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -17808,25 +17808,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -17840,7 +17840,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -18239,13 +18239,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -18253,7 +18253,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -18317,19 +18317,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -18362,13 +18362,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -18382,19 +18382,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -18471,7 +18471,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -18565,7 +18565,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -18595,61 +18595,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -18693,7 +18693,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -18701,25 +18701,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -18733,13 +18733,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -18753,7 +18753,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     ReferenceCreate:
@@ -19324,13 +19324,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -19338,13 +19338,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.baseItem:
@@ -19535,7 +19535,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -19543,25 +19543,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -19585,13 +19585,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -19599,19 +19599,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publicError:
@@ -19672,7 +19672,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -19838,25 +19838,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -19950,13 +19950,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -19986,7 +19986,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -19994,7 +19994,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -20028,13 +20028,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -20155,13 +20155,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -20185,7 +20185,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -20373,25 +20373,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -20500,7 +20500,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -20560,51 +20560,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactRelationship:
@@ -22053,7 +22053,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -22435,13 +22435,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -22514,13 +22514,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.MainError:
@@ -23235,7 +23235,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -23243,25 +23243,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -23281,7 +23281,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -23291,7 +23291,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -23488,7 +23488,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -23801,12 +23801,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -23946,7 +23946,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -23980,7 +23980,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -23988,13 +23988,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanContainer:
@@ -24035,7 +24035,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -24202,7 +24202,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsApp:
@@ -24226,7 +24226,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -25416,31 +25416,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.longRunningOperationStatus:
@@ -25732,30 +25732,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.ErrorDetails:
@@ -25901,7 +25901,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -26001,13 +26001,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -26038,19 +26038,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -26058,7 +26058,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.documentSetVersion:
@@ -26252,13 +26252,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -27099,7 +27099,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -27421,7 +27421,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/v1.0/Files.yml
+++ b/openApiDocs/v1.0/Files.yml
@@ -59100,19 +59100,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -59122,7 +59122,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.driveItem:
@@ -59198,7 +59198,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -59206,25 +59206,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemAnalytics:
@@ -59239,7 +59239,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -59283,7 +59283,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivity:
@@ -59323,7 +59323,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -59333,7 +59333,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.documentSetVersion:
@@ -59663,13 +59663,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -59677,19 +59677,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.columnDefinition:
@@ -59853,25 +59853,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.columnLink:
@@ -59926,7 +59926,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All driveItems contained in the sharing root. This collection cannot be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             listItem:
@@ -59964,13 +59964,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -59978,42 +59978,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -60021,7 +60021,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -60642,7 +60642,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -60650,25 +60650,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.entity:
@@ -61179,12 +61179,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -61310,13 +61310,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -61330,37 +61330,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.driveCollectionResponse:
@@ -61911,25 +61911,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -61937,41 +61937,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -61979,37 +61979,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -62017,13 +62017,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -62031,7 +62031,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -62039,42 +62039,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -62089,18 +62089,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -62109,12 +62109,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -62235,7 +62235,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -62335,13 +62335,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -62372,19 +62372,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -62392,7 +62392,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -62445,13 +62445,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -62487,7 +62487,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -62495,13 +62495,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.displayNameLocalization:
@@ -62599,7 +62599,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -62633,13 +62633,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -62760,13 +62760,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -62790,7 +62790,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -63276,31 +63276,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -63328,7 +63328,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -63450,7 +63450,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -63458,25 +63458,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -63498,25 +63498,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -63650,13 +63650,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -63664,7 +63664,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -63678,7 +63678,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -63725,31 +63725,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -63850,25 +63850,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -63882,7 +63882,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -64288,13 +64288,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -64302,7 +64302,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -64366,19 +64366,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -64411,13 +64411,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -64431,19 +64431,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -64542,7 +64542,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -64636,7 +64636,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -64666,61 +64666,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -64764,7 +64764,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -64772,25 +64772,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -64852,13 +64852,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -64866,25 +64866,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -64894,7 +64894,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -64912,13 +64912,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -64932,7 +64932,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookCommentReply:
@@ -65075,7 +65075,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -66690,7 +66690,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -66698,7 +66698,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -67134,7 +67134,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -67522,13 +67522,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -67742,25 +67742,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -67938,7 +67938,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -67946,55 +67946,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -68002,31 +68002,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -68034,25 +68034,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -68064,7 +68064,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -68139,7 +68139,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -68199,51 +68199,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -68286,13 +68286,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilter:
@@ -68438,7 +68438,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -69217,7 +69217,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -69656,31 +69656,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationPhoneType:
@@ -69740,7 +69740,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -69971,7 +69971,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.assignedLabel:
@@ -70076,7 +70076,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -70121,7 +70121,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -70158,7 +70158,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.operationError:
@@ -70476,30 +70476,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilterCriteria:
@@ -71140,13 +71140,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -71154,13 +71154,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequest:

--- a/openApiDocs/v1.0/Groups.yml
+++ b/openApiDocs/v1.0/Groups.yml
@@ -30106,7 +30106,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -30114,55 +30114,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -30170,31 +30170,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -30202,25 +30202,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -30232,7 +30232,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -30438,7 +30438,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -30446,25 +30446,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarRoleType:
@@ -30532,7 +30532,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -30577,7 +30577,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.post:
@@ -30618,13 +30618,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -30632,13 +30632,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attachment:
@@ -30758,7 +30758,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemReference:
@@ -30870,7 +30870,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -30878,25 +30878,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -31068,25 +31068,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.assignedLicense:
@@ -31352,13 +31352,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -31366,42 +31366,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -31409,7 +31409,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -31537,13 +31537,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.provisionChannelEmailResult:
@@ -31775,31 +31775,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -31825,19 +31825,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -31847,7 +31847,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerGroup:
@@ -31861,7 +31861,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -31875,37 +31875,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -31967,13 +31967,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -31981,25 +31981,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -32009,7 +32009,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -32893,7 +32893,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -32901,25 +32901,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemAnalytics:
@@ -32934,7 +32934,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -32956,7 +32956,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -32966,7 +32966,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -33168,12 +33168,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -33490,13 +33490,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -33504,19 +33504,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -33563,13 +33563,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chatMessageAttachment:
@@ -34023,7 +34023,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -34031,7 +34031,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -34065,13 +34065,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenotePage:
@@ -34170,13 +34170,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -34200,7 +34200,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -34380,25 +34380,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -34483,7 +34483,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -34543,51 +34543,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attendeeBase:
@@ -35130,25 +35130,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -35156,41 +35156,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -35198,37 +35198,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -35236,13 +35236,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -35250,7 +35250,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -35258,42 +35258,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -35308,18 +35308,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -35328,12 +35328,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -35430,7 +35430,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -35530,13 +35530,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -35567,19 +35567,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -35587,7 +35587,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contentTypeInfo:
@@ -36131,7 +36131,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -36165,7 +36165,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -36173,13 +36173,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chatMessageMentionedIdentitySet:
@@ -36328,7 +36328,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -36553,7 +36553,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTab:
@@ -36597,7 +36597,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -37241,7 +37241,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -37263,25 +37263,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -37415,13 +37415,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -37429,7 +37429,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -37443,7 +37443,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -37490,31 +37490,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -37615,25 +37615,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -37647,7 +37647,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -38046,13 +38046,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -38060,7 +38060,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -38124,19 +38124,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -38169,13 +38169,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -38189,19 +38189,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -38278,7 +38278,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -38372,7 +38372,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -38402,61 +38402,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -38500,7 +38500,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -38508,25 +38508,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -38540,13 +38540,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -38560,7 +38560,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookCommentReply:
@@ -38703,7 +38703,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -38793,13 +38793,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -40566,7 +40566,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -40877,13 +40877,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilter:
@@ -41029,7 +41029,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -41997,31 +41997,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationPhoneType:
@@ -42127,30 +42127,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilterCriteria:

--- a/openApiDocs/v1.0/Identity.DirectoryManagement.yml
+++ b/openApiDocs/v1.0/Identity.DirectoryManagement.yml
@@ -10781,19 +10781,19 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryObject:
@@ -10962,31 +10962,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.extension:
@@ -11007,19 +11007,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.administrativeUnit'
               description: Conceptual container for user and group directory objects.
-              readOnly: true
+              x-ms-navigationProperty: true
             deletedItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Recently deleted items. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             federationConfigurations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityProviderBase'
               description: Configure domain federation with organizations whose identity provider (IdP) supports either the SAML or WS-Fed protocol.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.administrativeUnit:
@@ -11045,19 +11045,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Users and groups that are members of this administrative unit. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: Scoped-role members of this administrative unit.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for this administrative unit. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scopedRoleMembership:
@@ -11111,13 +11111,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Users that are members of this directory role. HTTP Methods: GET, POST, DELETE. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
               description: Members of this directory role that are scoped to administrative units. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryRoleTemplate:
@@ -11196,25 +11196,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The objects such as users and groups that reference the domain ID. Read-only, Nullable. Supports $expand and $filter by the OData type of objects returned. For example /domains/{domainId}/domainNameReferences/microsoft.graph.user and /domains/{domainId}/domainNameReferences/microsoft.graph.group.'
-              readOnly: true
+              x-ms-navigationProperty: true
             federationConfiguration:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.internalDomainFederation'
               description: Domain settings configured by a customer when federated with Azure AD. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             serviceConfigurationRecords:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.domainDnsRecord'
               description: 'DNS records the customer adds to the DNS zone file of the domain before the domain can be used by Microsoft Online services. Read-only, Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             verificationDnsRecords:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.domainDnsRecord'
               description: 'DNS records that the customer adds to the DNS zone file of the domain before the customer can complete domain ownership verification with Azure AD. Read-only, Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.internalDomainFederation:
@@ -11387,13 +11387,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.certificateBasedAuthConfiguration'
               description: Navigation property to manage certificate-based authentication configuration. Only a single instance of certificateBasedAuthConfiguration can be created in the collection.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the organization. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.organizationalBranding:
@@ -11407,7 +11407,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.organizationalBrandingLocalization'
               description: Add different branding based on a locale.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.organizationalBrandingLocalization:

--- a/openApiDocs/v1.0/Identity.Governance.yml
+++ b/openApiDocs/v1.0/Identity.Governance.yml
@@ -24610,7 +24610,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: Read-only. Information about acceptances of this agreement.
-              readOnly: true
+              x-ms-navigationProperty: true
             file:
               $ref: '#/components/schemas/microsoft.graph.agreementFile'
             files:
@@ -24618,7 +24618,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementFileLocalization'
               description: PDFs linked to this agreement. This property is in the process of being deprecated. Use the  file property instead. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptance:
@@ -24694,7 +24694,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementFileLocalization'
               description: The localized version of the terms of use agreement files attached to the agreement.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementFileLocalization:
@@ -24708,7 +24708,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementFileVersion'
               description: Read-only. Customized versions of the terms of use agreement in the Azure AD tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementFileVersion:
@@ -24743,13 +24743,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewScheduleDefinition'
               description: Represents the template and scheduling for an access review.
-              readOnly: true
+              x-ms-navigationProperty: true
             historyDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewHistoryDefinition'
               description: Represents a collection of access review history data and the scopes used to collect that data.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewScheduleDefinition:
@@ -24819,7 +24819,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstance'
               description: 'If the accessReviewScheduleDefinition is a recurring access review, instances represent each recurrence. A review that does not recur will have exactly one instance. Instances also represent each unique resource under review in the accessReviewScheduleDefinition. If a review has multiple resources and multiple instances, each resource will have a unique instance for each recurrence.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewInstance:
@@ -24861,19 +24861,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewReviewer'
               description: 'Returns the collection of reviewers who were contacted to complete this review. While the reviewers and fallbackReviewers properties of the accessReviewScheduleDefinition might specify group owners or managers as reviewers, contactedReviewers returns their individual identities. Supports $select. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             decisions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewInstance has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
             stages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewStage'
               description: 'If the instance has multiple stages, this returns the collection of stages. A new stage will only be created when the previous stage ends. The existence, number, and settings of stages on a review instance are created based on the accessReviewStageSettings on the parent accessReviewScheduleDefinition.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewReviewer:
@@ -24996,7 +24996,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItem'
               description: 'Each user reviewed in an accessReviewStage has a decision item representing if they were approved, denied, or not yet reviewed.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewStageFilterByCurrentUserOptions:
@@ -25062,7 +25062,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessReviewHistoryInstance'
               description: 'If the accessReviewHistoryDefinition is a recurring definition, instances represent each recurrence. A definition that does not recur will have exactly one instance.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewHistoryInstance:
@@ -25118,7 +25118,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appConsentRequest'
               description: A collection of userConsentRequest objects for a specific application.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.appConsentRequest:
@@ -25144,7 +25144,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConsentRequest'
               description: A list of pending user consent requests. Supports $filter (eq).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userConsentRequest:
@@ -25172,7 +25172,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvalStage'
               description: A collection of stages in the approval decision.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.approvalStage:
@@ -25228,43 +25228,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.approval'
               description: Approval stages for decisions associated with access package assignment requests.
-              readOnly: true
+              x-ms-navigationProperty: true
             accessPackages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessPackage'
               description: Access packages define the collection of resource roles and the policies for which subjects can request or be assigned access to those resources.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignmentPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessPackageAssignmentPolicy'
               description: Access package assignment policies govern which subjects can request or be assigned an access package via an access package assignment.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignmentRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessPackageAssignmentRequest'
               description: Access package assignment requests created by or on behalf of a subject.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessPackageAssignment'
               description: The assignment of an access package to a subject for a period of time.
-              readOnly: true
+              x-ms-navigationProperty: true
             catalogs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessPackageCatalog'
               description: A container for access packages.
-              readOnly: true
+              x-ms-navigationProperty: true
             connectedOrganizations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.connectedOrganization'
               description: References to a directory or domain of another organization whose users can request access.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               $ref: '#/components/schemas/microsoft.graph.entitlementManagementSettings'
           additionalProperties:
@@ -25312,12 +25312,12 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessPackage'
               description: The access packages that are incompatible with this package. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             assignmentPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessPackageAssignmentPolicy'
-              readOnly: true
+              x-ms-navigationProperty: true
             catalog:
               $ref: '#/components/schemas/microsoft.graph.accessPackageCatalog'
             incompatibleAccessPackages:
@@ -25325,13 +25325,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessPackage'
               description: The access packages whose assigned users are ineligible to be assigned this access package.
-              readOnly: true
+              x-ms-navigationProperty: true
             incompatibleGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.group'
               description: The groups whose members are ineligible to be assigned this access package.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessPackageAssignmentPolicy:
@@ -25385,7 +25385,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessPackageQuestion'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessPackageCatalog:
@@ -25427,7 +25427,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.accessPackage'
               description: The access packages in this catalog. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessPackageQuestion:
@@ -25496,7 +25496,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.accessPackageQuestion'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.accessPackageFilterByCurrentUserOptions:
@@ -25658,12 +25658,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
             internalSponsors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryObject:
@@ -25734,13 +25734,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: Represents the current status of a user's response to a company's customizable terms of use agreement.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreements:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreement'
               description: Represents a tenant's customizable terms of use agreement that's created and managed with Azure Active Directory (Azure AD).
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.rbacApplication:
@@ -25754,49 +25754,49 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignment'
               description: Resource to grant access to users or groups.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleDefinitions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleDefinition'
               description: Resource representing the roles allowed by RBAC providers and the permissions assigned to the roles.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignmentScheduleInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignmentScheduleInstance'
               description: Instances for active role assignments.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignmentScheduleRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignmentScheduleRequest'
               description: Requests for active role assignments to principals through PIM.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleAssignmentSchedules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleAssignmentSchedule'
               description: Schedules for active role assignment operations.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleEligibilityScheduleInstances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleEligibilityScheduleInstance'
               description: Instances for role eligibility requests.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleEligibilityScheduleRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleEligibilityScheduleRequest'
               description: Requests for role eligibilities for principals through PIM.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleEligibilitySchedules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleEligibilitySchedule'
               description: Schedules for role eligibility operations.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.unifiedRoleAssignment:
@@ -25895,7 +25895,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleDefinition'
               description: Read-only collection of role definitions that the given role definition inherits from. Only Azure AD built-in roles (isBuiltIn is true) support this attribute. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.unifiedRoleAssignmentScheduleInstance:
@@ -26629,7 +26629,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -26637,55 +26637,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -26693,31 +26693,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -26725,25 +26725,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -26755,7 +26755,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -27888,31 +27888,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -28034,7 +28034,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -28042,25 +28042,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversation:
@@ -28093,7 +28093,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -28138,7 +28138,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -28164,19 +28164,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -28186,7 +28186,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -28214,13 +28214,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -28228,42 +28228,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -28271,7 +28271,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -28317,7 +28317,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -28331,37 +28331,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -28445,13 +28445,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -28459,25 +28459,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -28487,7 +28487,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -28998,13 +28998,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -29012,13 +29012,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.baseItem:
@@ -29209,7 +29209,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -29217,25 +29217,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -29259,13 +29259,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -29273,19 +29273,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publicError:
@@ -29346,7 +29346,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -29512,25 +29512,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -29624,13 +29624,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -29660,7 +29660,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -29668,7 +29668,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -29702,13 +29702,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -29829,13 +29829,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -29859,7 +29859,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -30047,25 +30047,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -30174,7 +30174,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -30234,51 +30234,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.ErrorDetails:
@@ -30851,25 +30851,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -30877,41 +30877,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -30919,37 +30919,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -30957,13 +30957,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -30971,7 +30971,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -30979,42 +30979,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -31029,18 +31029,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -31049,12 +31049,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -31555,7 +31555,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -31563,25 +31563,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -31601,7 +31601,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -31611,7 +31611,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -31808,7 +31808,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -32121,12 +32121,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -32296,7 +32296,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -32330,7 +32330,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -32338,13 +32338,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanContainer:
@@ -32385,7 +32385,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -32740,13 +32740,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharedWithChannelTeamInfo:
@@ -32764,7 +32764,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTab:
@@ -32808,7 +32808,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -33439,7 +33439,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -33461,25 +33461,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -33613,13 +33613,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -33627,7 +33627,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -33641,7 +33641,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -33688,31 +33688,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -33813,25 +33813,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -33845,7 +33845,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -34182,13 +34182,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -34196,7 +34196,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -34260,19 +34260,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -34305,13 +34305,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -34325,19 +34325,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -34414,7 +34414,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -34508,7 +34508,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -34538,61 +34538,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -34636,7 +34636,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -34644,25 +34644,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -34676,13 +34676,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -34696,7 +34696,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.album:
@@ -34789,7 +34789,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -34889,13 +34889,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -34926,19 +34926,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -34946,7 +34946,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.documentSetVersion:
@@ -35140,13 +35140,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -37065,7 +37065,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -37376,13 +37376,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookCommentReply:
@@ -37520,7 +37520,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -38561,31 +38561,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationPhoneType:
@@ -38691,30 +38691,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilter:
@@ -38860,7 +38860,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/v1.0/Identity.SignIns.yml
+++ b/openApiDocs/v1.0/Identity.SignIns.yml
@@ -14579,24 +14579,24 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityApiConnector'
               description: Represents entry point for API connectors.
-              readOnly: true
+              x-ms-navigationProperty: true
             b2xUserFlows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.b2xIdentityUserFlow'
               description: Represents entry point for B2X/self-service sign-up identity userflows.
-              readOnly: true
+              x-ms-navigationProperty: true
             identityProviders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityProviderBase'
-              readOnly: true
+              x-ms-navigationProperty: true
             userFlowAttributes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityUserFlowAttribute'
               description: Represents entry point for identity userflow attributes.
-              readOnly: true
+              x-ms-navigationProperty: true
             conditionalAccess:
               $ref: '#/components/schemas/microsoft.graph.conditionalAccessRoot'
           additionalProperties:
@@ -14632,24 +14632,24 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityProvider'
               description: The identity providers included in the user flow.
-              readOnly: true
+              x-ms-navigationProperty: true
             languages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userFlowLanguageConfiguration'
               description: The languages supported for customization within the user flow. Language customization is enabled by default in self-service sign-up user flow. You cannot create custom languages in self-service sign-up user flows.
-              readOnly: true
+              x-ms-navigationProperty: true
             userAttributeAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityUserFlowAttributeAssignment'
               description: The user attribute assignments included in the user flow.
-              readOnly: true
+              x-ms-navigationProperty: true
             userFlowIdentityProviders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.identityProviderBase'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.identityProvider:
@@ -14694,13 +14694,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userFlowLanguagePage'
               description: Collection of pages with the default content to display in a user flow for a specified language. This collection does not allow any kind of modification.
-              readOnly: true
+              x-ms-navigationProperty: true
             overridesPages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userFlowLanguagePage'
               description: 'Collection of pages with the overrides messages to display in a user flow for a specified language. This collection only allows to modify the content of the page, any other modification is not allowed (creation or deletion of pages).'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userFlowLanguagePage:
@@ -14780,25 +14780,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationContextClassReference'
               description: Read-only. Nullable. Returns a collection of the specified authentication context class references.
-              readOnly: true
+              x-ms-navigationProperty: true
             namedLocations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.namedLocation'
               description: Read-only. Nullable. Returns a collection of the specified named locations.
-              readOnly: true
+              x-ms-navigationProperty: true
             policies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conditionalAccessPolicy'
               description: Read-only. Nullable. Returns a collection of the specified Conditional Access (CA) policies.
-              readOnly: true
+              x-ms-navigationProperty: true
             templates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conditionalAccessTemplate'
               description: Read-only. Nullable. Returns a collection of the specified Conditional Access templates.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationContextClassReference:
@@ -14917,25 +14917,25 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.riskDetection'
           description: Risk detection in Azure AD Identity Protection and the associated information about the detection.
-          readOnly: true
+          x-ms-navigationProperty: true
         riskyServicePrincipals:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.riskyServicePrincipal'
           description: Azure AD service principals that are at risk.
-          readOnly: true
+          x-ms-navigationProperty: true
         riskyUsers:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.riskyUser'
           description: Users that are flagged as at-risk by Azure AD Identity Protection.
-          readOnly: true
+          x-ms-navigationProperty: true
         servicePrincipalRiskDetections:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.servicePrincipalRiskDetection'
           description: Represents information about detected at-risk service principals in an Azure AD tenant.
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.riskDetection:
@@ -15057,7 +15057,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.riskyServicePrincipalHistoryItem'
               description: Represents the risk history of Azure AD service principals.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.riskyServicePrincipalHistoryItem:
@@ -15113,7 +15113,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.riskyUserHistoryItem'
               description: The activity related to user risk level change
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.riskyUserHistoryItem:
@@ -15226,7 +15226,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.threatAssessmentRequest'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.bitlocker:
@@ -15240,7 +15240,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.bitlockerRecoveryKey'
               description: The recovery keys associated with the bitlocker entity.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.bitlockerRecoveryKey:
@@ -15294,7 +15294,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.threatAssessmentResult'
               description: 'A collection of threat assessment results. Read-only. By default, a GET /threatAssessmentRequests/{id} does not return this property unless you apply $expand on it.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.threatAssessmentResult:
@@ -15690,25 +15690,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -15716,41 +15716,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -15758,37 +15758,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -15796,13 +15796,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -15810,7 +15810,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -15818,42 +15818,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -15868,18 +15868,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -15888,12 +15888,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -15954,7 +15954,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityBasedTimeoutPolicy'
               description: The policy that controls the idle time out for web sessions for applications.
-              readOnly: true
+              x-ms-navigationProperty: true
             authorizationPolicy:
               $ref: '#/components/schemas/microsoft.graph.authorizationPolicy'
             claimsMappingPolicies:
@@ -15962,7 +15962,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.claimsMappingPolicy'
               description: 'The claim-mapping policies for WS-Fed, SAML, OAuth 2.0, and OpenID Connect protocols, for tokens issued to a specific application.'
-              readOnly: true
+              x-ms-navigationProperty: true
             crossTenantAccessPolicy:
               $ref: '#/components/schemas/microsoft.graph.crossTenantAccessPolicy'
             homeRealmDiscoveryPolicies:
@@ -15970,31 +15970,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
               description: The policy to control Azure AD authentication behavior for federated users.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrantPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permissionGrantPolicy'
               description: The policy that specifies the conditions under which consent can be granted.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenIssuancePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
               description: The policy that specifies the characteristics of SAML tokens issued by Azure AD.
-              readOnly: true
+              x-ms-navigationProperty: true
             tokenLifetimePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
               description: 'The policy that controls the lifetime of a JWT access token, an ID token, or a SAML 1.1/2.0 token issued by Azure AD.'
-              readOnly: true
+              x-ms-navigationProperty: true
             featureRolloutPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.featureRolloutPolicy'
               description: The feature rollout policy associated with a directory object.
-              readOnly: true
+              x-ms-navigationProperty: true
             adminConsentRequestPolicy:
               $ref: '#/components/schemas/microsoft.graph.adminConsentRequestPolicy'
             conditionalAccessPolicies:
@@ -16002,7 +16002,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conditionalAccessPolicy'
               description: The custom rules that define an access scenario.
-              readOnly: true
+              x-ms-navigationProperty: true
             identitySecurityDefaultsEnforcementPolicy:
               $ref: '#/components/schemas/microsoft.graph.identitySecurityDefaultsEnforcementPolicy'
             roleManagementPolicies:
@@ -16010,13 +16010,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleManagementPolicy'
               description: Specifies the various policies associated with scopes and roles.
-              readOnly: true
+              x-ms-navigationProperty: true
             roleManagementPolicyAssignments:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleManagementPolicyAssignment'
               description: The assignment of a role management policy to a role definition object.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.activityBasedTimeoutPolicy:
@@ -16115,7 +16115,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethodConfiguration'
               description: Represents the settings for each authentication method. Automatically expanded on GET /policies/authenticationMethodsPolicy.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationMethodConfiguration:
@@ -16183,7 +16183,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.crossTenantAccessPolicyConfigurationPartner'
               description: Defines partner-specific configurations for external Azure Active Directory organizations.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.crossTenantAccessPolicyConfigurationDefault:
@@ -16257,7 +16257,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Nullable. Specifies a list of directoryObjects that feature is enabled for.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryObject:
@@ -16330,13 +16330,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permissionGrantConditionSet'
               description: Condition sets which are excluded in this permission grant policy. Automatically expanded on GET.
-              readOnly: true
+              x-ms-navigationProperty: true
             includes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permissionGrantConditionSet'
               description: Condition sets which are included in this permission grant policy. Automatically expanded on GET.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permissionGrantConditionSet:
@@ -16420,13 +16420,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleManagementPolicyRule'
               description: 'The list of effective rules like approval rules and expiration rules evaluated based on inherited referenced rules. For example, if there is a tenant-wide policy to enforce enabling an approval rule, the effective rule will be to enable approval even if the policy has a rule to disable approval. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             rules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.unifiedRoleManagementPolicyRule'
               description: The collection of rules like approval rules and expiration rules. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.unifiedRoleManagementPolicyRule:
@@ -16487,61 +16487,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -16724,31 +16724,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.longRunningOperation:
@@ -17712,31 +17712,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -17764,7 +17764,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -17886,7 +17886,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -17894,25 +17894,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -17934,25 +17934,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -18086,13 +18086,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -18100,7 +18100,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -18114,7 +18114,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -18161,31 +18161,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -18286,25 +18286,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -18318,7 +18318,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -18430,19 +18430,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -18452,7 +18452,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -18480,13 +18480,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -18494,42 +18494,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -18537,7 +18537,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -18859,13 +18859,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -18873,7 +18873,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -18937,19 +18937,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -18982,13 +18982,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -19002,19 +19002,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -19042,37 +19042,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -19157,7 +19157,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -19251,7 +19251,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -19311,7 +19311,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -19319,25 +19319,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -19399,13 +19399,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -19413,25 +19413,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -19441,7 +19441,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -19459,13 +19459,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -19479,7 +19479,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.certificateAuthority:
@@ -19528,7 +19528,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessReviewReviewerScope:
@@ -19711,7 +19711,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.directoryObject'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.attestationLevel:
@@ -21460,7 +21460,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -21468,25 +21468,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -21510,13 +21510,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -21524,19 +21524,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publicError:
@@ -21597,7 +21597,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -21763,25 +21763,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -21875,13 +21875,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -22631,7 +22631,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -22639,7 +22639,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -22859,13 +22859,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -22986,13 +22986,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -23016,7 +23016,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -23275,7 +23275,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chatType:
@@ -23471,13 +23471,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -23691,25 +23691,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -23887,7 +23887,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -23895,55 +23895,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -23951,31 +23951,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -23983,25 +23983,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -24013,7 +24013,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -24088,7 +24088,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -24148,51 +24148,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -24235,13 +24235,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationMethodsRegistrationCampaign:
@@ -25346,7 +25346,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -25354,25 +25354,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -25392,7 +25392,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -25402,7 +25402,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -25599,7 +25599,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -25912,12 +25912,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -26057,7 +26057,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -26091,7 +26091,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -26099,13 +26099,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.actionState:
@@ -26344,7 +26344,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -26830,7 +26830,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -27061,7 +27061,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.assignedLabel:
@@ -27166,7 +27166,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -27211,7 +27211,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -27248,7 +27248,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.operationError:
@@ -27574,30 +27574,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.excludeTarget:
@@ -27837,7 +27837,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -27937,13 +27937,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -27974,19 +27974,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -27994,7 +27994,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.documentSetVersion:
@@ -28188,13 +28188,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -28671,13 +28671,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -28685,13 +28685,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequest:
@@ -29068,7 +29068,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -29390,7 +29390,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/v1.0/Mail.yml
+++ b/openApiDocs/v1.0/Mail.yml
@@ -7775,7 +7775,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassificationOverride:
@@ -7834,31 +7834,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.messageRule:
@@ -7996,25 +7996,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attachment:

--- a/openApiDocs/v1.0/Notes.yml
+++ b/openApiDocs/v1.0/Notes.yml
@@ -21980,37 +21980,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -22044,13 +22044,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sectionGroup:
@@ -22076,13 +22076,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -22106,7 +22106,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:

--- a/openApiDocs/v1.0/People.yml
+++ b/openApiDocs/v1.0/People.yml
@@ -1292,19 +1292,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharedInsight:

--- a/openApiDocs/v1.0/PersonalContacts.yml
+++ b/openApiDocs/v1.0/PersonalContacts.yml
@@ -6380,25 +6380,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -6532,13 +6532,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -6546,7 +6546,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.extension:

--- a/openApiDocs/v1.0/Planner.yml
+++ b/openApiDocs/v1.0/Planner.yml
@@ -11603,7 +11603,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -11633,7 +11633,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -11641,7 +11641,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerBucket:
@@ -11666,7 +11666,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -11860,19 +11860,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Returns a collection of the specified buckets
-              readOnly: true
+              x-ms-navigationProperty: true
             plans:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns a collection of the specified plans
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns a collection of the specified tasks
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerUser:
@@ -11886,13 +11886,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.entity:

--- a/openApiDocs/v1.0/Reports.yml
+++ b/openApiDocs/v1.0/Reports.yml
@@ -5217,17 +5217,17 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryAudit'
-              readOnly: true
+              x-ms-navigationProperty: true
             provisioning:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.provisioningObjectSummary'
-              readOnly: true
+              x-ms-navigationProperty: true
             signIns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.signIn'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.directoryAudit:
@@ -5440,7 +5440,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementExportJob'
               description: Entity representing a job to export a report
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Singleton entity that acts as a container for all reports functionality.
@@ -5498,22 +5498,22 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printUsageByPrinter'
-          readOnly: true
+          x-ms-navigationProperty: true
         dailyPrintUsageByUser:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printUsageByUser'
-          readOnly: true
+          x-ms-navigationProperty: true
         monthlyPrintUsageByPrinter:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printUsageByPrinter'
-          readOnly: true
+          x-ms-navigationProperty: true
         monthlyPrintUsageByUser:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printUsageByUser'
-          readOnly: true
+          x-ms-navigationProperty: true
         security:
           $ref: '#/components/schemas/microsoft.graph.securityReportsRoot'
       additionalProperties:

--- a/openApiDocs/v1.0/Search.yml
+++ b/openApiDocs/v1.0/Search.yml
@@ -1518,7 +1518,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.externalConnectors.externalConnection'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.externalConnectors.externalConnection:
@@ -1543,17 +1543,17 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalConnectors.externalGroup'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalConnectors.externalItem'
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalConnectors.connectionOperation'
-              readOnly: true
+              x-ms-navigationProperty: true
             schema:
               $ref: '#/components/schemas/microsoft.graph.externalConnectors.schema'
           additionalProperties:
@@ -1577,7 +1577,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalConnectors.identity'
               description: 'A member added to an externalGroup. You can add Azure Active Directory users, Azure Active Directory groups, or an externalGroup as members.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.externalConnectors.identity:

--- a/openApiDocs/v1.0/Security.yml
+++ b/openApiDocs/v1.0/Security.yml
@@ -8149,30 +8149,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.alert'
               description: A collection of alerts in Microsoft 365 Defender.
-              readOnly: true
+              x-ms-navigationProperty: true
             incidents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.incident'
               description: 'A collection of incidents in Microsoft 365 Defender, each of which is a set of correlated alerts and associated metadata that reflects the story of an attack.'
-              readOnly: true
+              x-ms-navigationProperty: true
             attackSimulation:
               $ref: '#/components/schemas/microsoft.graph.attackSimulationRoot'
             alerts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.alert'
-              readOnly: true
+              x-ms-navigationProperty: true
             secureScoreControlProfiles:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.secureScoreControlProfile'
-              readOnly: true
+              x-ms-navigationProperty: true
             secureScores:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.secureScore'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.alert:
@@ -8498,13 +8498,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.simulationAutomation'
               description: Represents simulation automation created to run on a tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
             simulations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.simulation'
               description: Represents an attack simulation training campaign in a tenant.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.simulationAutomation:
@@ -8556,7 +8556,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.simulationAutomationRun'
               description: A collection of simulation automation runs.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.simulationAutomationRun:
@@ -8657,7 +8657,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryCase'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.ediscoveryCase:
@@ -8683,31 +8683,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryCustodian'
               description: Returns a list of case ediscoveryCustodian objects for this case.
-              readOnly: true
+              x-ms-navigationProperty: true
             noncustodialDataSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryNoncustodialDataSource'
               description: Returns a list of case ediscoveryNoncustodialDataSource objects for this case.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.caseOperation'
               description: Returns a list of case caseOperation objects for this case.
-              readOnly: true
+              x-ms-navigationProperty: true
             reviewSets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewSet'
               description: Returns a list of eDiscoveryReviewSet objects in the case.
-              readOnly: true
+              x-ms-navigationProperty: true
             searches:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoverySearch'
               description: Returns a list of eDiscoverySearch objects associated with this case.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               $ref: '#/components/schemas/microsoft.graph.security.ediscoveryCaseSettings'
             tags:
@@ -8715,7 +8715,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewTag'
               description: Returns a list of ediscoveryReviewTag objects associated to this case.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.ediscoveryCustodian:
@@ -8741,19 +8741,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.siteSource'
               description: Data source entity for SharePoint sites associated with the custodian.
-              readOnly: true
+              x-ms-navigationProperty: true
             unifiedGroupSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.unifiedGroupSource'
               description: Data source entity for groups associated with the custodian.
-              readOnly: true
+              x-ms-navigationProperty: true
             userSources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.userSource'
               description: Data source entity for a the custodian. This is the container for a custodian's mailbox and OneDrive for Business site.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.ediscoveryIndexOperation:
@@ -8798,13 +8798,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -8812,42 +8812,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -8855,7 +8855,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -9047,7 +9047,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -9055,55 +9055,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -9111,31 +9111,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -9143,25 +9143,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -9173,7 +9173,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -9275,7 +9275,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewSetQuery'
               description: Represents queries within the review set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.ediscoverySearch:
@@ -9291,7 +9291,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.dataSource'
               description: Adds an additional source to the eDiscovery search.
-              readOnly: true
+              x-ms-navigationProperty: true
             addToReviewSetOperation:
               $ref: '#/components/schemas/microsoft.graph.security.ediscoveryAddToReviewSetOperation'
             custodianSources:
@@ -9299,7 +9299,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.dataSource'
               description: Custodian sources that are included in the eDiscovery search.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastEstimateStatisticsOperation:
               $ref: '#/components/schemas/microsoft.graph.security.ediscoveryEstimateOperation'
             noncustodialSources:
@@ -9307,7 +9307,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryNoncustodialDataSource'
               description: noncustodialDataSource sources that are included in the eDiscovery search
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.additionalDataOptions:
@@ -9337,7 +9337,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewTag'
               description: Returns the tags that are a child of a tag.
-              readOnly: true
+              x-ms-navigationProperty: true
             parent:
               $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewTag'
           additionalProperties:
@@ -9486,7 +9486,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.alert'
               description: The list of related alerts. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.huntingQueryResults:
@@ -10654,7 +10654,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -10820,25 +10820,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -10864,19 +10864,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -10886,7 +10886,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -10910,13 +10910,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -10924,19 +10924,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -11030,13 +11030,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -11050,37 +11050,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.security.sourceType:
@@ -11320,31 +11320,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -11466,7 +11466,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -11474,25 +11474,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversation:
@@ -11525,7 +11525,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -11570,7 +11570,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.extension:
@@ -11614,7 +11614,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -11698,13 +11698,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -11712,25 +11712,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -11740,7 +11740,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -13011,25 +13011,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -13037,41 +13037,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -13079,37 +13079,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -13117,13 +13117,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -13131,7 +13131,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -13139,42 +13139,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -13189,18 +13189,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -13209,12 +13209,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -13301,7 +13301,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -13614,12 +13614,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -13777,7 +13777,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -13785,25 +13785,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listInfo:
@@ -13841,7 +13841,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -13851,7 +13851,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -14038,7 +14038,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -14072,7 +14072,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -14080,13 +14080,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -14120,13 +14120,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -14247,13 +14247,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -14277,7 +14277,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -14650,13 +14650,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -14664,13 +14664,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -14700,7 +14700,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -14708,7 +14708,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamFunSettings:
@@ -14892,25 +14892,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -15019,7 +15019,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -15079,51 +15079,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.certificationControl:
@@ -15615,7 +15615,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -15637,25 +15637,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -15789,13 +15789,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -15803,7 +15803,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -15817,7 +15817,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -15864,31 +15864,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -15989,25 +15989,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -16021,7 +16021,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -16420,13 +16420,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -16434,7 +16434,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -16498,19 +16498,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -16543,13 +16543,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -16563,19 +16563,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -16652,7 +16652,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -16746,7 +16746,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -16776,61 +16776,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -16874,7 +16874,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -16882,25 +16882,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userTeamwork:
@@ -16914,13 +16914,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -16934,7 +16934,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActionStat:
@@ -17031,13 +17031,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -17550,7 +17550,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -17558,25 +17558,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnailSet:
@@ -18103,7 +18103,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -18336,13 +18336,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharedWithChannelTeamInfo:
@@ -18360,7 +18360,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTab:
@@ -18404,7 +18404,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -20080,7 +20080,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -20391,13 +20391,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.accessAction:
@@ -20527,7 +20527,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -20627,13 +20627,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -20664,19 +20664,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -20684,7 +20684,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -22145,31 +22145,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationPhoneType:
@@ -22275,30 +22275,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookCommentReply:
@@ -22436,7 +22436,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -23041,7 +23041,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/openApiDocs/v1.0/Sites.yml
+++ b/openApiDocs/v1.0/Sites.yml
@@ -102947,13 +102947,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -102961,42 +102961,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -103004,7 +103004,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -103021,7 +103021,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -103187,25 +103187,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.columnLink:
@@ -103243,19 +103243,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -103265,7 +103265,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.baseItem:
@@ -103333,13 +103333,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -103347,19 +103347,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -103379,7 +103379,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -103389,7 +103389,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.documentSetVersion:
@@ -103494,7 +103494,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -103502,25 +103502,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.fieldValueSet:
@@ -103638,37 +103638,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -103702,13 +103702,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sectionGroup:
@@ -103734,13 +103734,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -103764,7 +103764,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -103932,13 +103932,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.group:
@@ -103972,7 +103972,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -104006,7 +104006,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -104014,13 +104014,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.term:
@@ -104061,13 +104061,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -104163,7 +104163,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenotePatchContentCommand:
@@ -104682,12 +104682,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -105103,25 +105103,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -105129,41 +105129,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -105171,37 +105171,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -105209,13 +105209,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -105223,7 +105223,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -105231,42 +105231,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -105281,18 +105281,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -105301,12 +105301,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -105833,7 +105833,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -105841,25 +105841,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnailSet:
@@ -107162,31 +107162,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -107214,7 +107214,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -107336,7 +107336,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -107344,25 +107344,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -107384,25 +107384,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -107536,13 +107536,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -107550,7 +107550,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -107564,7 +107564,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -107611,31 +107611,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -107736,25 +107736,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -107768,7 +107768,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -108174,13 +108174,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -108188,7 +108188,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -108252,19 +108252,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -108297,13 +108297,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -108317,19 +108317,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -108428,7 +108428,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -108522,7 +108522,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -108552,61 +108552,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -108650,7 +108650,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -108658,25 +108658,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -108738,13 +108738,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -108752,25 +108752,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -108780,7 +108780,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -108798,13 +108798,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -108818,7 +108818,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.album:
@@ -108911,7 +108911,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -109011,13 +109011,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -109048,19 +109048,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -109068,7 +109068,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.thumbnail:
@@ -110524,7 +110524,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -110532,7 +110532,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -110973,7 +110973,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -111361,13 +111361,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -111581,25 +111581,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -111777,7 +111777,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -111785,55 +111785,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -111841,31 +111841,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -111873,25 +111873,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -111903,7 +111903,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -111978,7 +111978,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -112038,51 +112038,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -112125,13 +112125,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookCommentReply:
@@ -112269,7 +112269,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -113014,7 +113014,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -113453,31 +113453,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationPhoneType:
@@ -113537,7 +113537,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -113768,7 +113768,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.assignedLabel:
@@ -113873,7 +113873,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -113918,7 +113918,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -113955,7 +113955,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.operationError:
@@ -114273,30 +114273,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilter:
@@ -114442,7 +114442,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -114979,13 +114979,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -114993,13 +114993,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequest:

--- a/openApiDocs/v1.0/Teams.yml
+++ b/openApiDocs/v1.0/Teams.yml
@@ -43521,7 +43521,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -43611,7 +43611,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -43619,25 +43619,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppInstallation:
@@ -43801,13 +43801,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chatMessageHostedContent:
@@ -43961,13 +43961,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -43975,25 +43975,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -44003,7 +44003,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -44054,25 +44054,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.driveItem:
@@ -44148,7 +44148,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -44156,25 +44156,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.sharedWithChannelTeamInfo:
@@ -44192,7 +44192,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -44370,7 +44370,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -44378,55 +44378,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -44434,31 +44434,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -44466,25 +44466,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -44496,7 +44496,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -44611,51 +44611,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.offerShiftRequest:
@@ -44858,7 +44858,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamworkTagMember:
@@ -44925,7 +44925,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workforceIntegration'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workforceIntegration:
@@ -44970,13 +44970,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -46010,7 +46010,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -46018,25 +46018,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemAnalytics:
@@ -46051,7 +46051,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -46073,7 +46073,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -46083,7 +46083,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -46477,31 +46477,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -46623,7 +46623,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -46631,25 +46631,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversation:
@@ -46682,7 +46682,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -46727,7 +46727,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.drive:
@@ -46753,19 +46753,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -46775,7 +46775,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -46803,13 +46803,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -46817,42 +46817,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -46860,7 +46860,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -46906,7 +46906,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -46920,37 +46920,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.operationError:
@@ -47997,25 +47997,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -48023,41 +48023,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -48065,37 +48065,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -48103,13 +48103,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -48117,7 +48117,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -48125,42 +48125,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -48175,18 +48175,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -48195,12 +48195,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -48302,7 +48302,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -48402,13 +48402,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -48439,19 +48439,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -48459,7 +48459,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityStat:
@@ -48501,7 +48501,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contentTypeInfo:
@@ -49030,13 +49030,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -49044,13 +49044,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.quota:
@@ -49111,13 +49111,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -49125,19 +49125,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.siteCollection:
@@ -49317,25 +49317,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -49382,13 +49382,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlan:
@@ -49418,7 +49418,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -49426,7 +49426,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.notebook:
@@ -49460,13 +49460,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -49587,13 +49587,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -49617,7 +49617,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -50053,7 +50053,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -50075,25 +50075,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -50227,13 +50227,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -50241,7 +50241,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -50255,7 +50255,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -50302,31 +50302,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -50427,25 +50427,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -50459,7 +50459,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -50858,13 +50858,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -50872,7 +50872,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -50936,19 +50936,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -50981,13 +50981,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -51001,19 +51001,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -51090,7 +51090,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -51184,7 +51184,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -51214,61 +51214,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -51282,7 +51282,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookCommentReply:
@@ -51425,7 +51425,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -52074,12 +52074,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -52188,7 +52188,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -52222,7 +52222,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -52230,13 +52230,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanContainer:
@@ -52277,7 +52277,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -53862,7 +53862,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -54080,13 +54080,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilter:
@@ -54232,7 +54232,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -54396,13 +54396,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -55471,31 +55471,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.authenticationPhoneType:
@@ -55591,30 +55591,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilterCriteria:

--- a/openApiDocs/v1.0/Users.Actions.yml
+++ b/openApiDocs/v1.0/Users.Actions.yml
@@ -16575,7 +16575,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -16583,25 +16583,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -16773,25 +16773,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.provisionChannelEmailResult:
@@ -16919,25 +16919,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -16984,31 +16984,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.updateWindowsDeviceAccountActionParameter:
@@ -17264,7 +17264,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attachmentInfo:
@@ -18039,7 +18039,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -18047,25 +18047,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemAnalytics:
@@ -18080,7 +18080,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -18102,7 +18102,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -18112,7 +18112,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -18314,12 +18314,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -18865,7 +18865,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.assignedLicense:
@@ -19291,25 +19291,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -19317,41 +19317,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -19359,37 +19359,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -19397,13 +19397,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -19411,7 +19411,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -19419,42 +19419,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -19469,18 +19469,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -19489,12 +19489,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -19750,7 +19750,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -19850,13 +19850,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -19887,19 +19887,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -19907,7 +19907,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityStat:
@@ -19949,7 +19949,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contentTypeInfo:
@@ -21104,31 +21104,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -21156,7 +21156,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -21278,7 +21278,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -21286,25 +21286,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -21326,25 +21326,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -21478,13 +21478,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -21492,7 +21492,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -21506,7 +21506,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -21520,7 +21520,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -21632,19 +21632,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -21654,7 +21654,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -21682,13 +21682,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -21696,42 +21696,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -21739,7 +21739,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -22054,13 +22054,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -22068,7 +22068,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -22132,19 +22132,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -22177,13 +22177,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -22197,19 +22197,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -22237,37 +22237,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.profilePhoto:
@@ -22352,7 +22352,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -22382,61 +22382,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -22480,7 +22480,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -22488,25 +22488,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -22568,13 +22568,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -22582,25 +22582,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -22610,7 +22610,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -22628,13 +22628,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -22648,7 +22648,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.meetingTimeSuggestion:
@@ -22880,7 +22880,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -23026,13 +23026,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -23068,7 +23068,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -23076,13 +23076,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.displayNameLocalization:
@@ -23598,13 +23598,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -23612,19 +23612,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.siteCollection:
@@ -23687,13 +23687,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -24443,7 +24443,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -24451,7 +24451,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -24671,13 +24671,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenotePage:
@@ -24776,13 +24776,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -24806,7 +24806,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -25286,13 +25286,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -25498,25 +25498,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -25694,7 +25694,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -25702,55 +25702,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -25758,31 +25758,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -25790,25 +25790,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -25820,7 +25820,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -25895,7 +25895,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -25955,51 +25955,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -26042,13 +26042,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attendeeAvailability:
@@ -26204,7 +26204,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -26379,7 +26379,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookGeoCoordinates:
@@ -26860,7 +26860,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -27284,31 +27284,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.longRunningOperationStatus:
@@ -27367,7 +27367,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -27598,7 +27598,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.assignedLabel:
@@ -27703,7 +27703,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -27748,7 +27748,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -27785,7 +27785,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.operationError:
@@ -28103,30 +28103,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFilterCriteria:
@@ -28693,13 +28693,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -28707,13 +28707,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequest:

--- a/openApiDocs/v1.0/Users.Functions.yml
+++ b/openApiDocs/v1.0/Users.Functions.yml
@@ -11016,7 +11016,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -11138,7 +11138,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -11146,25 +11146,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarRoleType:
@@ -11270,13 +11270,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -11410,13 +11410,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -11424,7 +11424,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -11446,25 +11446,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemActivityStat:
@@ -11506,7 +11506,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.driveItem:
@@ -11582,7 +11582,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -11590,25 +11590,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contentType:
@@ -11674,25 +11674,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -11793,25 +11793,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -11858,31 +11858,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenotePagePreview:
@@ -12009,30 +12009,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todoTaskList:
@@ -12058,13 +12058,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.user:
@@ -12398,25 +12398,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -12424,41 +12424,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -12466,37 +12466,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -12504,13 +12504,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -12518,7 +12518,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -12526,42 +12526,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -12576,18 +12576,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -12596,12 +12596,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -12996,31 +12996,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.extension:
@@ -13878,7 +13878,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -13886,25 +13886,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.itemAnalytics:
@@ -13919,7 +13919,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -13941,7 +13941,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -13951,7 +13951,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.permission:
@@ -14127,12 +14127,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -14957,7 +14957,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -14971,7 +14971,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookUser:
@@ -14985,7 +14985,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -15097,19 +15097,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -15119,7 +15119,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -15147,13 +15147,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -15161,42 +15161,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -15204,7 +15204,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -15519,13 +15519,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -15533,7 +15533,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -15597,19 +15597,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -15642,13 +15642,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -15662,19 +15662,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userSettings:
@@ -15702,37 +15702,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -15826,7 +15826,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -15856,61 +15856,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -15954,7 +15954,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -15962,25 +15962,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -16042,13 +16042,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -16056,25 +16056,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -16084,7 +16084,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -16102,13 +16102,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -16122,7 +16122,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.ODataErrors.ODataError:
@@ -16648,7 +16648,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -16748,13 +16748,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -16785,19 +16785,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -16805,7 +16805,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contentTypeInfo:
@@ -17687,13 +17687,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -17701,19 +17701,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publicError:
@@ -17801,13 +17801,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -18527,7 +18527,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -18535,7 +18535,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -18755,13 +18755,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -18882,13 +18882,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -18912,7 +18912,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -19084,7 +19084,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -19622,25 +19622,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -19818,7 +19818,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -19826,55 +19826,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -19882,31 +19882,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -19914,25 +19914,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -19944,7 +19944,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -20019,7 +20019,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -20079,51 +20079,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -20367,7 +20367,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -20469,13 +20469,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -20511,7 +20511,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -20519,13 +20519,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.displayNameLocalization:
@@ -20746,7 +20746,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.actionState:
@@ -20985,7 +20985,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -21525,31 +21525,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.longRunningOperationStatus:
@@ -21618,7 +21618,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -21712,7 +21712,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.assignedLabel:
@@ -21817,7 +21817,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -21862,7 +21862,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -21899,7 +21899,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.operationError:
@@ -22329,7 +22329,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:
@@ -22805,13 +22805,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -22819,13 +22819,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequest:

--- a/openApiDocs/v1.0/Users.yml
+++ b/openApiDocs/v1.0/Users.yml
@@ -6284,25 +6284,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a user has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that were created by the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             directReports:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             licenseDetails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseDetails'
               description: A collection of this user's license details. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             manager:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -6310,41 +6310,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The groups and directory roles that the user is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             oauth2PermissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.oAuth2PermissionGrant'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Devices that are owned by the user. Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1).'
-              readOnly: true
+              x-ms-navigationProperty: true
             ownedObjects:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Directory objects that are owned by the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Devices that are registered for the user. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             scopedRoleMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.scopedRoleMembership'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups, including nested groups, and directory roles that a user is a member of. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarGroups:
@@ -6352,37 +6352,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarGroup'
               description: The user's calendar groups. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendars:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The user's calendars. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contactFolders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The user's contacts folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The user's contacts. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             inferenceClassification:
               $ref: '#/components/schemas/microsoft.graph.inferenceClassification'
             mailFolders:
@@ -6390,13 +6390,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The user's mail folders. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The messages in a mailbox or folder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             people:
@@ -6404,7 +6404,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.person'
               description: People that are relevant to the user. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -6412,42 +6412,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: A collection of drives available for this user. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             followedSites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the user. Read-only. Supports $expand. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.agreementAcceptance'
               description: The user's terms of use acceptance statuses. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedDevices:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedDevice'
               description: The managed devices associated with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             managedAppRegistrations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppRegistration'
               description: Zero or more managed app registrations that belong to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceManagementTroubleshootingEvents:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceManagementTroubleshootingEvent'
               description: The list of troubleshooting events for this user.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerUser'
             insights:
@@ -6462,18 +6462,18 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
-              readOnly: true
+              x-ms-navigationProperty: true
             activities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             onlineMeetings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
-              readOnly: true
+              x-ms-navigationProperty: true
             presence:
               $ref: '#/components/schemas/microsoft.graph.presence'
             authentication:
@@ -6482,12 +6482,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chat'
-              readOnly: true
+              x-ms-navigationProperty: true
             joinedTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.team'
-              readOnly: true
+              x-ms-navigationProperty: true
             teamwork:
               $ref: '#/components/schemas/microsoft.graph.userTeamwork'
             todo:
@@ -6575,7 +6575,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.outlookCategory'
               description: A list of categories defined for the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.outlookCategory:
@@ -6652,7 +6652,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTaskList'
               description: The task lists in the users mailbox.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todoTaskList:
@@ -6678,13 +6678,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.todoTask'
               description: The tasks in this task list. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todoTask:
@@ -6746,30 +6746,30 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentBase'
               description: A collection of file attachments for the task.
-              readOnly: true
+              x-ms-navigationProperty: true
             attachmentSessions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachmentSession'
-              readOnly: true
+              x-ms-navigationProperty: true
             checklistItems:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.checklistItem'
               description: A collection of checklistItems linked to a task.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             linkedResources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.linkedResource'
               description: A collection of resources linked to the task.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.attachmentBase:
@@ -7271,31 +7271,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarPermission'
               description: The permissions of the users with whom the calendar is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendarView:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The events in the calendar. Navigation property. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the calendar. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.calendarGroup:
@@ -7323,7 +7323,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendar'
               description: The calendars in the calendar group. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.event:
@@ -7445,7 +7445,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: 'The collection of FileAttachment, ItemAttachment, and referenceAttachment attachments for the event. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             extensions:
@@ -7453,25 +7453,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the event. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             instances:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: 'The occurrences of a recurring series, if the event is a series master. This property includes occurrences that are part of the recurrence pattern, and exceptions that have been modified, but does not include occurrences that have been cancelled from the series. Navigation property. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the event. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contactFolder:
@@ -7493,25 +7493,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contactFolder'
               description: The collection of child folders in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             contacts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contact'
               description: The contacts in the folder. Navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.contact:
@@ -7645,13 +7645,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             singleValueExtendedProperties:
@@ -7659,7 +7659,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the contact. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.inferenceClassification:
@@ -7673,7 +7673,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.inferenceClassificationOverride'
               description: 'A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.mailFolder:
@@ -7720,31 +7720,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.mailFolder'
               description: The collection of child folders in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messageRules:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.messageRule'
               description: The collection of rules that apply to the user's Inbox folder.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.message'
               description: The collection of messages in the mailFolder.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.message:
@@ -7845,25 +7845,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: The fileAttachment and itemAttachment attachments for the message.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             multiValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the message. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.person:
@@ -7975,19 +7975,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: 'Collection of [bundles][bundle] (albums and multi-select-shared sets of items). Only in personal OneDrive.'
-              readOnly: true
+              x-ms-navigationProperty: true
             following:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: The list of items the user is following. Only in OneDrive for Business.
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: All items contained in the drive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             list:
               $ref: '#/components/schemas/microsoft.graph.list'
             root:
@@ -7997,7 +7997,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection of common folders available in OneDrive. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.site:
@@ -8025,13 +8025,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions reusable across lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types defined for this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -8039,42 +8039,42 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The collection of drives (document libraries) under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             externalColumns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-              readOnly: true
+              x-ms-navigationProperty: true
             items:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.baseItem'
               description: Used to address any item contained in this site. This collection can't be enumerated.
-              readOnly: true
+              x-ms-navigationProperty: true
             lists:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.list'
               description: The collection of lists under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the site.
-              readOnly: true
+              x-ms-navigationProperty: true
             permissions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The permissions associated with the site. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The collection of the sub-sites under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             termStore:
               $ref: '#/components/schemas/microsoft.graph.termStore.store'
             termStores:
@@ -8082,7 +8082,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.store'
               description: The collection of termStores under this site.
-              readOnly: true
+              x-ms-navigationProperty: true
             onenote:
               $ref: '#/components/schemas/microsoft.graph.onenote'
           additionalProperties:
@@ -8397,13 +8397,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceCompliancePolicyState'
               description: Device compliance policy states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceConfigurationStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.deviceConfigurationState'
               description: Device configuration states for this device.
-              readOnly: true
+              x-ms-navigationProperty: true
             deviceCategory:
               $ref: '#/components/schemas/microsoft.graph.deviceCategory'
             users:
@@ -8411,7 +8411,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.user'
               description: The primary users associated with the managed device.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: Devices that are managed or pre-enrolled through Intune
@@ -8475,19 +8475,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policys already applied on the registered app when it last synchronized with managment service.
-              readOnly: true
+              x-ms-navigationProperty: true
             intendedPolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppPolicy'
               description: Zero or more policies admin intended for the app as of now.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.managedAppOperation'
               description: Zero or more long running operations triggered on the app registration.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
           description: The ManagedAppEntity is the base entity type for all other entity types under app management workflow.
@@ -8520,13 +8520,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerTasks assigned to the user.
-              readOnly: true
+              x-ms-navigationProperty: true
             tasks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Returns the plannerPlans shared with the user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.officeGraphInsights:
@@ -8540,19 +8540,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedInsight'
               description: 'Calculated relationship identifying documents shared with or by the user. This includes URLs, file attachments, and reference attachments to OneDrive for Business and SharePoint files found in Outlook messages and meetings. This also includes URLs and reference attachments to Teams conversations. Ordered by recency of share.'
-              readOnly: true
+              x-ms-navigationProperty: true
             trending:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.trending'
               description: 'Calculated relationship identifying documents trending around a user. Trending documents are calculated based on activity of the user''s closest network of people and include files stored in OneDrive for Business and SharePoint. Trending insights help the user to discover potentially useful content that the user has access to, but has never viewed before.'
-              readOnly: true
+              x-ms-navigationProperty: true
             used:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.usedInsight'
               description: 'Calculated relationship identifying the latest documents viewed or modified by a user, including OneDrive for Business and SharePoint documents, ranked by recency of use.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenote:
@@ -8566,37 +8566,37 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.notebook'
               description: The collection of OneNote notebooks that are owned by the user or group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteOperation'
               description: 'The status of OneNote operations. Getting an operations collection is not supported, but you can get the status of long-running operations if the Operation-Location header is returned in the response. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             pages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The pages in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             resources:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteResource'
               description: 'The image and other file resources in OneNote pages. Getting a resources collection is not supported, but you can get the binary content of a specific resource. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             sectionGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in all OneNote notebooks that are owned by the user or group.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.userActivity:
@@ -8659,7 +8659,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.activityHistoryItem'
               description: Optional. NavigationProperty/Containment; navigation property to the activity's historyItems.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onlineMeeting:
@@ -8753,7 +8753,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingAttendanceReport'
               description: The attendance reports of an online meeting. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.presence:
@@ -8783,61 +8783,61 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.emailAuthenticationMethod'
               description: The email address registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             fido2Methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fido2AuthenticationMethod'
               description: Represents the FIDO2 security keys registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             methods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.authenticationMethod'
               description: Represents all authentication methods registered to a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             microsoftAuthenticatorMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
               description: The details of the Microsoft Authenticator app registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.longRunningOperation'
               description: Represents the status of a long-running operation.
-              readOnly: true
+              x-ms-navigationProperty: true
             passwordMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.passwordAuthenticationMethod'
               description: 'Represents the password that''s registered to a user for authentication. For security, the password itself will never be returned in the object, but action can be taken to reset a password.'
-              readOnly: true
+              x-ms-navigationProperty: true
             phoneMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.phoneAuthenticationMethod'
               description: The phone numbers registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             softwareOathMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.softwareOathAuthenticationMethod'
               description: The software OATH TOTP applications registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
             temporaryAccessPassMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.temporaryAccessPassAuthenticationMethod'
               description: Represents a Temporary Access Pass registered to a user for authentication through time-limited passcodes.
-              readOnly: true
+              x-ms-navigationProperty: true
             windowsHelloForBusinessMethods:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.windowsHelloForBusinessAuthenticationMethod'
               description: Represents the Windows Hello for Business authentication method registered to a user for authentication.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.chat:
@@ -8881,7 +8881,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: A collection of all the apps in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             lastMessagePreview:
               $ref: '#/components/schemas/microsoft.graph.chatMessageInfo'
             members:
@@ -8889,25 +8889,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of all the members in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             pinnedMessages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.pinnedChatMessageInfo'
               description: A collection of all the pinned messages in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.team:
@@ -8969,13 +8969,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels either hosted in or shared with the team (incoming channels).
-              readOnly: true
+              x-ms-navigationProperty: true
             channels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: The collection of channels and messages associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             group:
               $ref: '#/components/schemas/microsoft.graph.group'
             incomingChannels:
@@ -8983,25 +8983,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.channel'
               description: List of channels shared with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppInstallation'
               description: The apps installed in this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: Members and owners of the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAsyncOperation'
               description: The async operations that ran or are running on this team.
-              readOnly: true
+              x-ms-navigationProperty: true
             photo:
               $ref: '#/components/schemas/microsoft.graph.profilePhoto'
             primaryChannel:
@@ -9011,7 +9011,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTag'
               description: The tags associated with the team.
-              readOnly: true
+              x-ms-navigationProperty: true
             template:
               $ref: '#/components/schemas/microsoft.graph.teamsTemplate'
             schedule:
@@ -9029,13 +9029,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.associatedTeamInfo'
               description: The list of associatedTeamInfo objects that a user is associated with.
-              readOnly: true
+              x-ms-navigationProperty: true
             installedApps:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.entity:
@@ -10131,7 +10131,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItem'
               description: Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             listItem:
               $ref: '#/components/schemas/microsoft.graph.listItem'
             permissions:
@@ -10139,25 +10139,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.permission'
               description: The set of permissions for the item. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the item. Only supported on the root of a drive.
-              readOnly: true
+              x-ms-navigationProperty: true
             thumbnails:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.thumbnailSet'
               description: 'Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.driveItemVersion'
               description: 'The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.list:
@@ -10181,13 +10181,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of field definitions for this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             contentTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types present in this list.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             items:
@@ -10195,19 +10195,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItem'
               description: All items contained in the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.richLongRunningOperation'
               description: The collection of long-running operations on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
             subscriptions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.subscription'
               description: The set of subscriptions on the list.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.publicError:
@@ -10268,7 +10268,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
-              readOnly: true
+              x-ms-navigationProperty: true
             lastSevenDays:
               $ref: '#/components/schemas/microsoft.graph.itemActivityStat'
           additionalProperties:
@@ -10434,25 +10434,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.contentType'
               description: The collection of content types that are ancestors of this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnLinks:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnLink'
               description: The collection of columns that are required by this content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columnPositions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: Column order information in a content type.
-              readOnly: true
+              x-ms-navigationProperty: true
             columns:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.columnDefinition'
               description: The collection of column definitions for this contentType.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.richLongRunningOperation:
@@ -10546,13 +10546,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.group'
               description: Collection of all groups available in the term store.
-              readOnly: true
+              x-ms-navigationProperty: true
             sets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: Collection of all sets available in the term store. This relationship can only be used to load a specific term set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -11302,7 +11302,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerBucket'
               description: Read-only. Nullable. Collection of buckets in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanDetails'
             tasks:
@@ -11310,7 +11310,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. Collection of tasks in the plan.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerTask:
@@ -11517,13 +11517,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the notebook. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteOperation:
@@ -11644,13 +11644,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.sectionGroup'
               description: The section groups in the section. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sections:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenoteSection'
               description: The sections in the section group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.onenoteSection:
@@ -11674,7 +11674,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.onenotePage'
               description: The collection of pages in the section.  Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             parentNotebook:
               $ref: '#/components/schemas/microsoft.graph.notebook'
             parentSectionGroup:
@@ -11933,7 +11933,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.emailAuthenticationMethod:
@@ -12351,13 +12351,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
               description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
-              readOnly: true
+              x-ms-navigationProperty: true
             replies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: Replies for a specified message. Supports $expand for channel messages.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.pinnedChatMessageInfo:
@@ -12571,25 +12571,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel.
-              readOnly: true
+              x-ms-navigationProperty: true
             messages:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.chatMessage'
               description: A collection of all the messages in the channel. A navigation property. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             sharedWithTeams:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.sharedWithChannelTeamInfo'
               description: A collection of teams with which a channel is shared.
-              readOnly: true
+              x-ms-navigationProperty: true
             tabs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the channel. A navigation property.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.group:
@@ -12767,7 +12767,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRoleAssignment'
               description: Represents the app roles a group has been granted for an application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             createdOnBehalfOf:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
             memberOf:
@@ -12775,55 +12775,55 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The members of this group, who can be users, devices, other groups, or service principals. Supports the List members, Add member, and Remove member operations. Nullable. Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=members($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             membersWithLicenseErrors:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: A list of group members with license errors from this group-based license assignment. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             owners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The owners of the group. Limited to 100 owners. Nullable. If this property is not specified when creating a Microsoft 365 group, the calling user is automatically assigned as the group owner.  Supports $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1). Supports $expand including nested $select. For example, /groups?$filter=startsWith(displayName,''Role'')&$select=id,displayName&$expand=owners($select=id,userPrincipalName,displayName).'
-              readOnly: true
+              x-ms-navigationProperty: true
             permissionGrants:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.resourceSpecificPermissionGrant'
               description: The permission that has been granted for a group to a specific application. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             settings:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupSetting'
               description: 'Settings that can govern this group''s behavior, like whether members can invite guest users to the group. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The groups that a group is a member of, either directly and through nested membership. Nullable.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMembers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The direct and transitive members of a group. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             acceptedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post.
-              readOnly: true
+              x-ms-navigationProperty: true
             calendar:
               $ref: '#/components/schemas/microsoft.graph.calendar'
             calendarView:
@@ -12831,31 +12831,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The calendar view for the calendar. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             conversations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversation'
               description: The group's conversations.
-              readOnly: true
+              x-ms-navigationProperty: true
             events:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.event'
               description: The group's calendar events.
-              readOnly: true
+              x-ms-navigationProperty: true
             rejectedSenders:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable
-              readOnly: true
+              x-ms-navigationProperty: true
             threads:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: The group's conversation threads. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             drive:
               $ref: '#/components/schemas/microsoft.graph.drive'
             drives:
@@ -12863,25 +12863,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.drive'
               description: The group's drives. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sites:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.site'
               description: The list of SharePoint sites in this group. Access the default site with /sites/root.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             groupLifecyclePolicies:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.groupLifecyclePolicy'
               description: The collection of lifecycle policies for this group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             planner:
               $ref: '#/components/schemas/microsoft.graph.plannerGroup'
             onenote:
@@ -12893,7 +12893,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.profilePhoto'
               description: The profile photos owned by the group. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             team:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
@@ -12968,7 +12968,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamworkTagMember'
               description: Users assigned to the tag.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsTemplate:
@@ -13028,51 +13028,51 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.offerShiftRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShiftChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShiftChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             openShifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.openShift'
-              readOnly: true
+              x-ms-navigationProperty: true
             schedulingGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.schedulingGroup'
               description: The logical grouping of users in the schedule (usually by role).
-              readOnly: true
+              x-ms-navigationProperty: true
             shifts:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.shift'
               description: The shifts in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             swapShiftsChangeRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.swapShiftsChangeRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffReasons:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffReason'
               description: The set of reasons for a time off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
             timeOffRequests:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOffRequest'
-              readOnly: true
+              x-ms-navigationProperty: true
             timesOff:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.timeOff'
               description: The instances of times off in the schedule.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -14091,7 +14091,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
-              readOnly: true
+              x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
             names:
@@ -14099,25 +14099,25 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Represents a collection of workbooks scoped named items (named ranges and constants). Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             operations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookOperation'
               description: 'The status of workbook operations. Getting an operation collection is not supported, but you can get the status of a long-running operation if the Location header is returned in the response. Read-only.'
-              readOnly: true
+              x-ms-navigationProperty: true
             tables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Represents a collection of tables associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             worksheets:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookWorksheet'
               description: Represents a collection of worksheets associated with the workbook. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.listItem:
@@ -14137,7 +14137,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.documentSetVersion'
               description: Version information for a document set version created by a user.
-              readOnly: true
+              x-ms-navigationProperty: true
             driveItem:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
             fields:
@@ -14147,7 +14147,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.listItemVersion'
               description: The list of previous versions of the list item.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.subscription:
@@ -14344,7 +14344,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.itemActivity'
               description: Exposes the itemActivities represented in this itemActivityStat resource.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.booleanColumn:
@@ -14657,12 +14657,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
         welcomePageColumns:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.columnDefinition'
-          readOnly: true
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
     microsoft.graph.documentSetContent:
@@ -14802,7 +14802,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.set'
               description: 'All sets under the group in a term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.termStore.set:
@@ -14836,7 +14836,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: 'Children terms of set in term [store].'
-              readOnly: true
+              x-ms-navigationProperty: true
             parentGroup:
               $ref: '#/components/schemas/microsoft.graph.termStore.group'
             relations:
@@ -14844,13 +14844,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: Indicates which terms have been pinned or reused directly under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
             terms:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: All the terms under the set.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.actionState:
@@ -15089,7 +15089,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerTask'
               description: Read-only. Nullable. The collection of tasks in the bucket.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.plannerPlanDetails:
@@ -15609,31 +15609,31 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that this device is a member of. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredOwners:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             registeredUsers:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: 'Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. Supports $expand.'
-              readOnly: true
+              x-ms-navigationProperty: true
             transitiveMemberOf:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.directoryObject'
               description: Groups and administrative units that the device is a member of. This operation is transitive. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the device. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.longRunningOperationStatus:
@@ -15702,7 +15702,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
               description: The details for each version of the app.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.teamsAppDefinition:
@@ -15933,7 +15933,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of team members who have access to the shared channel.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.assignedLabel:
@@ -16038,7 +16038,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.conversationThread'
               description: A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.conversationThread:
@@ -16083,7 +16083,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.post'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.groupLifecyclePolicy:
@@ -16120,7 +16120,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.plannerPlan'
               description: Read-only. Nullable. Returns the plannerPlans owned by the group.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.operationError:
@@ -16557,7 +16557,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookCommentReply'
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookFunctions:
@@ -16657,13 +16657,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableColumn'
               description: Represents a collection of all the columns in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             rows:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTableRow'
               description: Represents a collection of all the rows in the table. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             sort:
               $ref: '#/components/schemas/microsoft.graph.workbookTableSort'
             worksheet:
@@ -16694,19 +16694,19 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChart'
               description: Returns collection of charts that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             names:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookNamedItem'
               description: Returns collection of names that are associated with the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             pivotTables:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookPivotTable'
               description: Collection of PivotTables that are part of the worksheet.
-              readOnly: true
+              x-ms-navigationProperty: true
             protection:
               $ref: '#/components/schemas/microsoft.graph.workbookWorksheetProtection'
             tables:
@@ -16714,7 +16714,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookTable'
               description: Collection of tables that are part of the worksheet. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.documentSetVersion:
@@ -16908,13 +16908,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.term'
               description: Children of current term.
-              readOnly: true
+              x-ms-navigationProperty: true
             relations:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.termStore.relation'
               description: To indicate which terms are related to the current term as either pinned or reused.
-              readOnly: true
+              x-ms-navigationProperty: true
             set:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
           additionalProperties:
@@ -17395,13 +17395,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.attachment'
               description: Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             extensions:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the post. Read-only. Nullable. Supports $expand.
-              readOnly: true
+              x-ms-navigationProperty: true
             inReplyTo:
               $ref: '#/components/schemas/microsoft.graph.post'
             multiValueExtendedProperties:
@@ -17409,13 +17409,13 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.multiValueLegacyExtendedProperty'
               description: The collection of multi-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
             singleValueExtendedProperties:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueLegacyExtendedProperty'
               description: The collection of single-value extended properties defined for the post. Read-only. Nullable.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.scheduleChangeRequest:
@@ -17664,7 +17664,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartSeries'
               description: Represents either a single series or collection of series in the chart. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
             title:
               $ref: '#/components/schemas/microsoft.graph.workbookChartTitle'
             worksheet:
@@ -17986,7 +17986,7 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookChartPoint'
               description: Represents a collection of all points in the series. Read-only.
-              readOnly: true
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.workbookChartTitle:

--- a/tools/TweakOpenApi.ps1
+++ b/tools/TweakOpenApi.ps1
@@ -4,7 +4,10 @@
 Param(
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
-    [string] $OpenAPIFilesPath
+    [string] $OpenAPIFilesPath,
+
+    [Parameter(Mandatory = $false)]
+    [Switch] $SetNavigationPropertiesAsReadOnly
 )
 
 $prepositionReplacements = @{
@@ -33,7 +36,7 @@ Get-ChildItem -Path $OpenAPIFilesPath | ForEach-Object {
             return $operationId
         }
 
-        if ($_.contains("x-ms-navigationProperty: true")) {
+        if ($SetNavigationPropertiesAsReadOnly.IsPresent -and $_.contains("x-ms-navigationProperty: true")) {
             # Mark navigation properties as readOnly.
             $navigationPropertyExtension = ($_ -replace "x-ms-navigationProperty", "readOnly")
             $modified = $true


### PR DESCRIPTION
This PR removes the addition of `readOnly` on navigation properties since some workloads don't comply with OData conventions stated at https://github.com/microsoft/OpenAPI.NET.OData/issues/254.

Fixes #1822, fixes #1743.