### PR TITLE
Adds AzureIdentityAuthProvider for handling claims challenge

### DIFF
--- a/src/Authentication/Authentication.Core/Constants.cs
+++ b/src/Authentication/Authentication.Core/Constants.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Core
         public static readonly string GraphDirectoryPath = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".mg");
         internal const int TokenExpirationBufferInMinutes = 5;
         internal const string DefaultAzureADEndpoint = "https://login.microsoftonline.com";
-        internal static readonly string DefaultGraphEndpoint = "https://graph.microsoft.com";
+        internal const string DefaultGraphEndpoint = "https://graph.microsoft.com";
+        internal const string DefaultScopeUrl = "https://graph.microsoft.com/.default";
         internal const string CacheName = "mg.msal.cache";
         internal const string AuthRecordName = "mg.authrecord.json";
         internal const int MaxAuthRetry = 2;

--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -4,26 +4,26 @@
     <TargetFrameworks>netstandard2.0;net6.0;net472</TargetFrameworks>
     <RootNamespace>Microsoft.Graph.PowerShell.Authentication.Core</RootNamespace>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>preview2</VersionSuffix>
+    <VersionSuffix>preview5</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.25.0" />
-    <PackageReference Include="Azure.Identity" Version="1.6.1" />
-    <PackageReference Include="Microsoft.Graph.Core" Version="2.0.11" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.46.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.23.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.22.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.22.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.22.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.22.0" />
+    <PackageReference Include="Azure.Core" Version="1.28.0" />
+    <PackageReference Include="Azure.Identity" Version="1.8.2" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="2.0.15" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.50.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.26.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.27.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.27.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.27.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
     <!--Always ensure this version matches the versions of System.Security.Cryptography.* dependencies of Microsoft.Identity.Client when targeting PowerShell 6 and below.-->
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Text.Json" Version="6.0.5" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   <Target Name="CopyFiles" AfterTargets="Build">

--- a/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
+++ b/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Core.Utilities
             {
                 AuthorityHost = new Uri(GetAuthorityUrl(authContext))
             };
-            
+
             if (IsAuthFlowNotSupported())
             {
                 throw new Exception(string.Format(CultureInfo.InvariantCulture, ErrorConstants.Message.AuthNotSupported, "Username and password"));
@@ -187,7 +187,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Core.Utilities
             if (authContext is null)
                 throw new AuthenticationException(ErrorConstants.Message.MissingAuthContext);
             var tokenCrdential = await GetTokenCredentialAsync(authContext, default).ConfigureAwait(false);
-            return new TokenCredentialAuthProvider(tokenCrdential, GetScopes(authContext));
+            return new AzureIdentityAuthProvider(tokenCrdential, GetScopes(authContext));
         }
 
         public static async Task<IAuthContext> AuthenticateAsync(IAuthContext authContext, CancellationToken cancellationToken)

--- a/src/Authentication/Authentication.Core/Utilities/AzureIdentityAuthProvider.cs
+++ b/src/Authentication/Authentication.Core/Utilities/AzureIdentityAuthProvider.cs
@@ -1,0 +1,48 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Azure.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Graph.PowerShell.Authentication.Core.Utilities
+{
+    internal class AzureIdentityAuthProvider : IAuthenticationProvider
+    {
+        private readonly TokenCredential _credential;
+        private readonly IEnumerable<string> _scopes;
+        private readonly string _claims;
+
+        /// <summary>
+        /// An AuthProvider to handle instances of <see cref="TokenCredential"/> from Azure.Core and Azure.Identity
+        /// </summary>
+        /// <param name="tokenCredential">The <see cref="TokenCredential"/> to use for authentication</param>
+        /// <param name="scopes">Scopes required to access Microsoft Graph. This defaults to https://graph.microsoft.com/.default when none is set.</param>
+        /// <param name="claims">Additional claims to be included in the token.</param>
+        /// <exception cref="ArgumentException"> When a null <see cref="TokenCredential"/> is passed</exception>
+        public AzureIdentityAuthProvider(TokenCredential tokenCredential, IEnumerable<string> scopes = null, string claims = null)
+        {
+            _credential = tokenCredential ?? throw new ArgumentException(
+                              string.Format(ErrorConstants.Message.NullOrEmptyParameter, nameof(tokenCredential)),
+                              nameof(tokenCredential));
+            _scopes = scopes ?? new List<string> { Constants.DefaultScopeUrl };
+            _claims = claims;
+        }
+        public async Task AuthenticateRequestAsync(HttpRequestMessage request)
+        {
+            AuthenticationHandlerOption authenticationHandlerOption = request.GetMiddlewareOption<AuthenticationHandlerOption>() ?? new AuthenticationHandlerOption();
+            ICaeAuthenticationProviderOption authenticationProviderOption = authenticationHandlerOption.AuthenticationProviderOption as ICaeAuthenticationProviderOption;
+
+            var decodedClaims = authenticationProviderOption?.Claims ?? _claims;
+
+            AccessToken token = await _credential.GetTokenAsync(new TokenRequestContext(_scopes.ToArray(), claims: decodedClaims), CancellationToken.None).ConfigureAwait(false);
+            request.Headers.Authorization = new AuthenticationHeaderValue(CoreConstants.Headers.Bearer, token.Token);
+        }
+    }
+}

--- a/src/Authentication/Authentication.Test/Helpers/AuthenticationHelpersTests.cs
+++ b/src/Authentication/Authentication.Test/Helpers/AuthenticationHelpersTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Graph.Authentication.Test.Helpers
             await authProvider.AuthenticateRequestAsync(requestMessage);
 
             // Assert
-            Assert.IsType<TokenCredentialAuthProvider>(authProvider);
+            Assert.IsType<AzureIdentityAuthProvider>(authProvider);
             Assert.Equal("Bearer", requestMessage.Headers.Authorization.Scheme);
             Assert.Equal(accessToken, requestMessage.Headers.Authorization.Parameter);
 

--- a/src/Authentication/Authentication/Utilities/DependencyAssemblyResolver.cs
+++ b/src/Authentication/Authentication/Utilities/DependencyAssemblyResolver.cs
@@ -12,22 +12,22 @@ namespace Microsoft.Graph.PowerShell.Authentication.Utilities
     public static class DependencyAssemblyResolver
     {
         // Catalog our dependencies here to ensure we don't load anything else.
-        private static IReadOnlyDictionary<string, Version> Dependencies = new Dictionary<string, Version>
+        private static readonly IReadOnlyDictionary<string, Version> Dependencies = new Dictionary<string, Version>
         {
-            { "Azure.Core", new Version("1.25.0") },
-            { "Azure.Identity", new Version("1.6.1") },
+            { "Azure.Core", new Version("1.28.0") },
+            { "Azure.Identity", new Version("1.8.2") },
             { "Microsoft.Bcl.AsyncInterfaces", new Version("6.0.0") },
-            { "Microsoft.Graph.Core", new Version("2.0.11") },
-            { "Microsoft.Identity.Client", new Version("4.46.0") },
-            { "Microsoft.Identity.Client.Extensions.Msal", new Version("2.23.0") },
-            { "Microsoft.IdentityModel.Abstractions", new Version("6.22.0") },
-            { "Microsoft.IdentityModel.JsonWebTokens", new Version("6.22.0") },
-            { "Microsoft.IdentityModel.Logging", new Version("6.22.0") },
-            { "Microsoft.IdentityModel.Tokens", new Version("6.22.0") },
-            { "System.IdentityModel.Tokens.Jwt", new Version("6.22.0") },
-            { "System.Security.Cryptography.ProtectedData", new Version("6.0.0") },
-            { "Newtonsoft.Json", new Version("13.0.1") },
-            { "System.Text.Json", new Version("6.0.5") },
+            { "Microsoft.Graph.Core", new Version("2.0.15") },
+            { "Microsoft.Identity.Client", new Version("4.50.0") },
+            { "Microsoft.Identity.Client.Extensions.Msal", new Version("2.26.0") },
+            { "Microsoft.IdentityModel.Abstractions", new Version("6.27.0") },
+            { "Microsoft.IdentityModel.JsonWebTokens", new Version("6.27.0") },
+            { "Microsoft.IdentityModel.Logging", new Version("6.27.0") },
+            { "Microsoft.IdentityModel.Tokens", new Version("6.27.0") },
+            { "System.IdentityModel.Tokens.Jwt", new Version("6.27.0") },
+            { "System.Security.Cryptography.ProtectedData", new Version("7.0.1") },
+            { "Newtonsoft.Json", new Version("13.0.2") },
+            { "System.Text.Json", new Version("7.0.2") },
             { "System.Text.Encodings.Web", new Version("6.0.0") },
             { "System.Threading.Tasks.Extensions", new Version("4.5.4") },
             { "System.Diagnostics.DiagnosticSource", new Version("4.0.4") },


### PR DESCRIPTION
This PR fixes #1741 and fixes #1105 by:
- Adds `AzureIdentityAuthProvider` class which handles claims challenge by extracting claims from `ICaeAuthenticationProviderOption`. See https://learn.microsoft.com/en-us/azure/active-directory/develop/claims-challenge?tabs=dotnet.
- Updates dependencies to the latest version.