### PR TITLE
Add beta api version parameter to the failing pester test. [v2.0]

### DIFF
--- a/src/Authentication/Authentication/test/Find-MgGraphCommand.Tests.ps1
+++ b/src/Authentication/Authentication/test/Find-MgGraphCommand.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Find-MgGraphCommand Command" {
         It 'Should find command using URI with query parameters' {
             {
                 $Uri = "beta/users?`$select=displayName&`$filter=identities/any(c:c/issuerAssignedId eq 'j.smith@yahoo.com')"
-                $MgCommand = Find-MgGraphCommand -Uri $Uri -Method GET
+                $MgCommand = Find-MgGraphCommand -Uri $Uri -Method GET -ApiVersion beta
                 $MgCommand | Should -HaveCount 1
                 $MgCommand.Method | Should -Be "GET"
                 $MgCommand.APIVersion | Should -Be "beta"


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #
Failing test which expects a collection of 1 but gets 2 .
<img width="854" alt="image" src="https://user-images.githubusercontent.com/10947120/223209587-d949d2ad-9825-4ede-bfbe-500cf4f42580.png">
[Failing pipeline](https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=107258&view=logs&j=8237f910-645d-5a3a-aca0-8882f2669c51&t=ce4fbf81-c96e-55fb-0e09-e4dfd396271a)

Without specifying the api version, the test outputs both beta and v1.0 results hence making the test fail
<img width="964" alt="image" src="https://user-images.githubusercontent.com/10947120/223210994-d824b636-37dd-4bf7-b825-c7d8aa46c40e.png">

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Added ```-ApiVersion beta``` parameter to default the collection size to 1 as per the test expectation

