### PR TITLE
Connect-MgGraph Test (AZ.Accounts Module installation) fix

### DIFF
--- a/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
+++ b/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
@@ -7,9 +7,10 @@ BeforeAll {
     $ModulePath = Join-Path $PSScriptRoot "..\artifacts\$ModuleName.psd1"
     Import-Module $ModulePath -Force
     $RandomClientId = (New-Guid).Guid
-
-    if (!(Get-Module Az.Accounts -ListAvailable)) {
-        Install-Module Az.Accounts -Repository PSGallery -Scope CurrentUser -Force
+    
+    $AvailableAzModule = Get-Module Az.Accounts -ListAvailable
+    if ($AvailableAzModule.Count -lt 1) {
+        Install-Module Az.Accounts -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
     }
 }
 Describe 'Connect-MgGraph ParameterSets' {


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #
AZ.Accounts module failure as described [here](https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=108079&view=logs&j=8237f910-645d-5a3a-aca0-8882f2669c51&t=ce4fbf81-c96e-55fb-0e09-e4dfd396271a)

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Added AllowClober parameter to overwrite the existing old modules
- Modified check to determine if AZ.Accounts module is already installed. The check uses "Count" to get the number of modules installed
