### PR TITLE
fix legacy command resolution on win ps 5.1

### DIFF
--- a/src/Authentication/Authentication/custom/Find-MgGraphCommand.ps1
+++ b/src/Authentication/Authentication/custom/Find-MgGraphCommand.ps1
@@ -127,8 +127,11 @@ Function Find-MgGraphCommand {
             }
 
             # Resolve legacy commands.
-            [array]$ResolvedCommands = [Microsoft.Graph.PowerShell.Authentication.GraphSession]::Instance.MgLegacyCommandMapping | Where-Object LegacyMapping -Contains $Command | Select-Object -ExpandProperty Command
-            if (!$ResolvedCommands) {
+            [array]$ResolvedCommands = [Microsoft.Graph.PowerShell.Authentication.GraphSession]::Instance.MgLegacyCommandMapping | Where-Object LegacyMapping -Contains $Command
+            if ($ResolvedCommands) {
+                $ResolvedCommands = $ResolvedCommands.Command
+            }
+            else {
                 $ResolvedCommands = $Command
             }
             Write-Debug "Resolved Command: $ResolvedCommands"


### PR DESCRIPTION
<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Fix legacy command resolution on Windows PowerShell 5.x
-
-

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links

-
-
-
