### PR TITLE
Add support for `/security/alerts_v2` in v1

### DIFF
--- a/config/ModuleMetadata.json
+++ b/config/ModuleMetadata.json
@@ -25,5 +25,5 @@
   ],
   "releaseNotes": "See https://aka.ms/GraphPowerShell-Release.",
   "assemblyOriginatorKeyFile": "35MSSharedLib1024.snk",
-  "version": "1.24.0"
+  "version": "1.25.0"
 }

--- a/openApiDocs/beta/Security.yml
+++ b/openApiDocs/beta/Security.yml
@@ -484,7 +484,7 @@ paths:
       externalDocs:
         description: Find more info here
         url: https://docs.microsoft.com/graph/api/security-list-alerts_v2?view=graph-rest-1.0
-      operationId: security_ListAlerts_v2
+      operationId: security_ListAlertsGraphVTwo
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -628,7 +628,7 @@ paths:
       tags:
         - security.alert
       summary: Create new navigation property to alerts_v2 for security
-      operationId: security_CreateAlerts_v2
+      operationId: security_CreateAlertsGraphVTwo
       requestBody:
         description: New navigation property
         content:
@@ -652,7 +652,7 @@ paths:
         - security.alert
       summary: Get alerts_v2 from security
       description: A collection of alerts in Microsoft 365 Defender.
-      operationId: security_GetAlerts_v2
+      operationId: security_GetAlertsGraphVTwo
       parameters:
         - name: alert-id
           in: path
@@ -729,7 +729,7 @@ paths:
       tags:
         - security.alert
       summary: Update the navigation property alerts_v2 in security
-      operationId: security_UpdateAlerts_v2
+      operationId: security_UpdateAlertsGraphVTwo
       parameters:
         - name: alert-id
           in: path
@@ -756,7 +756,7 @@ paths:
       tags:
         - security.alert
       summary: Delete navigation property alerts_v2 for security
-      operationId: security_DeleteAlerts_v2
+      operationId: security_DeleteAlertsGraphVTwo
       parameters:
         - name: alert-id
           in: path

--- a/openApiDocs/v1.0/Security.yml
+++ b/openApiDocs/v1.0/Security.yml
@@ -404,7 +404,7 @@ paths:
       externalDocs:
         description: Find more info here
         url: https://docs.microsoft.com/graph/api/security-list-alerts_v2?view=graph-rest-1.0
-      operationId: security_ListAlerts_v2
+      operationId: security_ListAlertsGraphVTwo
       parameters:
         - $ref: '#/components/parameters/top'
         - $ref: '#/components/parameters/skip'
@@ -545,7 +545,7 @@ paths:
       tags:
         - security.alert
       summary: Create new navigation property to alerts_v2 for security
-      operationId: security_CreateAlerts_v2
+      operationId: security_CreateAlertsGraphVTwo
       requestBody:
         description: New navigation property
         content:
@@ -569,7 +569,7 @@ paths:
         - security.alert
       summary: Get alerts_v2 from security
       description: A collection of alerts in Microsoft 365 Defender.
-      operationId: security_GetAlerts_v2
+      operationId: security_GetAlertsGraphVTwo
       parameters:
         - name: alert-id
           in: path
@@ -645,7 +645,7 @@ paths:
       tags:
         - security.alert
       summary: Update the navigation property alerts_v2 in security
-      operationId: security_UpdateAlerts_v2
+      operationId: security_UpdateAlertsGraphVTwo
       parameters:
         - name: alert-id
           in: path
@@ -672,7 +672,7 @@ paths:
       tags:
         - security.alert
       summary: Delete navigation property alerts_v2 for security
-      operationId: security_DeleteAlerts_v2
+      operationId: security_DeleteAlertsGraphVTwo
       parameters:
         - name: alert-id
           in: path

--- a/src/Applications/Applications/readme.md
+++ b/src/Applications/Applications/readme.md
@@ -78,6 +78,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.psd1
@@ -12,7 +12,7 @@
 RootModule = './Microsoft.Graph.Authentication.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.24.0'
+ModuleVersion = '1.25.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core', 'Desktop'

--- a/src/Bookings/Bookings/readme.md
+++ b/src/Bookings/Bookings/readme.md
@@ -50,6 +50,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Calendar/Calendar/readme.md
+++ b/src/Calendar/Calendar/readme.md
@@ -52,6 +52,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/ChangeNotifications/ChangeNotifications/readme.md
+++ b/src/ChangeNotifications/ChangeNotifications/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/CloudCommunications/CloudCommunications/readme.md
+++ b/src/CloudCommunications/CloudCommunications/readme.md
@@ -59,6 +59,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Compliance/Compliance/readme.md
+++ b/src/Compliance/Compliance/readme.md
@@ -47,6 +47,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/CrossDeviceExperiences/CrossDeviceExperiences/readme.md
+++ b/src/CrossDeviceExperiences/CrossDeviceExperiences/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Actions/DeviceManagement.Actions/readme.md
+++ b/src/DeviceManagement.Actions/DeviceManagement.Actions/readme.md
@@ -166,6 +166,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Administration/DeviceManagement.Administration/readme.md
+++ b/src/DeviceManagement.Administration/DeviceManagement.Administration/readme.md
@@ -64,6 +64,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/readme.md
+++ b/src/DeviceManagement.Enrolment/DeviceManagement.Enrolment/readme.md
@@ -49,6 +49,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement.Functions/DeviceManagement.Functions/readme.md
+++ b/src/DeviceManagement.Functions/DeviceManagement.Functions/readme.md
@@ -47,6 +47,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DeviceManagement/DeviceManagement/readme.md
+++ b/src/DeviceManagement/DeviceManagement/readme.md
@@ -54,6 +54,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Devices.CloudPrint/Devices.CloudPrint/readme.md
+++ b/src/Devices.CloudPrint/Devices.CloudPrint/readme.md
@@ -50,6 +50,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Devices.CorporateManagement/Devices.CorporateManagement/readme.md
+++ b/src/Devices.CorporateManagement/Devices.CorporateManagement/readme.md
@@ -99,6 +99,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Devices.ServiceAnnouncement/Devices.ServiceAnnouncement/readme.md
+++ b/src/Devices.ServiceAnnouncement/Devices.ServiceAnnouncement/readme.md
@@ -49,6 +49,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/DirectoryObjects/DirectoryObjects/readme.md
+++ b/src/DirectoryObjects/DirectoryObjects/readme.md
@@ -47,6 +47,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Education/Education/readme.md
+++ b/src/Education/Education/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Files/Files/readme.md
+++ b/src/Files/Files/readme.md
@@ -50,6 +50,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Financials/Financials/readme.md
+++ b/src/Financials/Financials/readme.md
@@ -42,6 +42,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Groups/Groups/readme.md
+++ b/src/Groups/Groups/readme.md
@@ -120,6 +120,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Identity.DirectoryManagement/Identity.DirectoryManagement/readme.md
+++ b/src/Identity.DirectoryManagement/Identity.DirectoryManagement/readme.md
@@ -70,6 +70,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Identity.Governance/Identity.Governance/readme.md
+++ b/src/Identity.Governance/Identity.Governance/readme.md
@@ -315,6 +315,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Identity.SignIns/Identity.SignIns/readme.md
+++ b/src/Identity.SignIns/Identity.SignIns/readme.md
@@ -72,6 +72,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Mail/Mail/readme.md
+++ b/src/Mail/Mail/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/ManagedTenants/ManagedTenants/readme.md
+++ b/src/ManagedTenants/ManagedTenants/readme.md
@@ -43,6 +43,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Notes/Notes/readme.md
+++ b/src/Notes/Notes/readme.md
@@ -44,6 +44,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/People/People/readme.md
+++ b/src/People/People/readme.md
@@ -74,6 +74,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/PersonalContacts/PersonalContacts/readme.md
+++ b/src/PersonalContacts/PersonalContacts/readme.md
@@ -34,6 +34,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Planner/Planner/readme.md
+++ b/src/Planner/Planner/readme.md
@@ -75,6 +75,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Reports/Reports/readme.md
+++ b/src/Reports/Reports/readme.md
@@ -79,6 +79,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/SchemaExtensions/SchemaExtensions/readme.md
+++ b/src/SchemaExtensions/SchemaExtensions/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Search/Search/readme.md
+++ b/src/Search/Search/readme.md
@@ -35,6 +35,6 @@ subject-prefix: ''
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Security/Security/readme.md
+++ b/src/Security/Security/readme.md
@@ -40,7 +40,7 @@ subject-prefix: ''
 ``` yaml
 directive:
 # Remove invalid paths.
-  - remove-path-by-operation: ^security(_.*Alerts_v2|.cases.ediscoveryCases.noncustodialDataSources_.*DataSource)$
+  - remove-path-by-operation: ^security(.cases.ediscoveryCases.noncustodialDataSources_.*DataSource)$
 # Remove cmdlets
   - where:
       verb: Get|Update

--- a/src/Security/Security/readme.md
+++ b/src/Security/Security/readme.md
@@ -73,6 +73,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Sites/Sites/readme.md
+++ b/src/Sites/Sites/readme.md
@@ -88,6 +88,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Teams/Teams/readme.md
+++ b/src/Teams/Teams/readme.md
@@ -63,6 +63,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Users.Actions/Users.Actions/readme.md
+++ b/src/Users.Actions/Users.Actions/readme.md
@@ -146,6 +146,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Users.Functions/Users.Functions/readme.md
+++ b/src/Users.Functions/Users.Functions/readme.md
@@ -61,6 +61,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/Users/Users/readme.md
+++ b/src/Users/Users/readme.md
@@ -54,6 +54,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/WindowsUpdates/WindowsUpdates/readme.md
+++ b/src/WindowsUpdates/WindowsUpdates/readme.md
@@ -77,6 +77,6 @@ directive:
 ### Versioning
 
 ``` yaml
-module-version: 1.24.0
+module-version: 1.25.0
 release-notes: See https://aka.ms/GraphPowerShell-Release.
 ```

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -444,6 +444,10 @@ directive:
     set:
       subject: $1Of$2
   - where:
+      subject: ^(\w*[a-z])GraphVTwo(\w*)$
+    set:
+      subject: $1V2$2
+  - where:
       verb: Clear
       subject: ^UserManagedAppRegistrationByDeviceTag$
       variant: ^Wipe$|^WipeExpanded$|^WipeViaIdentity$|^WipeViaIdentityExpanded$

--- a/tools/TweakOpenApi.ps1
+++ b/tools/TweakOpenApi.ps1
@@ -13,6 +13,7 @@ $prepositionReplacements = @{
     At   = "GraphAPre"
     For  = "GraphFPre"
     Of   = "GraphOPre"
+    _v2   = "GraphVTwo"
 }
 $targetOperationIdRegex = [Regex]::new("([a-z*])($($prepositionReplacements.Keys -join "|"))([A-Z*]|$)", "Compiled")
 $stopwatch = [system.diagnostics.stopwatch]::StartNew()


### PR DESCRIPTION
This PR adds support for `/security/alerts_v2` in v1. It is a continuation of #1827.