### PR TITLE
Adds OData count paths support

### DIFF
--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -394,6 +394,13 @@ directive:
           - Body
           - DueDateTime
           - Importance
+  - where:
+      parameter-name: ConsistencyLevel
+    set:
+      completer:
+        name: ConsistencyLevel Completer
+        description: Gets the list of ConsistencyLevel header values.
+        script: "'eventual'"
 # Rename parameters.
   - where:
       variant: ^(Add|Insert|Apply|Approve|Unset|Clear|Wipe|Check|Copy|Disable|Locate|Get|Delta|Abort|Accept|Answer|Autofit|Bounding|Cell|Clean|Column|Columns|Commit|Decline|Dismiss|Down|Entire|Filter|Forward|Intersection|Invite|Keep|Last|Logout|Mute|Offset|Play|Preview|Range|Reassign|Reauthorize|Record|Redirect|Reject|Renew|Reply|Retire|Return|Row|Rows|Scan|Schedule|Snooze|Subscribe|Supported|Target|Time|Unmerge|Unmute|Unsubmit|View|Associate|Lock|Merge|Transfer|Move|Create|Update|Publish|Delete|Remove|Change|Request|Reset|Reboot|Restore|Recover|Send|Set|Assign|Bypass|Start|Cancel|Stop|Submit|Sync|Is|Unpublish|Purge|Close|Compare|Complete|Verify|Confirm|Clone|Disconnect|Enable|Export|Discover|Find|Acquire|Managed|Top|Grant|Hide|Import|Activate|Account|Archive|As|Batch|Begin|Bulk|Calendar|Clock|Cloud|Consent|Custom|Deprovision|Access|Estimate|Execute|Extend|Extract|Post|Force|Functions|Has|Have|Instantiate|Invalidate|License|Mark|Messages|Override|Parse|Pending|Postpone|Reactivate|Recent|Reenable|Reopen|Report|Reprovision|Reupload|Role|Rotate|Scoped|Self|Shared|Share|Soft|Summarize|Translate|Troubleshoot|Unarchive|Unassign|Unhide|Unshare|Unsubscribe|Upload|Users|Migrate|Provision|Generate|Make|Ping|Release|Rename|Resize|Restart|Resume|Revoke|Search|Trigger|Run|End|Pause|Validate|Evaluate|Unblock|Undo|Upgrade|Reprocess|Patch)\d*$
@@ -481,6 +488,17 @@ directive:
                 }
             }
           }
+# Set consistency level parameter as required.
+  - from: source-file-csharp
+    where: $
+    transform: >
+      if (!$documentPath.match(/generated%2Fcmdlets%2FGet\w*Count_Get\d*.cs/gm))
+      {
+        return $;
+      } else {
+        let consistencyLevelParamRegex = /(Required = )false(.*SerializedName = @"ConsistencyLevel")/gsi
+        $ = $.replace(consistencyLevelParamRegex, '$1true$2\n');
+      }
 # Modify generated .json.cs model classes.
   - from: source-file-csharp
     where: $

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -468,6 +468,19 @@ directive:
       verb: New|Remove|Update|Get
       subject: ^(.*)(IdentityGovernance)TermOfUse$
     remove: true
+# Modify OpenAPI documents to correct AutoREST.PowerShell limitations.
+# Change content-type from text/plain to application/json. AutoREST does not support non-json content types.
+# See https://github.com/Azure/autorest.powershell/issues/206.
+  - from: 'openapi-document'
+    where: $.components.responses.ODataCountResponse.content
+    transform: >-
+          return {
+            "application/json": {
+                "schema" : {
+                    "$ref" : '#/components/schemas/ODataCountResponse'
+                }
+            }
+          }
 # Modify generated .json.cs model classes.
   - from: source-file-csharp
     where: $

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -488,17 +488,10 @@ directive:
                 }
             }
           }
-# Set consistency level parameter as required.
-  - from: source-file-csharp
-    where: $
-    transform: >
-      if (!$documentPath.match(/generated%2Fcmdlets%2FGet\w*Count_Get\d*.cs/gm))
-      {
-        return $;
-      } else {
-        let consistencyLevelParamRegex = /(Required = )false(.*SerializedName = @"ConsistencyLevel")/gsi
-        $ = $.replace(consistencyLevelParamRegex, '$1true$2\n');
-      }
+# Mark consistency level parameter as required for /$count paths when header is present.
+  - from: openapi-document
+    where: $..paths.*[?(/(.*_GetCount)/gmi.exec(@.operationId))]..parameters[?(@.name === "ConsistencyLevel")]
+    transform: $['required'] = true
 # Modify generated .json.cs model classes.
   - from: source-file-csharp
     where: $


### PR DESCRIPTION
This PR fixes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/1931 by adding a directive to change the content type for OData count paths from `text/plain` to `application/json`. This is needed to due to https://github.com/Azure/autorest.powershell/issues/206.

The PR also adds parameter completer for `-ConsistencyLevel`.

Depends on https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/1480.