### PR TITLE
Identity Governance customization: remove StartDate default when creating new assignment request

### DIFF
--- a/src/Identity.Governance/Identity.Governance/custom/New-MgEntitlementManagementAccessPackageAssignment.ps1
+++ b/src/Identity.Governance/Identity.Governance/custom/New-MgEntitlementManagementAccessPackageAssignment.ps1
@@ -155,11 +155,6 @@ begin {
     $notDelivered = 0
     $nonUsers = 0
 
-    if ($null -eq $StartDate  -or $StartDate.Length -eq 0) {
-        $now = Get-Date
-        $ts = Get-Date $now.ToUniversalTime() -format "s"
-        $StartDate = $ts + "Z"
-    }
 
     if ($null -eq $Justification) {
         $Justification = ""


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #1726 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- An access package assignment policy can have a start date in the future, not known to the client.  By defaulting an absent start date field to the current date, those requests will fail unnecessarily. 
-
-
-


