### PR TITLE
Adds parameter completer for `-Period` in Reports module

### DIFF
--- a/src/Reports/Reports.md
+++ b/src/Reports/Reports.md
@@ -17,6 +17,13 @@ require:
 
 ``` yaml
 directive:
+  - where:
+      parameter-name: Period
+    set:
+      completer:
+        name: Period Completer
+        description: Gets the list of Period values.
+        script: "'D7', 'D30', 'D90', 'D180'"
 # Remove invalid paths.
   - remove-path-by-operation: auditLogs\.auditLogRoot.*|reports.reportRoot.*|(auditLogs|reports)_(Create|Delete|Update).*
 # Remove cmdlets


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #1592

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Adds parameter completer for `-Period` parameter in Reports module. The argument completer should allow customers to tab through the values when entering the parameter interactively.
