### PR TITLE
Adds `$` to OData query parameters for all API versions

### DIFF
--- a/src/Authentication/Authentication.Test/Handlers/ODataQueryOptionsHandlerTests.cs
+++ b/src/Authentication/Authentication.Test/Handlers/ODataQueryOptionsHandlerTests.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Graph.Authentication.Test
 {
     public class ODataQueryOptionsHandlerTests : IDisposable
     {
-        private HttpMessageInvoker _invoker;
-        private FakeSuccessHandler _fakeSuccessHandler;
-        private ODataQueryOptionsHandler _graphODataHandler;
+        private readonly HttpMessageInvoker _invoker;
+        private readonly FakeSuccessHandler _fakeSuccessHandler;
+        private readonly ODataQueryOptionsHandler _graphODataHandler;
 
         public ODataQueryOptionsHandlerTests()
         {
@@ -64,7 +64,7 @@ namespace Microsoft.Graph.Authentication.Test
         }
 
         [Fact]
-        public async Task ShouldSkipWhenGraphVersionIsBeta()
+        public async Task ShouldAddDollarSignWhenGraphVersionIsBeta()
         {
             // Arrange
             string topParam = "$top=5";
@@ -78,9 +78,15 @@ namespace Microsoft.Graph.Authentication.Test
 
             // Act
             var response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var sentRequestQuery = response.RequestMessage.RequestUri.Query;
 
             // Assert
-            Assert.Equal(requestUrl.ToString(), response.RequestMessage.RequestUri.ToString());
+            Assert.NotEqual(requestUrl.Query, sentRequestQuery);
+            Assert.Contains(topParam, sentRequestQuery);
+            Assert.Contains(orderbyParam, sentRequestQuery);
+            Assert.Contains($"${selectParam}", sentRequestQuery);
+            Assert.Contains($"${filterParam}", sentRequestQuery);
+            Assert.Contains($"${expandParam}", sentRequestQuery);
             Assert.Equal(5, response.RequestMessage.RequestUri.Query.Split('&').Length);
         }
 

--- a/src/Authentication/Authentication/Handlers/ODataQueryOptionsHandler.cs
+++ b/src/Authentication/Authentication/Handlers/ODataQueryOptionsHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Handlers
     /// </summary>
     internal class ODataQueryOptionsHandler : DelegatingHandler
     {
-        private List<string> _standardODataQueryOptions = new List<string>
+        private readonly List<string> _standardODataQueryOptions = new List<string>
         {
             "count",
             "expand",
@@ -59,13 +59,14 @@ namespace Microsoft.Graph.PowerShell.Authentication.Handlers
         }
 
         /// <summary>
-        /// Add `$` to all standard OData query options. v1.0 endpoint requires $ to be prefixed to all OData query options.
+        /// Add `$` to all standard OData query options. v1.0 and China cloud endpoint require $ to be prefixed to all OData query options.
+        /// See https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/1893
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
         private HttpRequestMessage AddDollarSignToQueryParameters(HttpRequestMessage request)
         {
-            if (request.RequestUri.Segments[1].ToLower().Contains("v1.0") && request.RequestUri.Query != null)
+            if (request.RequestUri.Query != null)
             {
                 string newRequestQuery = request.RequestUri.Query;
                 string[] querySegments = newRequestQuery.Split(new char[] { '&', '?' }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #1893

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Updates OData query options middleware handler to add `$` to OData query parameters for all API versions. This is needed to support beta commands in China cloud.
- Updates unit test to reflect the change.
