### PR TITLE
V2 RC 1 version bump

### DIFF
--- a/.azure-pipelines/common-templates/download-openapi-docs.yml
+++ b/.azure-pipelines/common-templates/download-openapi-docs.yml
@@ -90,7 +90,7 @@ steps:
       pwsh: true
       targetType: inline
       script: |
-        . "$(System.DefaultWorkingDirectory)\tools\Versions\BumpModuleVersion.ps1" -BumpV1Module -BumpBetaModule -BumpAuthModule -Debug
+        . "$(System.DefaultWorkingDirectory)\tools\Versions\BumpModuleVersion.ps1" -BumpV1Module -BumpBetaModule -BumpAuthModule -PreReleaseTag "rc" -Debug
 
   - task: Bash@3
     displayName: Commit downloaded files

--- a/config/ModuleMetadata.json
+++ b/config/ModuleMetadata.json
@@ -26,15 +26,15 @@
   ],
   "versions": {
     "authentication": {
-      "prerelease": "preview10",
+      "prerelease": "preview11",
       "version": "2.0.0"
     },
     "beta": {
-      "prerelease": "preview10",
+      "prerelease": "preview11",
       "version": "2.0.0"
     },
     "v1.0": {
-      "prerelease": "preview10",
+      "prerelease": "preview11",
       "version": "2.0.0"
     }
   }

--- a/config/ModuleMetadata.json
+++ b/config/ModuleMetadata.json
@@ -26,15 +26,15 @@
   ],
   "versions": {
     "authentication": {
-      "prerelease": "preview11",
+      "prerelease": "rc1",
       "version": "2.0.0"
     },
     "beta": {
-      "prerelease": "preview11",
+      "prerelease": "rc1",
       "version": "2.0.0"
     },
     "v1.0": {
-      "prerelease": "preview11",
+      "prerelease": "rc1",
       "version": "2.0.0"
     }
   }

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -164,6 +164,11 @@ directive:
       subject: ^Link(.*)HasPayload$
     set:
       subject: Has$1PayloadLink
+  - where:
+      verb: Get
+      subject: ^(.*)List(.*)(As.*)$
+    set:
+      subject: $1$2$3
 # Remove *AvailableExtensionProperty commands except those bound to DirectoryObject.
   - where:
       subject: ^(?!DirectoryObject).*AvailableExtensionProperty$

--- a/tools/BuildModule.ps1
+++ b/tools/BuildModule.ps1
@@ -88,6 +88,7 @@ if ($Prerelease) {
     $FullVersionNumber = "$Version-$Prerelease"
 }
 else {
+    $ModuleManifestSettings.Prerelease = " "
     $FullVersionNumber = $Version
 }
 

--- a/tools/Versions/BumpModuleVersion.ps1
+++ b/tools/Versions/BumpModuleVersion.ps1
@@ -6,6 +6,7 @@ Param(
     [switch] $BumpV1Module,
     [switch] $BumpBetaModule,
     [switch] $BumpAuthModule,
+    [string] $PreReleaseTag,
     [string] $Repository = "PSGallery"
 )
 $ErrorActionPreference = "Stop"
@@ -15,7 +16,7 @@ $ErrorActionPreference = "Stop"
 # Calculate and bump v1.0 module version
 if ($BumpV1Module.IsPresent) {
     $v1Module = Find-Module "Microsoft.Graph" -Repository $Repository -AllowPrerelease
-    $newV1Version = Invoke-BumpMinorOrPreReleaseVersion -FullVersion $v1Module.Version
+    $newV1Version = Invoke-BumpMinorOrPreReleaseVersion -FullVersion $v1Module.Version -PreReleaseTag $PreReleaseTag
     Write-Debug "Bumping Microsoft.Graph to $newV1Version"
     Set-ModuleVersion -SetV1Module -Version $newV1Version[0] -Prerelease $newV1Version[1]
 }
@@ -23,7 +24,7 @@ if ($BumpV1Module.IsPresent) {
 # Calculate and bump beta module version
 if ($BumpBetaModule.IsPresent) {
     $betaModule = Find-Module "Microsoft.Graph.Beta" -Repository $Repository -AllowPrerelease
-    $newBetaVersion = Invoke-BumpMinorOrPreReleaseVersion -FullVersion $betaModule.Version
+    $newBetaVersion = Invoke-BumpMinorOrPreReleaseVersion -FullVersion $betaModule.Version -PreReleaseTag $PreReleaseTag
     Write-Debug "Bumping Microsoft.Graph.Beta to $newBetaVersion"
     Set-ModuleVersion -SetBetaModule -Version $newBetaVersion[0] -Prerelease $newBetaVersion[1]
 }
@@ -31,7 +32,7 @@ if ($BumpBetaModule.IsPresent) {
 # Calculate and bump auth module version
 if ($BumpAuthModule.IsPresent) {
     $authModule = Find-Module "Microsoft.Graph.Authentication" -Repository $Repository -AllowPrerelease
-    $newAuthVersion = Invoke-BumpMinorOrPreReleaseVersion -FullVersion $authModule.Version
+    $newAuthVersion = Invoke-BumpMinorOrPreReleaseVersion -FullVersion $authModule.Version -PreReleaseTag $PreReleaseTag
     Write-Debug "Bumping Microsoft.Graph.Authentication to $newAuthVersion"
     Set-ModuleVersion -SetAuthModule -Version $newAuthVersion[0] -Prerelease $newAuthVersion[1]
 }

--- a/tools/Versions/SetModuleVersion.ps1
+++ b/tools/Versions/SetModuleVersion.ps1
@@ -33,13 +33,20 @@ function Set-ModuleVersion {
 
 function Invoke-BumpMinorOrPreReleaseVersion {
     Param(
-        [string] $FullVersion
+        [string] $FullVersion,
+        [string] $PreReleaseTag
     )
-    $versionSegments = $FullVersion -split "-preview"
-    if ($versionSegments.Count -gt 1) {
-        $version = [System.Version]("$($versionSegments[0]).$($versionSegments[1])")
+    $versionSegments = $FullVersion -split "-"
+    if ($versionSegments.Count -gt 1 -and [string]::IsNullOrWhiteSpace($PreReleaseTag) -eq $false) {
+        $PreReleaseVersion = $versionSegments[1] -split $PreReleaseTag
+        if ($PreReleaseVersion.Count -gt 1) {
+            $version = [System.Version]("$($versionSegments[0]).$($PreReleaseVersion[1])")
+        }
+        else {
+            $version = [System.Version]("$($versionSegments[0]).0")
+        }
         $newVersion = "$($version.Major).$($version.Minor).$($version.Build)"
-        $newPrereleaseVersion = "preview$($version.Revision + 1)"
+        $newPrereleaseVersion = "$PreReleaseTag$($version.Revision + 1)"
     }
     else {
         $version = [System.Version]("$($versionSegments[0])")


### PR DESCRIPTION
This PR bumps v2 preview version to RC status. RC1 brings the following fixes and updates to preview9:
* Fixes command names for commands that call OData count paths. This is a partial fix for https://github.com/microsoft/OpenAPI.NET.OData/issues/382.
* Adds `servicePrincipal`, `administrativeUnit`, and `device` derived types to `*-MgDirectoryDeletedItem*` commands in https://github.com/microsoftgraph/msgraph-metadata/pull/340
* Adds custom cmdlets for RSC configuration in https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/2001 and https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/1968
* Updates default output for common types in https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/2002
* Refreshes module with the latest API changes in https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/2005