### PR TITLE
Validate availability of a commandlet only once from metadata file

### DIFF
--- a/tools/ExamplesGenerator.ps1
+++ b/tools/ExamplesGenerator.ps1
@@ -79,12 +79,6 @@ function Get-Files {
         [Hashtable] $OpenApiContent 
     )
     
-    $ModuleManifestFile = (Join-Path $PSScriptRoot "..\src\$Module\$GraphProfile\Microsoft.Graph.$Module.psd1")
-    if($GraphProfile -eq "beta"){
-        $ModuleManifestFile = (Join-Path $PSScriptRoot "..\src\$Module\$GraphProfile\Microsoft.Graph.Beta.$Module.psd1")  
-    }
-    $ModuleManifestFileContent = Get-Content -Path $ModuleManifestFile
-
     try {
         if (Test-Path $GraphProfilePath) {
 
@@ -92,9 +86,6 @@ function Get-Files {
                
                 #Extract command over here
                 $Command = [System.IO.Path]::GetFileNameWithoutExtension($File)
-                #Check for cmdlet existence from the module manifest file
-                if ($ModuleManifestFileContent | Select-String -pattern $Command) {
-                
                     #Extract URI path
                     $UriPath = $null
                     if($GraphProfile -eq "beta"){
@@ -107,8 +98,6 @@ function Get-Files {
                         $Method = $UriPaths.Method
                         Get-ExternalDocsUrl -GraphProfile $GraphProfile -Url -UriPath $UriPath -Command $Command -OpenApiContent $OpenApiContent -GraphProfilePath $GraphProfilePath -Method $Method -Module $Module
                     }
-                    
-                }
 
             }
         }


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #
Pipeline run failures due to missing psd1 files on some modules.

<img width="940" alt="image" src="https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/abc85cb3-44e8-47f7-be0f-57ee43f9a12d">


<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Removes section where it validates availability from a modules psd1 file since we are already fetching commands from mgcommandmetadata.json file

