### PR TITLE
Fix date assignment in Reports module.

### DIFF
--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -558,6 +558,10 @@ directive:
         // Serialize streams (not supported by AutoREST).
         let streamContentRegex = /(request\.Content\s*=)\s*null\s*\/\*\s*serializeToNode\s*doesn't.*.\s*(request\.Content\.Headers\.ContentType.*Parse)\("application\/json"\);/gmi
         $ = $.replace(streamContentRegex, '$1 new global::System.Net.Http.StreamContent(body);\n $2("application/octet-stream");');
+
+        // Fix double = in date parameter. Temp fix for https://github.com/Azure/autorest.powershell/issues/1025.
+        let dateAssignmentRegex = /(date="\n.*)(\+.*"=")(.*\+.*date)/gmi
+        $ = $.replace(dateAssignmentRegex, '$1 $3');
         return $;
       }
 


### PR DESCRIPTION
Fixes #1486 by adding a directive to remove the extra `=` that's being applied by the AutoREST. This fix is limited to just Microsoft Graph PowerShell v2. A complete fix will be provided by https://github.com/Azure/autorest.powershell/issues/1025 in the code generator.

### Sample request
<img width="824" alt="image" src="https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/7061532/16981de3-dfd6-4e28-896e-effa592c8e4d">