### PR TITLE
Fixes Request Header Logging When Using WinHttpHandler

### DIFF
--- a/src/Authentication/Authentication/Helpers/HttpHelpers.cs
+++ b/src/Authentication/Authentication/Helpers/HttpHelpers.cs
@@ -6,7 +6,6 @@ using Microsoft.Graph.PowerShell.Authentication.Core.Utilities;
 using Microsoft.Graph.PowerShell.Authentication.Handlers;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Net;
 using System.Net.Http;
 
 namespace Microsoft.Graph.PowerShell.Authentication.Helpers
@@ -61,22 +60,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                 new RequestHeaderHandler() // Should always be last.
             };
 
-            HttpClient httpClient;
-            if (!RuntimeUtils.IsPsCore())
-            {
-                httpClient = GraphClientFactory.Create(delegatingHandlers,
-                finalHandler: new HttpClientHandler
-                {
-                    Proxy = null,
-                    AllowAutoRedirect = false,
-                    AutomaticDecompression = DecompressionMethods.None
-                });
-            }
-            else
-            {
-                httpClient = GraphClientFactory.Create(delegatingHandlers);
-            }
-
+            HttpClient httpClient = GraphClientFactory.Create(delegatingHandlers);
             httpClient.Timeout = requestContext.ClientTimeout;
             return httpClient;
         }

--- a/src/Authentication/Authentication/Helpers/RuntimeUtils.cs
+++ b/src/Authentication/Authentication/Helpers/RuntimeUtils.cs
@@ -1,0 +1,24 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Graph.PowerShell.Authentication.Helpers
+{
+    /// <summary>
+    /// Utility class containing runtime utility methods.
+    /// </summary>
+    internal static class RuntimeUtils
+    {
+        /// <summary>
+        /// Determines if the PSEdition of the current process is Core.
+        /// </summary>
+        /// <returns><see cref="true"/> when PSEdition is core, else <see cref="false"/>.</returns>
+        internal static bool IsPsCore()
+        {
+            var psCoreVersion = new Version(6, 0, 0);
+            return GraphSession.Instance.AuthContext.PSHostVersion >= psCoreVersion;
+        }
+    }
+}

--- a/tools/Custom/HttpMessageLogFormatter.cs
+++ b/tools/Custom/HttpMessageLogFormatter.cs
@@ -7,6 +7,7 @@ namespace NamespacePrefixPlaceholder.PowerShell
     using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using System.Net.Http;
     using System.Net.Http.Headers;
@@ -17,22 +18,54 @@ namespace NamespacePrefixPlaceholder.PowerShell
 
     public static class HttpMessageLogFormatter
     {
+        internal static async Task<HttpRequestMessage> CloneAsync(this HttpRequestMessage originalRequest)
+        {
+            var newRequest = new HttpRequestMessage(originalRequest.Method, originalRequest.RequestUri);
+
+            // Copy requestClone headers.
+            foreach (var header in originalRequest.Headers)
+                newRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+            // Copy requestClone properties.
+            foreach (var property in originalRequest.Properties)
+                newRequest.Properties.Add(property);
+
+            // Set Content if previous requestClone had one.
+            if (originalRequest.Content != null)
+            {
+                // HttpClient doesn't rewind streams and we have to explicitly do so.
+                await originalRequest.Content.ReadAsStreamAsync().ContinueWith(t =>
+                {
+                    if (t.Result.CanSeek)
+                        t.Result.Seek(0, SeekOrigin.Begin);
+
+                    newRequest.Content = new StreamContent(t.Result);
+                }).ConfigureAwait(false);
+
+                // Copy content headers.
+                if (originalRequest.Content.Headers != null)
+                    foreach (var contentHeader in originalRequest.Content.Headers)
+                        newRequest.Content.Headers.TryAddWithoutValidation(contentHeader.Key, contentHeader.Value);
+            }
+            return newRequest;
+        }
+
         public static async Task<string> GetHttpRequestLogAsync(HttpRequestMessage request)
         {
             if (request == null) return string.Empty;
-
+            var requestClone = await request.CloneAsync().ConfigureAwait(false);
             string body = string.Empty;
             try
             {
-                body = (request.Content == null) ? string.Empty : FormatString(await request.Content.ReadAsStringAsync());
+                body = (requestClone.Content == null) ? string.Empty : FormatString(await requestClone.Content.ReadAsStringAsync());
             }
             catch { }
 
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.AppendLine($"============================ HTTP REQUEST ============================{Environment.NewLine}");
-            stringBuilder.AppendLine($"HTTP Method:{Environment.NewLine}{request.Method.ToString()}{Environment.NewLine}");
-            stringBuilder.AppendLine($"Absolute Uri:{Environment.NewLine}{request.RequestUri.ToString()}{Environment.NewLine}");
-            stringBuilder.AppendLine($"Headers:{Environment.NewLine}{HeadersToString(ConvertHttpHeadersToCollection(request.Headers))}{Environment.NewLine}");
+            stringBuilder.AppendLine($"HTTP Method:{Environment.NewLine}{requestClone.Method.ToString()}{Environment.NewLine}");
+            stringBuilder.AppendLine($"Absolute Uri:{Environment.NewLine}{requestClone.RequestUri.ToString()}{Environment.NewLine}");
+            stringBuilder.AppendLine($"Headers:{Environment.NewLine}{HeadersToString(ConvertHttpHeadersToCollection(requestClone.Headers))}{Environment.NewLine}");
             stringBuilder.AppendLine($"Body:{Environment.NewLine}{SanitizeBody(body)}{Environment.NewLine}");
             return stringBuilder.ToString();
         }


### PR DESCRIPTION
Fixes #1916

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Clones request before reading/sanitizing request headers for logging to avoid thread safety issues when WinHttpHandler is used as the final handler (.NET Fx).
- Updates how `sdkVersion` and `client-request-id` are set on outgoing request.
