### PR TITLE
Sync artifacts branch with generation branch

### DIFF
--- a/.azure-pipelines/weekly-preview-generation.yml
+++ b/.azure-pipelines/weekly-preview-generation.yml
@@ -150,6 +150,17 @@ jobs:
             git commit -m 'Adds generated module artifacts'
             git push "https://$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git"
             git status
+      - task: Bash@3
+        displayName: Sync with generation branch
+        enabled: true
+        env:
+          GITHUB_TOKEN: $(GITHUB_TOKEN)
+        inputs:
+          targetType: inline
+          script: |
+            git merge $(GenerationBranch) -s ours
+            git push "https://$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git"
+            git status
       - ${{ if eq(parameters.CreatePullRequest, true) }}:
           - template: common-templates/create-pr.yml
             parameters:

--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,6 @@ coverage.xml
 
 #Wrong Examples report Folder
 examplesreport/
+
+# Code sign summary
+CodeSignSummary-*.md


### PR DESCRIPTION
This PR adds:
- A task to the weekly refresh pipeline script to ensure weekly artifacts branch is always synchronized with generation branch using `ours` merge strategy to avoid conflicts.
- `CodeSignSummary` files to `.GitIgnore`.