### PR TITLE
Use authorityUrl instead of tenantId when initializing MSAL

### DIFF
--- a/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
+++ b/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
     /// </summary>
     public static class AuthenticationHelpers
     {
-        static ReaderWriterLockSlim _cacheLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+        static readonly ReaderWriterLockSlim _cacheLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
         /// <summary>
         /// Signs out of the current session using the provided <see cref="IAuthContext"/>.
@@ -71,7 +71,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                         //https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/MSAL.NET-uses-web-browser
                         IPublicClientApplication publicClientApp = PublicClientApplicationBuilder
                             .Create(authContext.ClientId)
-                            .WithTenantId(authContext.TenantId)
                             .WithAuthority(authorityUrl)
                             .WithClientCapabilities(new[] { "cp1" })
                             .WithDefaultRedirectUri()
@@ -98,7 +97,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                     {
                         IConfidentialClientApplication confidentialClientApp = ConfidentialClientApplicationBuilder
                             .Create(authContext.ClientId)
-                            .WithTenantId(authContext.TenantId)
                             .WithAuthority(authorityUrl)
                             .WithCertificate(GetCertificate(authContext))
                             .Build();


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/1922

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Use `WithAuthority(authorityUrl)` when initializing MSAL applications to avoid the exception at https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/1922. Some versions of MSAL will throw an exception in prod environments when `WithAuthority` and `WithTenantId` are specified on the same client. `GetAuthorityUrl(authContext);` will construct an authority URL that takes into account the specified tenant id.

See https://learn.microsoft.com/en-us/azure/active-directory/develop/msal-client-application-configuration#how-to-specify-the-audience-in-your-codeconfiguration for more info.
