### PR TITLE
Fixes base64 serialization

### DIFF
--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -259,6 +259,11 @@ directive:
   - from: 'openapi-document'
     where: $.components.schemas.ReferenceUpdate..properties['@odata.id']
     transform: $['description'] = 'The entity reference URL of the resource. For example, https://graph.microsoft.com/v1.0/directoryObjects/{id}.'
+# Fix Base64 serialization.
+  - from: 'openapi-document'
+    where: $.components.schemas..properties.*
+    transform: >-
+        if ($.format === 'base64url') { $['format'] = 'byte' }
 # Mark consistency level parameter as required for /$count paths when header is present.
   - from: openapi-document
     where: $..paths.*[?(/(.*_GetCount)/gmi.exec(@.operationId))]..parameters[?(@.name === "ConsistencyLevel")]


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #2056

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Adds directive to change `base64Url` format to `byte`. The directive is needed to address the change that was made at https://github.com/Azure/autorest.powershell/pull/900. In AutoREST.PowerShell v3, properties are serialized as base64 when `format` is `byte` and `type` is string.

### Open Questions/External Enhancements:
1. The base64 encoded properties should be declared as `base64` instead of `base64Url` in the OpenAPI document.
2. AutoREST.PowerShell should support serialization of `base64` format. As a workaround, we can declare string properties as `byte` to inform AutoREST.PowerShell that the property is a `base64` encoded. See https://github.com/Azure/azure-powershell/issues/17131#issuecomment-1042497183.