### PR TITLE
Include "List" variant when updating example files

### DIFF
--- a/.azure-pipelines/common-templates/install-sdk.yml
+++ b/.azure-pipelines/common-templates/install-sdk.yml
@@ -1,0 +1,19 @@
+steps:
+- task: PowerShell@2
+  displayName: Install PowerShell SDK
+  inputs:
+    targetType: 'inline'
+    pwsh: true
+    script: |
+          try{
+              # Installing Beta module.
+              Install-Module Microsoft.Graph.Beta -Repository PSGallery -Scope AllUsers -AcceptLicense -SkipPublisherCheck -Force -AllowClobber
+          }catch{
+                echo "Error when installing Beta"
+          }
+          try{
+              # Installing V1 module.
+              Install-Module Microsoft.Graph -Repository PSGallery -Scope AllUsers -AcceptLicense -SkipPublisherCheck -Force -AllowClobber
+          }catch{
+                echo "Error when installing V1"
+          }

--- a/.azure-pipelines/weekly-examples-update.yml
+++ b/.azure-pipelines/weekly-examples-update.yml
@@ -33,7 +33,7 @@ jobs:
     name: ${{ parameters.BuildAgent }}
   timeoutInMinutes: ${{ parameters.PipelineTimeout }}
   steps:
-
+  - template: ./common-templates/install-sdk.yml
   - task: PowerShell@2
     name: "ComputeBranch"
     displayName: "Compute weekly examples update branch name"

--- a/tools/ImportExamples.ps1
+++ b/tools/ImportExamples.ps1
@@ -90,10 +90,16 @@ function Get-Files {
                 $CommandValue = $null
                 if ($GraphProfile -eq "beta") {
                     $CommandValue = $BetaCommandGetVariantList[$Command]
+                    if(-not($CommandValue)){
+                        $CommandValue = $BetaCommandListVariantList[$Command]
+                    }
                         
                 }
                 else {
                     $CommandValue = $V1CommandGetVariantList[$Command]
+                    if(-not($CommandValue)){
+                        $CommandValue = $V1CommandListVariantList[$Command]
+                    }
                 }
                         
                 if ($CommandValue) {


### PR DESCRIPTION
Currently the examples import script only fetches and process examples for cmdlets that fall under the "Get" variant. 
This PR will include cmdlets that also fall under the "List" variant.
<img width="941" alt="image" src="https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/414625c2-b4b0-4d5d-896e-a53d7d9a15b7">