### PR TITLE
Add error handling for unsupported label types in chat conditions for preapprovals

### DIFF
--- a/src/Teams/beta/custom/TeamsAppPreApprovalPolicyConverter.cs
+++ b/src/Teams/beta/custom/TeamsAppPreApprovalPolicyConverter.cs
@@ -189,7 +189,7 @@
                 {
                     throw new MGTeamsInternalException(
                         MGTeamsInternalErrorType.UnsupportedScenario,
-                        $"Unsupported scope sensitivity label '{groupCondition.SensitivityLabels.OdataType}' in preapproval policy '{permissionGrantPreApprovalPolicy.Id}'.");
+                        $"Unsupported team scope sensitivity label type '{groupCondition.SensitivityLabels.OdataType}' in preapproval policy '{permissionGrantPreApprovalPolicy.Id}'.");
                 }
 
                 MGTeamsInternalEnumeratedPreApprovedPermissions mGTeamsInternalEnumeratedPreApprovedPermissions =
@@ -209,6 +209,13 @@
 
             if (chatCondition != null)
             {
+                if (!string.Equals(chatCondition.SensitivityLabels.OdataType, "#microsoft.graph.allScopeSensitivityLabels", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new MGTeamsInternalException(
+                        MGTeamsInternalErrorType.UnsupportedScenario,
+                        $"Unsupported chat scope sensitivity label type '{chatCondition.SensitivityLabels.OdataType}' in preapproval policy '{permissionGrantPreApprovalPolicy.Id}'.");
+                }
+
                 MGTeamsInternalEnumeratedPreApprovedPermissions mGTeamsInternalEnumeratedPreApprovedPermissions =
                     chatCondition.Permissions as MGTeamsInternalEnumeratedPreApprovedPermissions;
                 if (mGTeamsInternalEnumeratedPreApprovedPermissions != null)


### PR DESCRIPTION
Add error handling for unsupported label types in chat conditions for preapprovals.

﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

-
-
-

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links

-
-
-
