### PR TITLE
Update Roslyn analyzer task

### DIFF
--- a/.azure-pipelines/common-templates/guardian-analyzer.yml
+++ b/.azure-pipelines/common-templates/guardian-analyzer.yml
@@ -6,14 +6,14 @@
 
 steps:
   - task: RoslynAnalyzers@3
+    displayName: 'Run Roslyn Analyzers'
     inputs:
-      userProvideBuildInfo: 'msBuildInfo'
-      msBuildVersion: '17.0'
-      msBuildArchitecture: 'x64'
+      continueOnError: true
+      msBuildVersion: 17.0
+      msBuildArchitecture: amd64
+      msBuildCommandline: |
+        dotnet.exe build $(Build.SourcesDirectory)\src\Authentication /p:Platform="Any CPU" /p:Configuration="Release"
       setupCommandlinePicker: 'vs2022'
-      rulesetName: Recommended
-      rulesetVersion: Latest
       policyName: 'M365'
-      loadRoslynConfiguredAnalyzersOption: Enable # Keep code generators running
     env:
       SYSTEM_ACCESSTOKEN: $(system.accesstoken)

--- a/.azure-pipelines/common-templates/guardian-analyzer.yml
+++ b/.azure-pipelines/common-templates/guardian-analyzer.yml
@@ -5,10 +5,15 @@
 # https://marketplace.visualstudio.com/items?itemName=securedevelopmentteam.vss-secure-development-tools
 
 steps:
-- task: RoslynAnalyzers@3
-  inputs:
-    userProvideBuildInfo: 'autoMsBuildInfo'
-    setupCommandlinePicker: 'vs2022'
-    policyName: 'M365'
-  env:
-    SYSTEM_ACCESSTOKEN: $(system.accesstoken)
+  - task: RoslynAnalyzers@3
+    inputs:
+      userProvideBuildInfo: 'msBuildInfo'
+      msBuildVersion: '17.0'
+      msBuildArchitecture: 'x64'
+      setupCommandlinePicker: 'vs2022'
+      rulesetName: Recommended
+      rulesetVersion: Latest
+      policyName: 'M365'
+      loadRoslynConfiguredAnalyzersOption: Enable # Keep code generators running
+    env:
+      SYSTEM_ACCESSTOKEN: $(system.accesstoken)

--- a/.azure-pipelines/generation-templates/authentication-module.yml
+++ b/.azure-pipelines/generation-templates/authentication-module.yml
@@ -21,8 +21,6 @@ steps:
       script: |
         . $(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1 -EnableSigning:$${{ parameters.Sign }} -Build
 
-  - template: ../common-templates/guardian-analyzer.yml
-
   - ${{ if eq(parameters.Test, true) }}:
       - task: PowerShell@2
         displayName: Test Authentication Module
@@ -53,6 +51,9 @@ steps:
             $ModulePsm1 = "$(System.DefaultWorkingDirectory)/src/Authentication/Authentication/Microsoft.Graph.Authentication.psm1"
             ($ModulePsd1 | Get-AuthenticodeSignature).Status | Should -Be "Valid"
             ($ModulePsm1 | Get-AuthenticodeSignature).Status | Should -Be "Valid"
+  
+  # Run analyzer after signing is complete.
+  - template: ../common-templates/guardian-analyzer.yml
 
   - ${{ if eq(parameters.Pack, true) }}:
       - task: PowerShell@2

--- a/.azure-pipelines/generation-templates/authentication-module.yml
+++ b/.azure-pipelines/generation-templates/authentication-module.yml
@@ -21,8 +21,6 @@ steps:
       script: |
         . $(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1 -EnableSigning:$${{ parameters.Sign }} -Build
 
-  - template: ../common-templates/guardian-analyzer.yml
-
   - ${{ if eq(parameters.Test, true) }}:
       - task: PowerShell@2
         displayName: Test Authentication Module
@@ -62,3 +60,6 @@ steps:
           pwsh: true
           script: |
             . $(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1 -Pack -ArtifactsLocation $(Build.ArtifactStagingDirectory)
+
+  # Run analyzer after build & sign.
+  - template: ../common-templates/guardian-analyzer.yml

--- a/.azure-pipelines/generation-templates/authentication-module.yml
+++ b/.azure-pipelines/generation-templates/authentication-module.yml
@@ -21,6 +21,8 @@ steps:
       script: |
         . $(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1 -EnableSigning:$${{ parameters.Sign }} -Build
 
+  - template: ../common-templates/guardian-analyzer.yml
+
   - ${{ if eq(parameters.Test, true) }}:
       - task: PowerShell@2
         displayName: Test Authentication Module
@@ -51,9 +53,6 @@ steps:
             $ModulePsm1 = "$(System.DefaultWorkingDirectory)/src/Authentication/Authentication/Microsoft.Graph.Authentication.psm1"
             ($ModulePsd1 | Get-AuthenticodeSignature).Status | Should -Be "Valid"
             ($ModulePsm1 | Get-AuthenticodeSignature).Status | Should -Be "Valid"
-  
-  # Run analyzer after signing is complete.
-  - template: ../common-templates/guardian-analyzer.yml
 
   - ${{ if eq(parameters.Pack, true) }}:
       - task: PowerShell@2

--- a/src/Authentication/Authentication.Core/Properties/AssemblyInfo.cs
+++ b/src/Authentication/Authentication.Core/Properties/AssemblyInfo.cs
@@ -2,4 +2,6 @@
 
 #if DEBUG
 [assembly: InternalsVisibleTo("Microsoft.Graph.Authentication.Test")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Graph.Authentication.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 #endif

--- a/src/Authentication/Authentication/Properties/AssemblyInfo.cs
+++ b/src/Authentication/Authentication/Properties/AssemblyInfo.cs
@@ -2,4 +2,6 @@
 
 #if DEBUG
 [assembly: InternalsVisibleTo("Microsoft.Graph.Authentication.Test")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Graph.Authentication.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 #endif

--- a/tools/GenerateAuthenticationModule.ps1
+++ b/tools/GenerateAuthenticationModule.ps1
@@ -44,11 +44,14 @@ if ($null -eq $ModuleMetadata.versions.authentication.version) {
 # Build and pack generated module.
 if ($Build -or $Run) {
   $AuthCoreCSProj = Join-Path $AuthSrcPath "$ModuleName.Core" "$ModuleFullName.Core.csproj"
+  $AuthTestCSProj = Join-Path $AuthSrcPath "$ModuleName.Test" "$ModuleFullName.Test.csproj"
   if ($EnableSigning) {
     Set-CSProjValues -ModuleCsProj $AuthCoreCSProj -AssemblyOriginatorKeyFile $ModuleMetadata.assemblyOriginatorKeyFile -ModuleVersion $ModuleMetadata.versions.authentication.version -PreRelease $ModuleMetadata.versions.authentication.prerelease
+    Set-CSProjValues -ModuleCsProj $AuthTestCSProj -AssemblyOriginatorKeyFile $ModuleMetadata.assemblyOriginatorKeyFile -ModuleVersion $ModuleMetadata.versions.authentication.version -PreRelease $ModuleMetadata.versions.authentication.prerelease
   }
   else {
     Set-CSProjValues -ModuleCsProj $AuthCoreCSProj -ModuleVersion $ModuleMetadata.versions.authentication.version -PreRelease $ModuleMetadata.versions.authentication.prerelease
+    Set-CSProjValues -ModuleCsProj $AuthTestCSProj -ModuleVersion $ModuleMetadata.versions.authentication.version -PreRelease $ModuleMetadata.versions.authentication.prerelease
   }
   & $BuildModulePS1 -ModuleFullName $ModuleFullName -ModuleSrc $AuthModulePath -EnableSigning:$EnableSigning -Version $ModuleMetadata.versions.authentication.version -Prerelease $ModuleMetadata.versions.authentication.prerelease -ModuleMetadata $ModuleMetadata.Clone()
 }


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #2279 and builds on #2266

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Adds `msBuildCommandline` to `RoslynAnalyzers@3` task. This ensures we always use `dotnet build ...` when Roslyn Analyzer runs.
- Adds `Authentication.Test` assembly as friend to `Authentication` and `Authentication.Core` assembly via `InternalsVisibleTo` when `configuration=release`.

cc\ @MIchaelMainer 