### PR TITLE
Resolve duplicate command names in `Users.Functions`

### DIFF
--- a/.azure-pipelines/generation-templates/workload-modules.yml
+++ b/.azure-pipelines/generation-templates/workload-modules.yml
@@ -30,6 +30,14 @@ steps:
       script: |
         . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -SkipGeneration -Test
 
+  - task: PowerShell@2
+    displayName: Find Duplicate Commands
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        . $(System.DefaultWorkingDirectory)/tools/PostGeneration/FindDuplicateCommand.ps1 -SourcePath "$(System.DefaultWorkingDirectory)/src/"
+
   - ${{ if eq(parameters.Sign, true) }}:
       - template: ../common-templates/esrp/strongname.yml
         parameters:

--- a/src/Users.Functions/Users.Functions.md
+++ b/src/Users.Functions/Users.Functions.md
@@ -32,7 +32,7 @@ directive:
       subject: $1AllowedCalendarSharingRoles
   - where:
       verb: Get
-      subject: ^(UserChatMessage)$
+      subject: ^(User)(ChatMessage|OnlineMeetingTranscript|OnlineMeetingRecording)$
     set:
-      subject: All$1
+      subject: All$1$2
 ```

--- a/tools/PostGeneration/FindDuplicateCommand.ps1
+++ b/tools/PostGeneration/FindDuplicateCommand.ps1
@@ -15,17 +15,17 @@ if (!(Test-Path $SourcePath)) {
     Write-Error "SourcePath is not valid or does not exist. Please ensure that $SourcePath exists then try again."
 }
 
-$psd1s = Get-ChildItem -Path $SourcePath -Filter "Microsoft.Graph.*.psd1" -Recurse | where { $_.BaseName -ne "Microsoft.Graph.Authentication" }
-$allModules = (Invoke-Expression (($psd1s.FullName | ForEach-Object{ Get-Content $_}) | Out-String ))
+$psd1s = Get-ChildItem -Path $SourcePath -Filter "Microsoft.Graph.*.psd1" -Recurse | Where-Object { $_.BaseName -ne "Microsoft.Graph.Authentication" }
+$allModules = Import-PowerShellDataFile $psd1s.FullName
 $unique = $allModules.FunctionsToExport | Select-Object -unique
 $duplicates = Compare-object -ReferenceObject $unique -DifferenceObject $allModules.FunctionsToExport
 
 if ($duplicates.Count -gt 0) {
     Write-Host "The following functions are duplicated in the psd1 files:"
-    $duplicates.InputObject | %{
+    $duplicates.InputObject | ForEach-Object {
         $duplicateCommand = $_
         Write-Host "$duplicateCommand is duplicated in:"
-        Write-Host ($allModules | where { $_.FunctionsToExport -contains $duplicateCommand }).RootModule
+        Write-Host ($allModules | Where-Object { $_.FunctionsToExport -contains $duplicateCommand }).RootModule
         Write-Host "********************************"
     }
     Write-Error "Please ensure that the functions are unique and try again."


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Resolves duplicate command names in `Users.Functions` module using AutoREST directive.
- Adds `FindDuplicateCommand.ps1` to build pipelines. The script will detect duplicate command names across all modules.
