### PR TITLE
Revert AutoREST.PowerShell to v3.0.509

### DIFF
--- a/config/ModuleMetadata.json
+++ b/config/ModuleMetadata.json
@@ -27,15 +27,15 @@
   "versions": {
     "authentication": {
       "prerelease": "",
-      "version": "2.6.0"
+      "version": "2.6.1"
     },
     "beta": {
       "prerelease": "",
-      "version": "2.6.0"
+      "version": "2.6.1"
     },
     "v1.0": {
       "prerelease": "",
-      "version": "2.6.0"
+      "version": "2.6.1"
     }
   }
 }

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -6,7 +6,7 @@
 azure: false
 powershell: true
 version: latest
-use: "@autorest/powershell@3.x"
+use: "@autorest/powershell@3.0.509"
 export-properties-for-dict: false
 metadata:
     authors: Microsoft Corporation


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #2313 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Reverts AutoREST.PowerShell to v3.0.509. AutoREST.PowerShell v3.0.510 introduces a type that is only available in Azure SDK - https://www.npmjs.com/package/@autorest/powershell?activeTab=versions
- Bumps SDK version to 2.6.1
