### PR TITLE
Updates Azure.Identity and Azure.Identity.Broker package references to fix interactive browser credentials error

### DIFF
--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -11,7 +11,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.9.0" />
     <PackageReference Include="Azure.Identity.BrokeredAuthentication" Version="1.0.0-beta.3" />
     <PackageReference Include="Microsoft.Graph.Core" Version="3.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -11,7 +11,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.9.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="Azure.Identity.Broker" Version="1.0.0-beta.5" />
     <PackageReference Include="Microsoft.Graph.Core" Version="3.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.9.0" />
-    <PackageReference Include="Azure.Identity.BrokeredAuthentication" Version="1.0.0-beta.3" />
+    <PackageReference Include="Azure.Identity.Broker" Version="1.0.0-beta.5" />
     <PackageReference Include="Microsoft.Graph.Core" Version="3.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
+++ b/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
@@ -133,7 +133,11 @@ namespace Microsoft.Graph.PowerShell.Authentication.Core.Utilities
                 }
                 else
                 {
-                    authRecord = await interactiveBrowserCredential.AuthenticateAsync(new TokenRequestContext(authContext.Scopes), cancellationToken).ConfigureAwait(false);
+                    authRecord = await Task.Run(() =>
+                    {
+                        // Run the thread in MTA.
+                        return interactiveBrowserCredential.AuthenticateAsync(new TokenRequestContext(authContext.Scopes), cancellationToken);
+                    });
                 }
                 await WriteAuthRecordAsync(authRecord).ConfigureAwait(false);
                 return interactiveBrowserCredential;

--- a/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
+++ b/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
@@ -4,7 +4,7 @@
 using Azure.Core;
 using Azure.Core.Diagnostics;
 using Azure.Identity;
-using Azure.Identity.BrokeredAuthentication;
+using Azure.Identity.Broker;
 using Microsoft.Graph.Authentication;
 using Microsoft.Graph.PowerShell.Authentication.Core.Extensions;
 using Microsoft.Identity.Client;

--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.nuspec
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.nuspec
@@ -29,7 +29,7 @@
     <!-- Copy framework dependent assemblies to respective framework directory. -->
     <!-- Shared -->
     <file src="artifacts\Dependencies\Azure.Identity.dll" target="Dependencies" />
-    <file src="artifacts\Dependencies\Azure.Identity.BrokeredAuthentication.dll" target="Dependencies" />
+    <file src="artifacts\Dependencies\Azure.Identity.Broker.dll" target="Dependencies" />
     <file src="artifacts\Dependencies\Microsoft.Identity.Client.Broker.dll" target="Dependencies" />
     <file src="artifacts\Dependencies\Microsoft.Identity.Client.NativeInterop.dll" target="Dependencies" />
     <file src="artifacts\Dependencies\Microsoft.Bcl.AsyncInterfaces.dll" target="Dependencies" />


### PR DESCRIPTION
The current version bump of  Azure.Identity (1.10.2) introduced interactive browser errors when running ``Connect-MgGraph``
command. In some cases, the pop window with auth credential options fails to load.

This PR corrects that by rolling back to version 1.9.0 which doesn't have those errors
<img width="874" alt="image" src="https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/304fa82c-f5e3-46be-ab24-875c998fca5d">
