### PR TITLE
Escapes special characters on path segments when using ``Invoke-MgGraphRequest``

### DIFF
--- a/src/Authentication/Authentication.Test/Helpers/EncodeUriPathTests.cs
+++ b/src/Authentication/Authentication.Test/Helpers/EncodeUriPathTests.cs
@@ -1,0 +1,26 @@
+﻿
+using Xunit;
+using System;
+using Microsoft.Graph.PowerShell.Authentication.Helpers;
+
+namespace Microsoft.Graph.Authentication.Test.Helpers
+{
+    public class EncodeUriPathTests
+    {
+        private string url = "https://graph.microsoft.com/beta/users/first.last_foo.com#EXT#@contoso.onmicrosoft.com";
+        private string encodedUrl = "https://graph.microsoft.com/beta/users/first.last_foo.com%23EXT%23%40contoso.onmicrosoft.com";
+
+        [Fact]
+        public void ShouldReturnAnEncodedUriGivenAUrlWithSpecialCharactersInPathSegments()
+        {
+            //arrange
+            Uri uri = new Uri(url);
+
+            //act
+            Uri result = uri.EscapeDataStrings();
+
+            //assert
+            Assert.Equal(encodedUrl, result.ToString());
+        }
+    }
+}

--- a/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
@@ -402,31 +402,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                 // set body to null to prevent later FillRequestStream
                 Body = null;
             }
-            return EscapeDataStrings(uriBuilder.Uri);
-        }
-
-        /// <summary>
-        /// Escape data string/url encode Uris that have paths containing special characters like #.
-        /// For a path like /beta/users/first.last_foo.com#EXT#@contoso.onmicrosoft.com, the last segment contains special characters that need to be escaped
-        /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
-        private Uri EscapeDataStrings(Uri uri)
-        {
-            int counter = 0;
-            var pathSegments = uri.OriginalString.Split('/');
-            StringBuilder sb = new StringBuilder();
-            foreach (var segment in pathSegments)
-            {
-                //Skips the left part of the uri i.e https://graph.microsoft.com
-                if (counter > 2)
-                {
-                    sb.Append("/" + Uri.EscapeDataString(segment));
-                }
-                counter++;
-            }
-            Uri escapedUri = new Uri(uri.GetLeftPart(UriPartial.Authority) + sb.ToString());
-            return escapedUri;
+            return uriBuilder.Uri.EscapeDataStrings();
         }
 
         private void ThrowIfError(ErrorRecord error)

--- a/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
@@ -20,7 +20,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using static Microsoft.Graph.PowerShell.Authentication.Helpers.AsyncHelpers;
 using DriveNotFoundException = System.Management.Automation.DriveNotFoundException;
 

--- a/src/Authentication/Authentication/Helpers/EncodeUriPath.cs
+++ b/src/Authentication/Authentication/Helpers/EncodeUriPath.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                 //Skips the left part of the uri i.e https://graph.microsoft.com
                 if (counter > 2)
                 {
-                    sb.Append("/" + Uri.EscapeDataString(segment));
+                    sb.Append('/');
+                    sb.Append(Uri.EscapeDataString(segment));
                 }
                 counter++;
             }

--- a/src/Authentication/Authentication/Helpers/EncodeUriPath.cs
+++ b/src/Authentication/Authentication/Helpers/EncodeUriPath.cs
@@ -1,0 +1,34 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Text;
+
+namespace Microsoft.Graph.PowerShell.Authentication.Helpers
+{
+    /// <summary>
+    /// Escape data string/url encode Uris that have paths containing special characters like #.
+    /// For a path like /beta/users/first.last_foo.com#EXT#@contoso.onmicrosoft.com, the last segment contains special characters that need to be escaped
+    /// </summary>
+    public static class EncodeUriPaths
+    {
+        public static Uri EscapeDataStrings(this Uri uri)
+        {
+            int counter = 0;
+            var pathSegments = uri.OriginalString.Split('/');
+            StringBuilder sb = new StringBuilder();
+            foreach (var segment in pathSegments)
+            {
+                //Skips the left part of the uri i.e https://graph.microsoft.com
+                if (counter > 2)
+                {
+                    sb.Append("/" + Uri.EscapeDataString(segment));
+                }
+                counter++;
+            }
+            Uri escapedUri = new Uri(uri.GetLeftPart(UriPartial.Authority) + sb.ToString());
+            return escapedUri;
+        }
+    }
+}


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #1947

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

-  Added function to escape data string/url encode path segments that have special characters like #. Results for both Absolute and relative uri are shown on the image below.
![image](https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/e5bafbce-9c3f-4f7a-bc37-e30800054789)



