### PR TITLE
Change preapproval commandlets to not call directory settings apis

### DIFF
--- a/src/Teams/beta/custom/GetMgBetaTeamRscConfiguration_Get.cs
+++ b/src/Teams/beta/custom/GetMgBetaTeamRscConfiguration_Get.cs
@@ -242,11 +242,6 @@
 
                     WriteVerbose($"Fetched permission grant policies for tenant.");
 
-                    // Get Group consent settings
-                    MGTeamsInternalTenantConsentSettingsCollection tenantConsentSettingCollection = await this.Client.GetTenantConsentSettings(this, Pipeline);
-
-                    WriteVerbose($"Fetched Tenant App Settings for tenant.");
-
                     if (((Microsoft.Graph.Beta.PowerShell.Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
 
                     // Get authorization policy
@@ -259,7 +254,6 @@
                     RscConfigurationSynthesizer rscConfigurationConverter = new RscConfigurationSynthesizer();
                     Models.IMicrosoftGraphRscConfiguration microsoftGraphRscConfiguration = rscConfigurationConverter.ConvertToTeamRscConfiguration(
                         permissionGrantPolicyCollection,
-                        tenantConsentSettingCollection,
                         authorizationPolicy,
                         this);
 

--- a/src/Teams/beta/custom/MicrosoftGraphRscConfigurationState.cs
+++ b/src/Teams/beta/custom/MicrosoftGraphRscConfigurationState.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Graph.Beta.PowerShell.Models
         EnabledForAllApps,
 
         /// <summary>
-        /// Enabled for selected group of users.
+        /// RSC configuration is managed by Microsoft.
         /// </summary>
-        EnabledForSelectedGroupOfUsers,
+        ManagedByMicrosoft,
 
         /// <summary>
         /// Custom configuration not understood by the sdk.

--- a/src/Teams/beta/custom/RscConfigurationSynthesizer.cs
+++ b/src/Teams/beta/custom/RscConfigurationSynthesizer.cs
@@ -17,7 +17,7 @@
 
         internal const string MicrosoftCreatedPermissionGrantPolicyEnabledForPreapprovedAppsForChats = "ManagePermissionGrantsForOwnedResource.microsoft-pre-approval-apps-for-chat";
 
-        internal const string MicrosoftCreatedPermissionGrantPolicyEnabledForAllAppsForChats = "ManagePermissionGrantsForOwnedResource.microsoft-pre-approval-apps-for-chat";
+        internal const string MicrosoftCreatedPermissionGrantPolicyEnabledForAllAppsForChats = "ManagePermissionGrantsForOwnedResource.microsoft-all-application-permissions-for-chat";
 
         internal const string MicrosoftCreatedPermissionGrantPolicyManagedByMicrosoftForChats = "ManagePermissionGrantsForOwnedResource.microsoft-dynamically-managed-permissions-for-chat";
 

--- a/src/Teams/beta/custom/SetMgBetaChatRscConfiguration_Update.cs
+++ b/src/Teams/beta/custom/SetMgBetaChatRscConfiguration_Update.cs
@@ -291,6 +291,16 @@
                     }
                     else if (this.State == MicrosoftGraphRscConfigurationState.EnabledForPreApprovedAppsOnly)
                     {
+                        // Disable chat RSC Teams Setting.
+                        await this.Client.UpdateTeamsAppSettings(
+                            isChatResourceSpecificConsentEnabled: false,
+                            eventListener: this,
+                            sender: Pipeline);
+
+                        WriteVerbose($"Disabled Chat RSC Teams setting.");
+
+                        if (((Microsoft.Graph.Beta.PowerShell.Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
+
                         // Remove all permission grant policies assigned to default user role permissions which are relevant to chat scope and add
                         // Microsoft created.policy enabling pre-approvals.
                         IEnumerable<string> updatedPermissionGrantPolicies = authorizationPolicy.DefaultUserRolePermissions.PermissionGrantPoliciesAssigned
@@ -306,7 +316,9 @@
                         WriteVerbose($"Updated permission grant policies assigned to default user role: '{string.Join(", ", updatedPermissionGrantPolicies)}'.");
 
                         if (((Microsoft.Graph.Beta.PowerShell.Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
-
+                    }
+                    else if (this.State == MicrosoftGraphRscConfigurationState.ManagedByMicrosoft)
+                    {
                         // Disable chat RSC Teams Setting.
                         await this.Client.UpdateTeamsAppSettings(
                             isChatResourceSpecificConsentEnabled: false,
@@ -316,30 +328,48 @@
                         WriteVerbose($"Disabled Chat RSC Teams setting.");
 
                         if (((Microsoft.Graph.Beta.PowerShell.Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
-                    }
-                    else if (this.State == MicrosoftGraphRscConfigurationState.EnabledForAllApps)
-                    {
-                        // Enable chat RSC Teams Setting.
-                        await this.Client.UpdateTeamsAppSettings(
-                            isChatResourceSpecificConsentEnabled: true,
-                            eventListener: this,
-                            sender: Pipeline);
 
-                        WriteVerbose($"Enabled Chat RSC Teams setting.");
-
-                        if (((Microsoft.Graph.Beta.PowerShell.Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
-
-                        // Remove all permission grant policies assigned to default user role permissions which are relevant to chat scope.
-                        IEnumerable<string> existingPermissionGrantPoliciesExceptChatScopePolicies = authorizationPolicy.DefaultUserRolePermissions.PermissionGrantPoliciesAssigned
+                        // Remove all permission grant policies assigned to default user role permissions which are relevant to chat scope and add
+                        // Microsoft created.policy enabling pre-approvals.
+                        IEnumerable<string> updatedPermissionGrantPolicies = authorizationPolicy.DefaultUserRolePermissions.PermissionGrantPoliciesAssigned
                             .Except(
                                 assignedPermissionGrantPoliciesApplicableToChatScope.Select(p => p.ManagePermissionGrantsForOwnedResourcePrefixedId),
-                                StringComparer.OrdinalIgnoreCase);
+                                StringComparer.OrdinalIgnoreCase)
+                            .Union(new string[] { RscConfigurationSynthesizer.MicrosoftCreatedPermissionGrantPolicyManagedByMicrosoftForChats }, StringComparer.OrdinalIgnoreCase);
                         await this.Client.UpdateDefaultUserRolePermissionGrantPoliciesAssigned(
-                            existingPermissionGrantPoliciesExceptChatScopePolicies,
+                            updatedPermissionGrantPolicies,
                             this,
                             Pipeline);
 
-                        WriteVerbose($"Updated permission grant policies assigned to default user role: '{string.Join(", ", existingPermissionGrantPoliciesExceptChatScopePolicies)}'.");
+                        WriteVerbose($"Updated permission grant policies assigned to default user role: '{string.Join(", ", updatedPermissionGrantPolicies)}'.");
+
+                        if (((Microsoft.Graph.Beta.PowerShell.Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
+                    }
+                    else if (this.State == MicrosoftGraphRscConfigurationState.EnabledForAllApps)
+                    {
+                        // Disable chat RSC Teams Setting.
+                        await this.Client.UpdateTeamsAppSettings(
+                            isChatResourceSpecificConsentEnabled: false,
+                            eventListener: this,
+                            sender: Pipeline);
+
+                        WriteVerbose($"Disabled Chat RSC Teams setting.");
+
+                        if (((Microsoft.Graph.Beta.PowerShell.Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
+
+                        // Remove all permission grant policies assigned to default user role permissions which are relevant to chat scope and add
+                        // Microsoft created.policy enabling permissions for all apps.
+                        IEnumerable<string> updatedPermissionGrantPolicies = authorizationPolicy.DefaultUserRolePermissions.PermissionGrantPoliciesAssigned
+                            .Except(
+                                assignedPermissionGrantPoliciesApplicableToChatScope.Select(p => p.ManagePermissionGrantsForOwnedResourcePrefixedId),
+                                StringComparer.OrdinalIgnoreCase)
+                            .Union(new string[] { RscConfigurationSynthesizer.MicrosoftCreatedPermissionGrantPolicyEnabledForAllAppsForChats }, StringComparer.OrdinalIgnoreCase);
+                        await this.Client.UpdateDefaultUserRolePermissionGrantPoliciesAssigned(
+                            updatedPermissionGrantPolicies,
+                            this,
+                            Pipeline);
+
+                        WriteVerbose($"Updated permission grant policies assigned to default user role: '{string.Join(", ", updatedPermissionGrantPolicies)}'.");
 
                         if (((Microsoft.Graph.Beta.PowerShell.Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                     }

--- a/src/Teams/beta/custom/SetMgBetaChatRscConfiguration_Update.cs
+++ b/src/Teams/beta/custom/SetMgBetaChatRscConfiguration_Update.cs
@@ -330,7 +330,7 @@
                         if (((Microsoft.Graph.Beta.PowerShell.Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
 
                         // Remove all permission grant policies assigned to default user role permissions which are relevant to chat scope and add
-                        // Microsoft created.policy enabling pre-approvals.
+                        // Microsoft managed policy for consent.
                         IEnumerable<string> updatedPermissionGrantPolicies = authorizationPolicy.DefaultUserRolePermissions.PermissionGrantPoliciesAssigned
                             .Except(
                                 assignedPermissionGrantPoliciesApplicableToChatScope.Select(p => p.ManagePermissionGrantsForOwnedResourcePrefixedId),

--- a/src/Teams/beta/custom/SetMgBetaChatRscConfiguration_Update.cs
+++ b/src/Teams/beta/custom/SetMgBetaChatRscConfiguration_Update.cs
@@ -297,7 +297,7 @@
                             .Except(
                                 assignedPermissionGrantPoliciesApplicableToChatScope.Select(p => p.ManagePermissionGrantsForOwnedResourcePrefixedId),
                                 StringComparer.OrdinalIgnoreCase)
-                            .Union(new string[] { RscConfigurationSynthesizer.MicrosoftCreatedPermissionGrantPolicyForChatRscPreApproval }, StringComparer.OrdinalIgnoreCase);
+                            .Union(new string[] { RscConfigurationSynthesizer.MicrosoftCreatedPermissionGrantPolicyEnabledForPreapprovedAppsForChats }, StringComparer.OrdinalIgnoreCase);
                         await this.Client.UpdateDefaultUserRolePermissionGrantPoliciesAssigned(
                             updatedPermissionGrantPolicies,
                             this,

--- a/src/Teams/beta/custom/SetMgBetaTeamRscConfiguration_Update.cs
+++ b/src/Teams/beta/custom/SetMgBetaTeamRscConfiguration_Update.cs
@@ -307,7 +307,8 @@
                     }
                     else if (this.State == MicrosoftGraphRscConfigurationState.ManagedByMicrosoft)
                     {
-                        // Remove all permission grant policies assigned to default user role permissions which are relevant to team scope.
+                        // Remove all permission grant policies assigned to default user role permissions which are relevant to team scope and add
+                        // Microsoft managed policy for consent.
                         IEnumerable<string> existingPermissionGrantPoliciesExceptTeamScopePolicies = authorizationPolicy.DefaultUserRolePermissions.PermissionGrantPoliciesAssigned
                             .Except(
                                 assignedPermissionGrantPoliciesApplicableToTeamScope.Select(p => p.ManagePermissionGrantsForOwnedResourcePrefixedId),


### PR DESCRIPTION
﻿Change preapproval commandlets to not call directory settings APIs and manage preapprovals solely through permission grant policies.


<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

-
-
-

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links

-
-
-
