### PR TITLE
Fixes weekly SDK build pipeline failure due to cmdlet conflict. 

### DIFF
--- a/src/Bookings/beta/readme.md
+++ b/src/Bookings/beta/readme.md
@@ -33,5 +33,5 @@ namespace: Microsoft.Graph.Beta.PowerShell
 
 directive:
 # Remove path causing module conflict by operationId.
-  remove-path-by-operation: solutions.bookingBusinesses_getStaffAvailability
+  remove-path-by-operation: solution.bookingBusiness_getStaffAvailability|solution.bookingBusiness.*._cancel
 ```

--- a/src/Bookings/beta/readme.md
+++ b/src/Bookings/beta/readme.md
@@ -30,4 +30,8 @@ require:
 title: $(service-name)
 subject-prefix: 'Beta'
 namespace: Microsoft.Graph.Beta.PowerShell
+
+directive:
+# Remove path causing module conflict by operationId.
+  remove-path-by-operation: solutions.bookingBusinesses_getStaffAvailability
 ```

--- a/src/Bookings/v1.0/readme.md
+++ b/src/Bookings/v1.0/readme.md
@@ -30,4 +30,8 @@ require:
 title: $(service-name)
 subject-prefix: ''
 namespace: Microsoft.Graph.PowerShell
+
+directive:
+# Remove path causing module conflict by operationId.
+  remove-path-by-operation: solution.bookingBusiness_getStaffAvailability|solution.bookingBusiness.*._cancel
 ```


### PR DESCRIPTION
Newly added [Open API](https://graphexplorerapi.azurewebsites.net/$openapi?tags=^solutions|^bookingBusinesses|^bookingCurrencies&title=Bookings&openapiversion=3&style=Powershell&graphVersion=beta) path ``/solutions/bookingBusinesses/{bookingBusiness-id}/microsoft.graph.getStaffAvailability`` causes cmdlet conflict during module build. 
![image](https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/1a52c136-7d09-4560-bfe6-834f0c6fb85f)

 **Changes proposed**
- Added Autorest directive to remove the path.