### PR TITLE
Generate cmdlets from forked AutoREST.PowerShell repository.

### DIFF
--- a/.azure-pipelines/common-templates/checkout.yml
+++ b/.azure-pipelines/common-templates/checkout.yml
@@ -10,7 +10,7 @@ steps:
   - checkout: self
     clean: true
     fetchDepth: 1
-    submodules: true
+    submodules: recursive
     persistCredentials: true
 
   - task: PowerShell@2
@@ -36,13 +36,5 @@ steps:
         git checkout ${{ parameters.TargetBranch }}
         git pull
         git status
-
-  - task: PowerShell@2
-    displayName: "Update Git Submodules"
-    inputs:
-      targetType: inline
-      script: |
-        git pull --recurse-submodules
-        git submodule sync
-
+        
   - template: ./security-pre-checks.yml

--- a/.azure-pipelines/common-templates/checkout.yml
+++ b/.azure-pipelines/common-templates/checkout.yml
@@ -42,7 +42,6 @@ steps:
     inputs:
       targetType: inline
       script: |
-        git pull --recurse-submodules
         git submodule update --init --recursive --remote
 
   - template: ./security-pre-checks.yml

--- a/.azure-pipelines/common-templates/checkout.yml
+++ b/.azure-pipelines/common-templates/checkout.yml
@@ -43,6 +43,6 @@ steps:
       targetType: inline
       script: |
         git pull --recurse-submodules
-        git submodule update --init --recursive --remote
+        git submodule sync
 
   - template: ./security-pre-checks.yml

--- a/.azure-pipelines/common-templates/checkout.yml
+++ b/.azure-pipelines/common-templates/checkout.yml
@@ -36,5 +36,12 @@ steps:
         git checkout ${{ parameters.TargetBranch }}
         git pull
         git status
-        
+
+  - task: PowerShell@2
+    displayName: "Update Git Submodules"
+    inputs:
+      targetType: inline
+      script: |
+        git submodule update --recursive --remote
+
   - template: ./security-pre-checks.yml

--- a/.azure-pipelines/common-templates/checkout.yml
+++ b/.azure-pipelines/common-templates/checkout.yml
@@ -43,6 +43,6 @@ steps:
       targetType: inline
       script: |
         git pull --recurse-submodules
-        git submodule update --recursive
+        git submodule update --init --recursive --remote
 
   - template: ./security-pre-checks.yml

--- a/.azure-pipelines/common-templates/checkout.yml
+++ b/.azure-pipelines/common-templates/checkout.yml
@@ -37,11 +37,4 @@ steps:
         git pull
         git status
 
-  - task: PowerShell@2
-    displayName: "Update Git Submodules"
-    inputs:
-      targetType: inline
-      script: |
-        git submodule update --remote
-
   - template: ./security-pre-checks.yml

--- a/.azure-pipelines/common-templates/checkout.yml
+++ b/.azure-pipelines/common-templates/checkout.yml
@@ -42,6 +42,6 @@ steps:
     inputs:
       targetType: inline
       script: |
-        git submodule update --recursive --remote
+        git submodule update --remote
 
   - template: ./security-pre-checks.yml

--- a/.azure-pipelines/common-templates/checkout.yml
+++ b/.azure-pipelines/common-templates/checkout.yml
@@ -42,6 +42,7 @@ steps:
     inputs:
       targetType: inline
       script: |
-        git submodule update --init --recursive --remote
+        git pull --recurse-submodules
+        git submodule update --recursive
 
   - template: ./security-pre-checks.yml

--- a/.azure-pipelines/common-templates/checkout.yml
+++ b/.azure-pipelines/common-templates/checkout.yml
@@ -37,4 +37,12 @@ steps:
         git pull
         git status
 
+  - task: PowerShell@2
+    displayName: "Update Git Submodules"
+    inputs:
+      targetType: inline
+      script: |
+        git pull --recurse-submodules
+        git submodule update --init --recursive --remote
+
   - template: ./security-pre-checks.yml

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -29,7 +29,7 @@ steps:
   - task: NodeTool@0
     displayName: Install NodeJs
     inputs:
-      versionSpec: '14.15.5'
+      versionSpec: 16.x
       
   - task: Npm@1
     displayName: Install AutoRest

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -32,8 +32,8 @@ steps:
       versionSpec: 16.x
 
   - task: Npm@1
-    displayName: Install AutoRest
+    displayName: Install Rush
     inputs:
       command: custom
-      customCommand: install -g autorest@latest
+      customCommand: install -g @microsoft/rush
 

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -29,7 +29,7 @@ steps:
   - task: NodeTool@0
     displayName: Install NodeJs
     inputs:
-      versionSpec: 16.x
+      versionSpec: 15.x
 
   - task: Npm@1
     displayName: Install Rush

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -29,7 +29,13 @@ steps:
   - task: NodeTool@0
     displayName: Install NodeJs
     inputs:
-      versionSpec: 15.x
+      versionSpec: '14.15.5'
+      
+  - task: Npm@1
+    displayName: Install AutoRest
+    inputs:
+      command: custom
+      customCommand: install -g autorest@latest
 
   - task: Npm@1
     displayName: Install Rush

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,3 @@
 	path = autorest.powershell
 	url = https://github.com/microsoftgraph/autorest.powershell
 	branch = powershell-v2
-	fetch = refs/remotes/origin/powershell-v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "autorest.powershell"]
 	path = autorest.powershell
 	url = https://github.com/microsoftgraph/autorest.powershell
-	branch = powershell-v2
+	branch = origin/powershell-v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "autorest.powershell"]
 	path = autorest.powershell
 	url = https://github.com/microsoftgraph/autorest.powershell
-	branch = origin/powershell-v2
+	branch = powershell-v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = autorest.powershell
 	url = https://github.com/microsoftgraph/autorest.powershell
 	branch = powershell-v2
+	fetch = refs/remotes/origin/powershell-v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "autorest.powershell"]
+	path = autorest.powershell
+	url = https://github.com/microsoftgraph/autorest.powershell
+	branch = powershell-v2

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_Create.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_Create.cs
@@ -43,7 +43,15 @@
 
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
 
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -262,12 +270,12 @@
                 try
                 {
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletBeforeAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
-                    await this.Client.GroupCreateMemberGraphBPreRef(GroupId, BodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateMemberGraphBPreRef(GroupId, CustomHeader, BodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Microsoft.Graph.Beta.PowerShell.Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new global::System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), global::System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, body = BodyParameter })
+                    WriteError(new global::System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), global::System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, CustomHeader = CustomHeader, body = BodyParameter })
                     {
                         ErrorDetails = new global::System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_CreateExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_CreateExpanded.cs
@@ -33,6 +33,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -263,12 +272,12 @@
                 {
                     await ((Runtime.IEventListener)this).Signal(Microsoft.Graph.Beta.PowerShell.Runtime.Events.CmdletBeforeAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                     _bodyParameter.OdataId = $"https://graph.microsoft.com/beta/directoryObjects/{DirectoryObjectId}";
-                    await this.Client.GroupCreateMemberGraphBPreRef(GroupId, _bodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateMemberGraphBPreRef(GroupId, CustomHeader, _bodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Microsoft.Graph.Beta.PowerShell.Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, body = _bodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, CustomHeader = CustomHeader, body = _bodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentity.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentity.cs
@@ -44,6 +44,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -261,12 +270,12 @@
                     {
                         ThrowTerminatingError(new System.Management.Automation.ErrorRecord(new System.Exception("InputObject has null value for InputObject.GroupId"), string.Empty, System.Management.Automation.ErrorCategory.InvalidArgument, InputObject));
                     }
-                    await this.Client.GroupCreateMemberGraphBPreRef(InputObject.GroupId, BodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateMemberGraphBPreRef(InputObject.GroupId, CustomHeader, BodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { body = BodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { CustomHeader = CustomHeader, body = BodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentityExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentityExpanded.cs
@@ -33,6 +33,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -262,12 +271,12 @@
                         ThrowTerminatingError(new System.Management.Automation.ErrorRecord(new System.Exception("InputObject has null value for InputObject.GroupId"), string.Empty, System.Management.Automation.ErrorCategory.InvalidArgument, InputObject));
                     }
                     _bodyParameter.OdataId = $"https://graph.microsoft.com/beta/directoryObjects/{DirectoryObjectId}";
-                    await this.Client.GroupCreateMemberGraphBPreRef(InputObject.GroupId, _bodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateMemberGraphBPreRef(InputObject.GroupId, CustomHeader, _bodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { body = _bodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { CustomHeader = CustomHeader, body = _bodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_Create.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_Create.cs
@@ -42,6 +42,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -260,12 +269,12 @@
                 try
                 {
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletBeforeAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
-                    await this.Client.GroupCreateOwnerGraphBPreRef(GroupId, BodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateOwnerGraphBPreRef(GroupId, CustomHeader, BodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, body = BodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, CustomHeader = CustomHeader, body = BodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateExpanded.cs
@@ -33,6 +33,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -263,12 +272,12 @@
                 {
                     await ((Runtime.IEventListener)this).Signal(Microsoft.Graph.Beta.PowerShell.Runtime.Events.CmdletBeforeAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                     _bodyParameter.OdataId = $"https://graph.microsoft.com/beta/directoryObjects/{DirectoryObjectId}";
-                    await this.Client.GroupCreateOwnerGraphBPreRef(GroupId, _bodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateOwnerGraphBPreRef(GroupId, CustomHeader, _bodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Microsoft.Graph.Beta.PowerShell.Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, body = _bodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, CustomHeader = CustomHeader, body = _bodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentity.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentity.cs
@@ -44,6 +44,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -261,12 +270,12 @@
                     {
                         ThrowTerminatingError(new System.Management.Automation.ErrorRecord(new System.Exception("InputObject has null value for InputObject.GroupId"), string.Empty, System.Management.Automation.ErrorCategory.InvalidArgument, InputObject));
                     }
-                    await this.Client.GroupCreateOwnerGraphBPreRef(InputObject.GroupId, BodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateOwnerGraphBPreRef(InputObject.GroupId, CustomHeader, BodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { body = BodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { CustomHeader = CustomHeader, body = BodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentityExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentityExpanded.cs
@@ -33,6 +33,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -262,12 +271,12 @@
                         ThrowTerminatingError(new System.Management.Automation.ErrorRecord(new System.Exception("InputObject has null value for InputObject.GroupId"), string.Empty, System.Management.Automation.ErrorCategory.InvalidArgument, InputObject));
                     }
                     _bodyParameter.OdataId = $"https://graph.microsoft.com/beta/directoryObjects/{DirectoryObjectId}";
-                    await this.Client.GroupCreateOwnerGraphBPreRef(InputObject.GroupId ?? null, _bodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateOwnerGraphBPreRef(InputObject.GroupId ?? null,CustomHeader, _bodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { body = _bodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { CustomHeader = CustomHeader, body = _bodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/v1.0/custom/NewMgGroupMember_Create.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_Create.cs
@@ -43,6 +43,16 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
+
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -261,12 +271,12 @@
                 try
                 {
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletBeforeAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
-                    await this.Client.GroupCreateMemberGraphBPreRef(GroupId, BodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateMemberGraphBPreRef(GroupId, CustomHeader, BodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Microsoft.Graph.PowerShell.Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new global::System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), global::System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, body = BodyParameter })
+                    WriteError(new global::System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), global::System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, CustomHeader=CustomHeader, body = BodyParameter })
                     {
                         ErrorDetails = new global::System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/v1.0/custom/NewMgGroupMember_Create.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_Create.cs
@@ -49,8 +49,8 @@
         /// <summary>
         /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
         /// </summary>
-        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
-        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
         public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
 
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateExpanded.cs
@@ -32,6 +32,17 @@
 
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
+        
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
+
 
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
@@ -263,12 +274,12 @@
                 {
                     await ((Runtime.IEventListener)this).Signal(Microsoft.Graph.PowerShell.Runtime.Events.CmdletBeforeAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                     _bodyParameter.OdataId = $"https://graph.microsoft.com/v1.0/directoryObjects/{DirectoryObjectId}";
-                    await this.Client.GroupCreateMemberGraphBPreRef(GroupId, _bodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateMemberGraphBPreRef(GroupId, CustomHeader, _bodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Microsoft.Graph.PowerShell.Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, body = _bodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, CustomHeader=CustomHeader, body = _bodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateExpanded.cs
@@ -32,15 +32,15 @@
 
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
-        
+
         /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
         private string _customHeader;
 
         /// <summary>
         /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
         /// </summary>
-        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
-        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
         public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
 
 

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentity.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentity.cs
@@ -44,6 +44,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -261,12 +270,12 @@
                     {
                         ThrowTerminatingError(new System.Management.Automation.ErrorRecord(new System.Exception("InputObject has null value for InputObject.GroupId"), string.Empty, System.Management.Automation.ErrorCategory.InvalidArgument, InputObject));
                     }
-                    await this.Client.GroupCreateMemberGraphBPreRef(InputObject.GroupId, BodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateMemberGraphBPreRef(InputObject.GroupId, CustomHeader, BodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { body = BodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { CustomHeader = CustomHeader, body = BodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentity.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentity.cs
@@ -50,8 +50,8 @@
         /// <summary>
         /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
         /// </summary>
-        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
-        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
         public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentityExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentityExpanded.cs
@@ -33,6 +33,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -262,12 +271,12 @@
                         ThrowTerminatingError(new System.Management.Automation.ErrorRecord(new System.Exception("InputObject has null value for InputObject.GroupId"), string.Empty, System.Management.Automation.ErrorCategory.InvalidArgument, InputObject));
                     }
                     _bodyParameter.OdataId = $"https://graph.microsoft.com/v1.0/directoryObjects/{DirectoryObjectId}";
-                    await this.Client.GroupCreateMemberGraphBPreRef(InputObject.GroupId, _bodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateMemberGraphBPreRef(InputObject.GroupId, CustomHeader, _bodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { body = _bodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { CustomHeader = CustomHeader, body = _bodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentityExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentityExpanded.cs
@@ -39,8 +39,8 @@
         /// <summary>
         /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
         /// </summary>
-        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
-        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
         public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_Create.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_Create.cs
@@ -42,6 +42,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -260,12 +269,12 @@
                 try
                 {
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletBeforeAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
-                    await this.Client.GroupCreateOwnerGraphBPreRef(GroupId, BodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateOwnerGraphBPreRef(GroupId, CustomHeader, BodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, body = BodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, CustomHeader = CustomHeader, body = BodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_Create.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_Create.cs
@@ -48,8 +48,8 @@
         /// <summary>
         /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
         /// </summary>
-        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
-        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
         public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateExpanded.cs
@@ -33,6 +33,15 @@
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -263,12 +272,12 @@
                 {
                     await ((Runtime.IEventListener)this).Signal(Microsoft.Graph.PowerShell.Runtime.Events.CmdletBeforeAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                     _bodyParameter.OdataId = $"https://graph.microsoft.com/v1.0/directoryObjects/{DirectoryObjectId}";
-                    await this.Client.GroupCreateOwnerGraphBPreRef(GroupId, _bodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateOwnerGraphBPreRef(GroupId, CustomHeader, _bodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Microsoft.Graph.PowerShell.Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, body = _bodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { GroupId = GroupId, CustomHeader = CustomHeader, body = _bodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateExpanded.cs
@@ -39,8 +39,8 @@
         /// <summary>
         /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
         /// </summary>
-        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
-        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
         public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentity.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentity.cs
@@ -47,8 +47,8 @@
         /// <summary>
         /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
         /// </summary>
-        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
-        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
         public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentity.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentity.cs
@@ -41,6 +41,15 @@
         [Category(ParameterCategory.Runtime)]
         public System.Management.Automation.SwitchParameter Break { get; set; }
 
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
+
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
 
@@ -261,12 +270,12 @@
                     {
                         ThrowTerminatingError(new System.Management.Automation.ErrorRecord(new System.Exception("InputObject has null value for InputObject.GroupId"), string.Empty, System.Management.Automation.ErrorCategory.InvalidArgument, InputObject));
                     }
-                    await this.Client.GroupCreateOwnerGraphBPreRef(InputObject.GroupId, BodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateOwnerGraphBPreRef(InputObject.GroupId, CustomHeader, BodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { body = BodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { CustomHeader = CustomHeader, body = BodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentityExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentityExpanded.cs
@@ -32,7 +32,16 @@
 
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
+        /// <summary>Backing field for <see cref="CustomHeader" /> property.</summary>
+        private string _customHeader;
 
+        /// <summary>
+        /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
+        /// </summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
+        
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -262,12 +271,12 @@
                         ThrowTerminatingError(new System.Management.Automation.ErrorRecord(new System.Exception("InputObject has null value for InputObject.GroupId"), string.Empty, System.Management.Automation.ErrorCategory.InvalidArgument, InputObject));
                     }
                     _bodyParameter.OdataId = $"https://graph.microsoft.com/v1.0/directoryObjects/{DirectoryObjectId}";
-                    await this.Client.GroupCreateOwnerGraphBPreRef(InputObject.GroupId ?? null, _bodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateOwnerGraphBPreRef(InputObject.GroupId ?? null, CustomHeader = CustomHeader, _bodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
                 {
-                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { body = _bodyParameter })
+                    WriteError(new System.Management.Automation.ErrorRecord(urexception, urexception.StatusCode.ToString(), System.Management.Automation.ErrorCategory.InvalidOperation, new { CustomHeader = CustomHeader, body = _bodyParameter })
                     {
                         ErrorDetails = new System.Management.Automation.ErrorDetails(urexception.Message) { RecommendedAction = urexception.Action }
                     });

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentityExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentityExpanded.cs
@@ -38,8 +38,8 @@
         /// <summary>
         /// CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs
         /// </summary>
-        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
-        [global::Sample.API.Category(global::Sample.API.ParameterCategory.Runtime)]
+        [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "CustomHeader Parameter. This should have a key:value and comma separated for multiple key:value pairs", ValueFromPipeline = true)]
+        [Category(ParameterCategory.Runtime)]
         public string CustomHeader { get => this._customHeader; set => this._customHeader = value; }
         
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -6,7 +6,8 @@
 azure: false
 powershell: true
 version: latest
-use: "@autorest/powershell@3.0.509"
+#use: "@autorest/powershell@3.0.509"
+use: "$(this-folder)../autorest.powershell"
 export-properties-for-dict: false
 metadata:
     authors: Microsoft Corporation

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -52,7 +52,7 @@ if (-not (Test-Path $ModuleMappingPath)) {
 
 # Build AutoREST.PowerShell submodule.
 Set-Location (Join-Path $ScriptRoot "../autorest.powershell")
-rush update
+rush update --purge
 rush build
 
 $RequiredGraphModules = @()

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -50,6 +50,11 @@ if (-not (Test-Path $ModuleMappingPath)) {
     Write-Error "Module mapping file not be found: $ModuleMappingPath."
 }
 
+# Build AutoREST.PowerShell submodule.
+Set-Location (Join-Path $ScriptRoot "../autorest.powershell")
+rush update
+rush build
+
 $RequiredGraphModules = @()
 $AuthModuleManifest = Join-Path $ModulesSrc "Authentication" "Authentication" "artifacts" "Microsoft.Graph.Authentication.psd1"
 $LoadedAuthModule = Import-Module $AuthModuleManifest -PassThru -ErrorAction SilentlyContinue


### PR DESCRIPTION
Fixes #1570 and #2476

### Changes proposed in this pull request
- Adds forked [Autorest ](https://github.com/microsoftgraph/autorest.powershell/tree/powershell-v2)as a submodule which will be used to generate cmdlets.
- Updates custom commands in the group module to include custom header parameter as expected by the auto generated Client API class.
- Updates pipelines to run generation using the forked AutoREST.PowerShell repo.
- Updates the global directive file (readme.graph.md) to point to the AutoREST.PowerShell submodule.

Generated cmdlets were published to an internal feed. Using cmdlets obtained from that feed manual tests involving PATCH, POST and DELETE operations were done while raptor handled GET operations. Use [this script](https://github.com/timayabi2020/AutorestFiles/blob/main/PowerShellAutorestFeed.ps1) to register the feed as a PS repository. 

**Sample cmdlet with optional custom header parameter**
![image](https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/a7b62fdf-f80c-474b-a5f2-6b6f91e29ed6)

**Sample cmdlet extracting the correct media type from file inputs and setting the correct request content type. (Intitally all input file requests defaulted to application/octet-stream
![image](https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/a7264069-00a2-402d-a3af-bf1166cb33cf)

**Sample cmdlet with optional parameter for specifying the media/content type for file inputs**

![image](https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/602c7a33-8ba4-4085-b022-88c5241fcba1)

**Sample raptor test run results for stable tests**
**NB** This was locally run because the feed was locally registered.
![image](https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/f3a7b4a4-559d-437f-9abb-7ebcb2020067)

