### PR TITLE
Updates Azure Devops service connection

### DIFF
--- a/.azure-pipelines/weekly-examples-update.yml
+++ b/.azure-pipelines/weekly-examples-update.yml
@@ -23,7 +23,7 @@ resources:
  repositories:     
    - repository: msgraph-sdk-powershell
      type: github
-     endpoint: microsoftgraph
+     endpoint: MicrosoftDocs
      name: microsoftgraph/msgraph-sdk-powershell
      ref: dev
 


### PR DESCRIPTION
This PR updates Azure Devops service connection from the disabled one ``microsoftgraph`` to a working one ``MicrosoftDocs``. Currently being used by https://github.com/MicrosoftDocs/microsoftgraph-docs-powershell to update PowerShell online reference docs.
