### PR TITLE
Patch Release. Ensures that ``-Header`` parameter is not mandatory

### DIFF
--- a/config/ModuleMetadata.json
+++ b/config/ModuleMetadata.json
@@ -27,15 +27,15 @@
   "versions": {
     "authentication": {
       "prerelease": "",
-      "version": "2.12.0"
+      "version": "2.13.1"
     },
     "beta": {
       "prerelease": "",
-      "version": "2.12.0"
+      "version": "2.13.1"
     },
     "v1.0": {
       "prerelease": "",
-      "version": "2.12.0"
+      "version": "2.13.1"
     }
   }
 }


### PR DESCRIPTION
Currently for all cmdlets one must specify the ``-Header`` parameter.
Updated AutoREST code generator to prevent this scenario.


