### PR TITLE
Adds an optional ``-RHV`` parameter that will assign response headers to a variable (Value provided to the optional RHV parameter)

### DIFF
--- a/src/Groups/beta/custom/NewMgBetaGroupMember_Create.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_Create.cs
@@ -13,7 +13,7 @@
     public partial class NewMgBetaGroupMember_Create : System.Management.Automation.PSCmdlet,
         Runtime.IEventListener
     {
-        
+
         /// <summary>A copy of the Invocation Info (necessary to allow asJob to clone this cmdlet)</summary>
         private System.Management.Automation.InvocationInfo __invocationInfo;
 
@@ -322,12 +322,12 @@
                 {
                     WriteObject(true);
                 }
-                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_Create.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_Create.cs
@@ -51,6 +51,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -313,6 +321,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_CreateExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_CreateExpanded.cs
@@ -368,9 +368,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_CreateExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_CreateExpanded.cs
@@ -41,6 +41,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -356,6 +364,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentity.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentity.cs
@@ -52,6 +52,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -354,6 +362,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentity.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentity.cs
@@ -366,9 +366,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentityExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentityExpanded.cs
@@ -367,9 +367,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentityExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupMember_CreateViaIdentityExpanded.cs
@@ -41,6 +41,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -355,6 +363,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_Create.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_Create.cs
@@ -323,9 +323,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_Create.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_Create.cs
@@ -50,6 +50,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -311,6 +319,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateExpanded.cs
@@ -368,9 +368,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateExpanded.cs
@@ -41,6 +41,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -356,6 +364,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentity.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentity.cs
@@ -52,6 +52,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -354,6 +362,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentity.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentity.cs
@@ -366,9 +366,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentityExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentityExpanded.cs
@@ -40,6 +40,14 @@
         [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional headers that will be added to the request.", ValueFromPipeline = true)]
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
+
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
         
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
@@ -355,6 +363,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentityExpanded.cs
+++ b/src/Groups/beta/custom/NewMgBetaGroupOwner_CreateViaIdentityExpanded.cs
@@ -48,7 +48,7 @@
         [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
         [global::System.Management.Automation.Alias("RHV")]
         public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
-        
+
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -278,7 +278,7 @@
                         ThrowTerminatingError(new System.Management.Automation.ErrorRecord(new System.Exception("InputObject has null value for InputObject.GroupId"), string.Empty, System.Management.Automation.ErrorCategory.InvalidArgument, InputObject));
                     }
                     _bodyParameter.OdataId = $"https://graph.microsoft.com/beta/directoryObjects/{DirectoryObjectId}";
-                    await this.Client.GroupCreateOwnerGraphBPreRef(InputObject.GroupId ?? null,Headers, _bodyParameter, onNoContent, onDefault, this, Pipeline);
+                    await this.Client.GroupCreateOwnerGraphBPreRef(InputObject.GroupId ?? null, Headers, _bodyParameter, onNoContent, onDefault, this, Pipeline);
                     await ((Runtime.IEventListener)this).Signal(Runtime.Events.CmdletAfterAPICall); if (((Runtime.IEventListener)this).Token.IsCancellationRequested) { return; }
                 }
                 catch (Runtime.UndeclaredResponseException urexception)
@@ -367,9 +367,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupMember_Create.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_Create.cs
@@ -325,9 +325,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupMember_Create.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_Create.cs
@@ -51,6 +51,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -313,6 +321,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateExpanded.cs
@@ -48,7 +48,7 @@
         [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
         [global::System.Management.Automation.Alias("RHV")]
         public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
-        
+
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -368,9 +368,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateExpanded.cs
@@ -41,7 +41,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
 
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+        
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -357,6 +364,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentity.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentity.cs
@@ -51,7 +51,7 @@
         [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional headers that will be added to the request.", ValueFromPipeline = true)]
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
-    
+
         // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
         private string _responseHeadersVariable;
 
@@ -366,9 +366,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentity.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentity.cs
@@ -51,6 +51,14 @@
         [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional headers that will be added to the request.", ValueFromPipeline = true)]
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
+    
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
 
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
@@ -354,6 +362,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentityExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentityExpanded.cs
@@ -367,9 +367,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentityExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupMember_CreateViaIdentityExpanded.cs
@@ -41,6 +41,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -355,6 +363,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_Create.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_Create.cs
@@ -48,6 +48,15 @@
         [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional headers that will be added to the request.", ValueFromPipeline = true)]
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
+
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+        
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -309,6 +318,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_Create.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_Create.cs
@@ -56,7 +56,7 @@
         [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
         [global::System.Management.Automation.Alias("RHV")]
         public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
-        
+
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -322,9 +322,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateExpanded.cs
@@ -368,9 +368,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateExpanded.cs
@@ -41,6 +41,14 @@
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
 
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
+
         /// <summary>Backing field for <see cref="GroupId" /> property.</summary>
         private string _groupId;
 
@@ -356,6 +364,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentity.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentity.cs
@@ -48,6 +48,14 @@
         [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional headers that will be added to the request.", ValueFromPipeline = true)]
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
+        
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
 
         /// <summary>The reference to the client API class.</summary>
         public Groups Client => Module.Instance.ClientAPI;
@@ -354,6 +362,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentity.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentity.cs
@@ -48,7 +48,7 @@
         [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional headers that will be added to the request.", ValueFromPipeline = true)]
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
-        
+
         // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
         private string _responseHeadersVariable;
 
@@ -366,9 +366,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentityExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentityExpanded.cs
@@ -40,6 +40,14 @@
         [System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional headers that will be added to the request.", ValueFromPipeline = true)]
         [Category(ParameterCategory.Runtime)]
         public System.Collections.IDictionary Headers { get => this._headers; set => this._headers = value; }
+
+        // <summary>Backing field for <see cref="ResponseHeadersVariable" /> property.</summary>
+        private string _responseHeadersVariable;
+
+        /// <summary>Optional Response Headers Variable</summary>
+        [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
+        [global::System.Management.Automation.Alias("RHV")]
+        public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
         
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
@@ -355,6 +363,13 @@
                 if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
+                }
+                // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
+                if (!string.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                   var vi = this.SessionState.PSVariable;
+                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentityExpanded.cs
+++ b/src/Groups/v1.0/custom/NewMgGroupOwner_CreateViaIdentityExpanded.cs
@@ -48,7 +48,7 @@
         [global::System.Management.Automation.Parameter(Mandatory = false, HelpMessage = "Optional Response Headers Variable.")]
         [global::System.Management.Automation.Alias("RHV")]
         public string ResponseHeadersVariable { get => this._responseHeadersVariable; set => this._responseHeadersVariable = value; }
-        
+
         /// <summary>SendAsync Pipeline Steps to be appended to the front of the pipeline</summary>
         [System.Management.Automation.Parameter(Mandatory = false, DontShow = true, HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline")]
         [System.Management.Automation.ValidateNotNull]
@@ -367,9 +367,9 @@
                 // get the headers from the response and assign it to the variable provided by the user via the RHV(ResponseHeadersVariable) parameter.
                 if (!string.IsNullOrEmpty(ResponseHeadersVariable))
                 {
-                   var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
-                   var vi = this.SessionState.PSVariable;
-                   vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
+                    var headers = Microsoft.Graph.PowerShell.ResponseHeaders.Helpers.ResponseHeaderHelper.GetHttpResponseHeaders(responseMessage);
+                    var vi = this.SessionState.PSVariable;
+                    vi.Set(new System.Management.Automation.PSVariable($"global:{ResponseHeadersVariable}", headers));
                 }
             }
         }

--- a/src/Groups/v1.0/test/New-MgGroup.Tests.ps1
+++ b/src/Groups/v1.0/test/New-MgGroup.Tests.ps1
@@ -25,14 +25,29 @@ Describe 'New-MgGroup' {
     Context 'Create' {
         It 'ShouldCreateNewGroup' {
             $CreateGroups = @()
-            1..100 | ForEach-Object {
+            1..10 | ForEach-Object {
                 $Mock.PushScenario('ShouldCreateNewGroup')
                 $CreateGroups += New-MgGroup -DisplayName "new-mggroup-test" -MailEnabled:$false -MailNickname 'unused' -SecurityEnabled
             }
 
-            $CreateGroups | Should -HaveCount 100
+            $CreateGroups | Should -HaveCount 10
             $CreateGroups[0].DisplayName | Should -Be "new-mggroup-test"
             $CreateGroups[0].MailEnabled | Should -BeFalse
         } 
+
+        It 'ShouldHaveASingleResponseObjectIfRHVIsPassed' {
+            $Mock.PushScenario('ShouldCreateNewGroup')
+            $group = New-MgGroup -DisplayName "new-mggroup-test" -MailEnabled:$false -MailNickname 'unused' -SecurityEnabled -RHV rh
+            $group.Count | Should -HaveCount 1
+        }
+
+        It 'ShouldAssignRetrieveHeadersToRHVIfPassed' {
+            $Mock.PushScenario('ShouldCreateNewGroup')
+            New-MgGroup -DisplayName "new-mggroup-test" -MailEnabled:$false -MailNickname 'unused' -SecurityEnabled -RHV rv
+            $rv.Vary | Should -Be "Accept-Encoding"
+            $rv.'Content-Type' | Should -Be "application/json"
+            
+
+        }
     }
 }

--- a/src/Groups/v1.0/test/New-MgGroup.Tests.ps1
+++ b/src/Groups/v1.0/test/New-MgGroup.Tests.ps1
@@ -25,12 +25,12 @@ Describe 'New-MgGroup' {
     Context 'Create' {
         It 'ShouldCreateNewGroup' {
             $CreateGroups = @()
-            1..10 | ForEach-Object {
+            1..100 | ForEach-Object {
                 $Mock.PushScenario('ShouldCreateNewGroup')
                 $CreateGroups += New-MgGroup -DisplayName "new-mggroup-test" -MailEnabled:$false -MailNickname 'unused' -SecurityEnabled
             }
 
-            $CreateGroups | Should -HaveCount 10
+            $CreateGroups | Should -HaveCount 100
             $CreateGroups[0].DisplayName | Should -Be "new-mggroup-test"
             $CreateGroups[0].MailEnabled | Should -BeFalse
         } 
@@ -45,9 +45,7 @@ Describe 'New-MgGroup' {
             $Mock.PushScenario('ShouldCreateNewGroup')
             New-MgGroup -DisplayName "new-mggroup-test" -MailEnabled:$false -MailNickname 'unused' -SecurityEnabled -RHV rv
             $rv.Vary | Should -Be "Accept-Encoding"
-            $rv.'Content-Type' | Should -Be "application/json"
-            
-
+            $rv.'Content-Type' | Should -Be "application/json" 
         }
     }
 }


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #2600 and #2394.
This change is based on the ``Invoke-MgGraphRequest`` design for capturing response headers by providing the same ``-RHV`` parameter

<img width="1269" alt="image" src="https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/f91f3622-ee65-47a2-9dda-3ec5ea154b95">


<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

-  Adds Optional ``-RHV`` parameter.
-  Updates AutoREST submodule

<img width="695" alt="image" src="https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/38da2c26-a44a-42ce-98cc-09170030c4c8">
