### PR TITLE
Orders permissions based on least privilege property value (``True`` or ``false``)

### DIFF
--- a/src/Authentication/Authentication/Models/GraphCommand.cs
+++ b/src/Authentication/Authentication/Models/GraphCommand.cs
@@ -103,5 +103,9 @@ namespace Microsoft.Graph.PowerShell.Authentication.Models
         /// Full deescription of the permission.
         /// </summary>
         public string FullDescription { get; set; }
+        /// <summary>
+        /// Least privilege flag shows whether the permission is the least privilege.
+        /// </summary>
+        public bool IsLeastPrivilege { get; set; }
     }
 }

--- a/tools/PostGeneration/NewCommandMetadata.ps1
+++ b/tools/PostGeneration/NewCommandMetadata.ps1
@@ -102,9 +102,15 @@ $ApiVersion | ForEach-Object {
                                 Description     = $_.consentDisplayName
                                 FullDescription = $_.consentDescription
                                 IsAdmin         = $_.IsAdmin
+                                ScopeType       = $_.ScopeType
+                                IsLeastPrivilege = $_.isLeastPrivilege
                             }
                         }
-                        $MappingValue.Permissions = ($Permissions | Sort-Object -Property Name -Unique)
+                        $Permissions = $Permissions | Sort-Object -Property Name -Unique
+                        $Permissions = $Permissions | Sort-Object -Property ScopeType
+                        $Permissions = $Permissions | Sort-Object -Property IsLeastPrivilege
+                        [array]::Reverse($Permissions)
+                        $MappingValue.Permissions = $Permissions
                     }
                     catch {
                         Write-Warning "Failed to fetch permissions: $($PermissionsUrl)?requesturl=$($MappingValue.Uri)&method=$($MappingValue.Method)"


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #2618 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Updated NewCommandMetadata.ps1 to order permissions from graphexplorer api based on the least privilege property. (See image below)
- Updated GraphCommand.cs by adding ``IsLeastPrivilege`` property

<img width="914" alt="image" src="https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/fa30c54e-b9bb-4ab7-8ee0-ce675824bd62">

