### PR TITLE
Restricts escaping of special characters to path segments only when using Invoke-MgGraphRequest and bumps ``Azure.Identity.Broker`` Library

### DIFF
--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -4,7 +4,7 @@
     <LangVersion>9.0</LangVersion>
     <TargetFrameworks>netstandard2.0;net6.0;net472</TargetFrameworks>
     <RootNamespace>Microsoft.Graph.PowerShell.Authentication.Core</RootNamespace>
-    <Version>2.6.1</Version>
+    <Version>2.18.0</Version>
   </PropertyGroup>
   <PropertyGroup>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.11.0" />
-    <PackageReference Include="Azure.Identity.Broker" Version="1.0.0-beta.5" />
+    <PackageReference Include="Azure.Identity.Broker" Version="1.1.0" />
     <PackageReference Include="Microsoft.Graph.Core" Version="3.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
@@ -402,8 +402,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                 // set body to null to prevent later FillRequestStream
                 Body = null;
             }
-            // TODO: Review the fix made in https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/2455.
-            return uriBuilder.Uri;
+            return uriBuilder.Uri.EscapeDataStrings();
         }
 
         private void ThrowIfError(ErrorRecord error)

--- a/src/Authentication/Authentication/Helpers/EncodeUriPath.cs
+++ b/src/Authentication/Authentication/Helpers/EncodeUriPath.cs
@@ -15,17 +15,24 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
     {
         public static Uri EscapeDataStrings(this Uri uri)
         {
-            if(uri.Query.Length > 0)
-                return uri;
             int counter = 0;
             var pathSegments = uri.OriginalString.Split('/');
             StringBuilder sb = new StringBuilder();
-            foreach (var segment in pathSegments)
+            foreach (var s in pathSegments)
             {
+                var segment = s;
                 //Skips the left part of the uri i.e https://graph.microsoft.com
                 if (counter > 2)
                 {
                     sb.Append('/');
+                    if(s.Contains("?"))
+                    {
+                        var queryStringIndex = segment.IndexOf("?");
+                        string queryString = segment.Substring(queryStringIndex);
+                        segment = s.Substring(0, queryStringIndex);
+                        sb.Append(Uri.EscapeDataString(segment));
+                        sb.Append(queryString);
+                    }
                     sb.Append(Uri.EscapeDataString(segment));
                 }
                 counter++;

--- a/src/Authentication/Authentication/Helpers/EncodeUriPath.cs
+++ b/src/Authentication/Authentication/Helpers/EncodeUriPath.cs
@@ -33,7 +33,10 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                         sb.Append(Uri.EscapeDataString(segment));
                         sb.Append(queryString);
                     }
-                    sb.Append(Uri.EscapeDataString(segment));
+                    else
+                    {
+                        sb.Append(Uri.EscapeDataString(segment));
+                    }
                 }
                 counter++;
             }

--- a/src/Authentication/Authentication/Helpers/EncodeUriPath.cs
+++ b/src/Authentication/Authentication/Helpers/EncodeUriPath.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
     {
         public static Uri EscapeDataStrings(this Uri uri)
         {
+            if(uri.Query.Length > 0)
+                return uri;
             int counter = 0;
             var pathSegments = uri.OriginalString.Split('/');
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Fixes #1947 and ``Azure.Identity.Broker`` package conflict due to bumping of Azure Identity [here](https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/2675)

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Restricted escaping/URL encoding of special characters in path segments only. Uri with system query options should not URL encoded values. 

**Uri with OData system query options**
![image](https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/a0aed2ef-0d33-464f-843f-76500de0e3b7)

**Uri with special characters in path segments**
<img width="1268" alt="image" src="https://github.com/microsoftgraph/msgraph-sdk-powershell/assets/10947120/1ce10cdd-cad5-4301-91fa-5bbedd6f2f99">

- Updated ``Azure.Identity.Broker`` due to interactive browser errors  (``Method 'get_UseDefaultBrokerAccount' in type 'Azure.Identity.Broker.InteractiveBrowserCredentialBrokerOptions' from assembly 'Azure.Identity.Broker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8' does not have an implementation``) as a result of bumping the ``Azure.Identity``. The version bump is based on the library documentation [here](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/identity.broker-readme?view=azure-dotnet)


