### PR TITLE
Add flag to send certificate chain for subject name / issuer based auth in Connect-MgGraph

### DIFF
--- a/src/Authentication/Authentication.Core/Interfaces/IAuthContext.cs
+++ b/src/Authentication/Authentication.Core/Interfaces/IAuthContext.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Graph.PowerShell.Authentication
         string Account { get; set; }
         string CertificateThumbprint { get; set; }
         string CertificateSubjectName { get; set; }
+        bool SendCertificateChain {  get; set; }
         X509Certificate2 Certificate { get; set; }
         ContextScope ContextScope { get; set; }
         Version PSHostVersion { get; set; }

--- a/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
+++ b/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
@@ -184,7 +184,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Core.Utilities
             var clientCredentialOptions = new ClientCertificateCredentialOptions
             {
                 AuthorityHost = new Uri(GetAuthorityUrl(authContext)),
-                TokenCachePersistenceOptions = GetTokenCachePersistenceOptions(authContext)
+                TokenCachePersistenceOptions = GetTokenCachePersistenceOptions(authContext),
+                SendCertificateChain = authContext.SendCertificateChain
             };
             var clientCertificateCredential = new ClientCertificateCredential(authContext.TenantId, authContext.ClientId, GetCertificate(authContext), clientCredentialOptions);
             return await Task.FromResult(clientCertificateCredential).ConfigureAwait(false);

--- a/src/Authentication/Authentication/Cmdlets/ConnectMgGraph.cs
+++ b/src/Authentication/Authentication/Cmdlets/ConnectMgGraph.cs
@@ -46,6 +46,9 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
         [Parameter(ParameterSetName = Constants.AppCertificateParameterSet, Position = 3, HelpMessage = HelpMessages.CertificateThumbprint)]
         public string CertificateThumbprint { get; set; }
 
+        [Parameter(ParameterSetName = Constants.AppCertificateParameterSet, HelpMessage = HelpMessages.SendCertificateChain)]
+        public bool SendCertificateChain { get; set; }
+
         [Parameter(Mandatory = false, ParameterSetName = Constants.AppCertificateParameterSet, HelpMessage = HelpMessages.Certificate)]
         public X509Certificate2 Certificate { get; set; }
 
@@ -200,6 +203,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                             authContext.ClientId = ClientId;
                             authContext.CertificateThumbprint = CertificateThumbprint;
                             authContext.CertificateSubjectName = CertificateSubjectName;
+                            authContext.SendCertificateChain = SendCertificateChain;
                             authContext.Certificate = Certificate;
                             // Default to Process but allow the customer to change this via `-ContextScope`.
                             authContext.ContextScope = this.IsParameterBound(nameof(ContextScope)) ? ContextScope : ContextScope.Process;

--- a/src/Authentication/Authentication/Constants.cs
+++ b/src/Authentication/Authentication/Constants.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Graph.PowerShell.Authentication
             public const string ClientId = "The client id of your application.";
             public const string CertificateSubjectName = "The subject distinguished name of a certificate. The Certificate will be retrieved from the current user's certificate store.";
             public const string CertificateThumbprint = "The thumbprint of your certificate. The Certificate will be retrieved from the current user's certificate store.";
+            public const string SendCertificateChain = "Include x5c header in client claims when acquiring a token to enable subject name / issuer based authentication using given certificate.";
             public const string Certificate = "An X.509 certificate supplied during invocation.";
             public const string ClientSecretCredential = "The PSCredential object provides the application ID and client secret for service principal credentials. For more information about the PSCredential object, type Get-Help Get-Credential.";
             public const string AccessToken = "Specifies a bearer token for Microsoft Graph service. Access tokens do timeout and you'll have to handle their refresh.";

--- a/src/Authentication/Authentication/Models/AuthContext.cs
+++ b/src/Authentication/Authentication/Models/AuthContext.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Graph.PowerShell.Authentication
         public TokenCredentialType TokenCredentialType { get; set; }
         public string CertificateThumbprint { get; set; }
         public string CertificateSubjectName { get; set; }
+        public bool SendCertificateChain { get; set; }
         public string Account { get; set; }
         public string AppName { get; set; }
         public ContextScope ContextScope { get; set; }

--- a/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
+++ b/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
@@ -32,7 +32,7 @@ Describe 'Connect-MgGraph ParameterSets' {
     It 'Should have AppCertificateParameterSet' {
         $AppCertificateParameterSet = $ConnectMgGraphCommand.ParameterSets | Where-Object Name -eq 'AppCertificateParameterSet'
         $AppCertificateParameterSet | Should -Not -BeNull
-        @('ClientId', 'TenantId', 'CertificateSubjectName', 'CertificateThumbprint', 'ContextScope', 'Environment', 'ClientTimeout') | Should -BeIn $AppCertificateParameterSet.Parameters.Name
+        @('ClientId', 'TenantId', 'CertificateSubjectName', 'CertificateThumbprint', 'SendCertificateChain', 'ContextScope', 'Environment', 'ClientTimeout') | Should -BeIn $AppCertificateParameterSet.Parameters.Name
         $MandatoryParameters = $AppCertificateParameterSet.Parameters | Where-Object IsMandatory
         $MandatoryParameters | Should -HaveCount 1
         $MandatoryParameters.Name | Should -Be 'ClientId'


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #2698 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

Adds a flag `SendCertificateChain` to `Connect-MgGraph` to send entire certificate chain while requesting access token. This allows subject name / issuer based auth.

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links

`ClientCertificateCredentialOptions.SendCertificateChain` - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/src/Credentials/ClientCertificateCredentialOptions.cs
