### PR TITLE
Fix Metadata breaking change workflow

### DIFF
--- a/.github/workflows/metadatachanges.yml
+++ b/.github/workflows/metadatachanges.yml
@@ -18,6 +18,8 @@ jobs:
   CheckForMetadataChanges:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -50,6 +52,16 @@ jobs:
             repo: context.repo.repo,
             body: body
           })
+
+          await github.rest.pulls.createReview({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body,
+            pull_number: context.issue.number,
+            event: 'REQUEST_CHANGES'
+          })
+
+          core.setFailed(body)
 
 # [0] https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
 # [1] https://hub.github.com/hub-pull-request.1.html

--- a/.github/workflows/metadatachanges.yml
+++ b/.github/workflows/metadatachanges.yml
@@ -3,14 +3,15 @@
 # This is a basic workflow to help you get started with Actions
 
 name: "Metadata Changes"
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
     branches:
       - dev
+    paths:
+      - openApiDocs/**
+      - src/Authentication/Authentication/custom/common/MgCommandMetadata.json
+      - docs/OpenApiInfo/**
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
This PR:
- reduces unnecessary runs to those that affect generation config files
- gives job write permissions to fix current failures e.g. https://github.com/microsoftgraph/msgraph-sdk-powershell/actions/runs/9353079967
- updates workflow to fail if OpenAPI errors exist & creates a PR review to prevent merging with breaking changes.