### PR TITLE
Fix bug when populating command alias value in command metadata JSON

### DIFF
--- a/tools/PostGeneration/NewCommandMetadata.ps1
+++ b/tools/PostGeneration/NewCommandMetadata.ps1
@@ -78,7 +78,7 @@ $ApiVersion | ForEach-Object {
             if (-not($Null -eq $CommandAliasValue)) {
                 $CommandAliasValue = $CommandAliasValue.Replace("[global::System.Management.Automation.Alias(`"", "").Replace("`")", "").Replace("]", "")
             }
-            if(-not($CommandAliasValue -contains "-Mg")) {
+            if(-not($CommandAliasValue.Contains("-Mg"))) {
                 $CommandAliasValue = $null
             }
             $MappingValue = @{


### PR DESCRIPTION
Previous check would always set aliases to `null` when command metadata is being updated post-generation with the latest cmdlets.

Setting `null` aliases causes unit tests for aliasing in `Find-MgGraphCommand` to fail, breaking the build pipeline.

(Draft PR: pending a build pipeline run to update the command metadata.json with aliases)