### PR TITLE
Resets graph environment session to its original state.

### DIFF
--- a/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
@@ -999,8 +999,11 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
         /// </summary>
         private void ResetGraphSessionEnvironment()
         {
-            _originalEnvironment = GraphSession.Instance.Environment;
-            GraphSession.Instance.Environment = _originalEnvironment;
+            var currentEnvironment = GraphSession.Instance.Environment;
+            if(currentEnvironment != null && !currentEnvironment.Equals(_originalEnvironment))
+            {
+                GraphSession.Instance.Environment = _originalEnvironment;
+            }
         }
 
         #region CmdLet LifeCycle
@@ -1039,6 +1042,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                             if (ShouldCheckHttpStatus && !isSuccess)
                             {
                                 var httpErrorRecord = await GenerateHttpErrorRecordAsync(httpResponseMessageFormatter, httpRequestMessage);
+                                // A reset of the GraphSession Environment is required to avoid side effects
+                                ResetGraphSessionEnvironment();
                                 ThrowTerminatingError(httpErrorRecord);
                             }
                             await ProcessResponseAsync(httpResponseMessage);


### PR DESCRIPTION

﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #2795

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Resets session to original environment set during authentication. This is required especially when subsequent graph requests are not connecting to the default environment which has ``graph.microsoft.com`` as the base Uri (See ``PrepareUri`` method in ``InvokeMgGraphRequest.cs`` file)
