### PR TITLE
fix: adds workflow to publish docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: Publish Docker image
+on:
+  workflow_dispatch:
+  push:
+    tags: ["*"]
+env:
+  REGISTRY: msgraphprod.azurecr.io
+  IMAGE_NAME: public/microsoftgraph/powershell
+jobs:
+  push_to_registry:
+    environment:
+      name: acr
+    name: Push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Login to GitHub package feed
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+
+      - name: Get truncated run number
+        id: getversion
+        run: |
+          $version = $Env:GITHUB_REF.replace("refs/tags/", "")
+          Write-Output "version=$version" >> $Env:GITHUB_OUTPUT
+        shell: pwsh
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Push to GitHub Packages - Release
+        uses: docker/build-push-action@v6.5.0
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.getversion.outputs.version }}
+          build-args: |
+            VERSION=${{ steps.getversion.outputs.version }}


### PR DESCRIPTION
it looks like when we released v2, we broke docker images publishing. https://mcr.microsoft.com/en-us/product/microsoftgraph/powershell/tags
This adds a workflow to fix that

Related https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/1348