### PR TITLE
Removes ``ApiReferenceLink`` values that point to intune API reference docs and adds AutoREST directive to remove ``Get-MgUserMailFolderMessageContent``

### DIFF
--- a/src/Mail/Mail.md
+++ b/src/Mail/Mail.md
@@ -17,4 +17,10 @@ require:
 
 ``` yaml
 # Directives go here!
+directive:
+# Remove cmdlets.
+  - where:
+      verb: Get
+      subject: ^UserMailFolderMessageContent$
+    remove: true
 ```


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #2867 and #1627

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Ensures that ApiReferenceLink property in ``Find-MgGraphCommand`` ``MgCommandMetadata.json``  file to has graph Api reference docs values only during generation of command metadata.
- Add AutoREST directive to remove ``Get-MgUserMailFolderMessageContent`` that points to an invalid Api Path.
