### PR TITLE
fix: removes arm64v8 and armv7 platforms from docker since upstream image doesn't seem to support it

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v6.5.0
         with:
           push: true
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          platforms: linux/amd64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.getversion.outputs.version }}
           build-args: |
             VERSION=${{ steps.getversion.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM mcr.microsoft.com/powershell
 ARG VERSION=latest
 
 RUN pwsh -c "if ('${VERSION}' -eq 'latest') { Install-Module Microsoft.Graph -Scope CurrentUser -AllowClobber -Force} else { Install-Module Microsoft.Graph -Scope CurrentUser -AllowClobber -Force -RequiredVersion ${VERSION} }"
+RUN pwsh -c "if (!(Test-Path -Path \$PROFILE)) { New-Item -ItemType File -Path \$PROFILE -Force } echo 'Import-Module Microsoft.Graph.Authentication' >> \$PROFILE"
 
 LABEL description="# Welcome to Microsoft Graph PowrShell \
 To start learning about the module checkout the [getting started documentation](https://docs.microsoft.com/en-us/powershell/microsoftgraph/get-started)"


### PR DESCRIPTION
related https://github.com/microsoftgraph/msgraph-sdk-powershell/actions/runs/10197572950
docker manifest inspect mcr.microsoft.com/powershell returns linux/amd64 (I'm guessing the mac M users use that with QEMU), windows/amd64 (nobody uses that anymore AFAIK), linux/arm/v7 (this one I couldn't run, and I suggest we try to get feedback for a need for this before we invest further).