### PR TITLE
Adds AutoRest directives to remove over generated cmdlets

### DIFF
--- a/src/Security/Security.md
+++ b/src/Security/Security.md
@@ -24,6 +24,11 @@ directive:
       verb: Get|Update
       subject: ^Security$
     remove: true
+# Removes overgenerated cmdlets. Related issue: https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2961
+  - where:
+      verb: Get
+      subject: ^(SecurityAuditLog|SecurityAuditLogQuery|SecurityAuditLogQueryCount|SecurityAuditLogQueryRecord|SecurityAuditLogQueryRecordCount)$
+    remove: true
   - where:
       verb: Update
       subject: ^SecurityAttackSimulation$


### PR DESCRIPTION
Fixes #2961
Adds AutoRest directives to remove over generated cmdlets in Security module.

The following cmdlets won't be generated:
``Get-MgBetaSecurityAuditLog``
``Get-MgBetaSecurityAuditLogQuery``
``Get-MgBetaSecurityAuditLogQueryCount``
``Get-MgBeta`SecurityAuditLogQueryRecord``
``Get-MgBetaSecurityAuditLogQueryRecordCount``

