### PR TITLE
Fixes failure on the build pipeline.

### DIFF
--- a/src/Devices.CorporateManagement/beta/readme.md
+++ b/src/Devices.CorporateManagement/beta/readme.md
@@ -36,4 +36,9 @@ directive:
       subject: ^(DeviceAppManagementMobileAppAssignmentCount|DeviceAppManagementMobileAppCategoryCount|DeviceAppManagementMobileAppContentVersionFileCount|DeviceAppManagementMobileAppContentVersionCount|DeviceAppManagementMobileAppContentVersionContainedAppCount|DeviceAppManagementMobileAppRelationshipCount)$
       variant: ^(Get|GetExpanded|GetViaIdentity|GetViaIdentityExpanded)([1-9]{1,2})$
     remove: true
+  # This cmdlet is causing build pipeline errors due multiple parameter types in the body parameter
+  - where:
+      verb: Update
+      subject: ^(DeviceAppManagementMobileAppRelationship)$
+    remove: true
 ```


### PR DESCRIPTION
Added directive to skip ``Update-MgBetaDeviceAppManagementMobileAppRelationship`` from cmdlet generation process causing overall failure in the Weekly refresh Open API pipeline.
<img width="927" alt="image" src="https://github.com/user-attachments/assets/9ee78dea-6a91-47f7-b057-fe8d5e5b9686">
