### PR TITLE
Fixes subsequent failures after first successful ``Invoke-MgGraphRequest`` run when using national cloud environments

### DIFF
--- a/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
@@ -1004,7 +1004,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
         private void ResetGraphSessionEnvironment()
         {
             _originalEnvironment = GraphSession.Instance.Environment;
-            GraphSession.Instance.Environment = _originalEnvironment;
         }
 
         #region CmdLet LifeCycle

--- a/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
+++ b/src/Authentication/Authentication/Cmdlets/InvokeMgGraphRequest.cs
@@ -1003,11 +1003,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
         /// </summary>
         private void ResetGraphSessionEnvironment()
         {
-            var currentEnvironment = GraphSession.Instance.Environment;
-            if(currentEnvironment != null && !currentEnvironment.Equals(_originalEnvironment))
-            {
-                GraphSession.Instance.Environment = _originalEnvironment;
-            }
+            _originalEnvironment = GraphSession.Instance.Environment;
+            GraphSession.Instance.Environment = _originalEnvironment;
         }
 
         #region CmdLet LifeCycle
@@ -1046,8 +1043,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Cmdlets
                             if (ShouldCheckHttpStatus && !isSuccess)
                             {
                                 var httpErrorRecord = await GenerateHttpErrorRecordAsync(httpResponseMessageFormatter, httpRequestMessage);
-                                // A reset of the GraphSession Environment is required to avoid side effects
-                                ResetGraphSessionEnvironment();
                                 ThrowTerminatingError(httpErrorRecord);
                             }
                             await ProcessResponseAsync(httpResponseMessage);

--- a/src/Authentication/Authentication/custom/common/Permissions.ps1
+++ b/src/Authentication/Authentication/custom/common/Permissions.ps1
@@ -34,7 +34,20 @@ function Permissions_GetPermissionsData([bool] $online) {
     # Make a REST request to MS Graph to get the permissions data from the Microsoft Graph service principal
     if ( $online -or ! $_permissions.msGraphServicePrincipal -or ! $_permissions.isFromInvokeMgGraphRequest ) {
         try {
-            $restResult = Invoke-MgGraphRequest -method GET -OutputType PSObject $_permissions.msGraphPermissionsRequestUri
+            
+            # Get-MgContext is used to get the current context for the request to MS Graph
+            # From the context, we can get the current environment and use it to get the permissions request URI
+            # If the context is not available, then we will use the default permissions request URI
+
+            $context = Get-MgContext
+            $uri = $_permissions.msGraphPermissionsRequestUri
+            if($context){
+                $currentEnv = $context.Environment
+                $allEnv = Get-MgEnvironment
+                $env = $allEnv | Where-Object { $_.Name -eq $currentEnv }
+                $uri = $env.GraphEndpoint + "/v1.0/servicePrincipals?`$filter=appId eq '$Permissions_msGraphApplicationId'"
+            }
+            $restResult = Invoke-MgGraphRequest -method GET -OutputType PSObject $uri
 
             if ( $restResult ) {
                 $_permissions.msGraphServicePrincipal = $restResult | Select-Object -ExpandProperty value


### PR DESCRIPTION
Fixes #2950 
The fix provided [here](https://github.com/microsoftgraph/msgraph-sdk-powershell/commit/815b63f7d6ff529880bf12441272850a35d2f293) only works once when an absolute uri is passed to ``Invoke-MgGraphRequest`` cmdlet after connecting to a national cloud environment.  Subsequent requests after the first successful one fails.
<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

-  Added Microsoft graph context check in ``Find-MgGraphPermission`` in order to get the correct environment and extract the correct graph endpoint instead of using the default graph one (https://graph.microsoft.com) assigned to global environment. 
- Reset GraphSession environment back to its original state defined by the user.

### Test scenarios.
- Check that ``Find-MgGraphPermission`` does not default the session to the global graph endpoint after connecting to a national cloud environment.
- Subsequent calls to graph endpoints do not fail after connecting to a national cloud environment. 

NB: See attached image below for the above tests
![image](https://github.com/user-attachments/assets/ef1de07e-3dbf-47c2-842c-e1b8aded21e2)

