### PR TITLE
Removes duplicate generated cmdlet blocking cmdlet builds during Weekly Open Api refresh

### DIFF
--- a/src/Calendar/Calendar.md
+++ b/src/Calendar/Calendar.md
@@ -31,4 +31,9 @@ directive:
       variant: ^List$|^Create$|^CreateExpanded$|^CreateViaIdentity$|^CreateViaIdentityExpanded$
     set:
       subject: $1Default$2
+# Remove duplicate cmdlet
+  - where:
+      verb: Get
+      subject: ^(UserCalendarSchedule)$
+    remove: true
 ```


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Adds Autorest directive to remove duplicate ``Get-MgUserCalendarSchedule`` cmdlet in the Calendar module failing during generation due to multiple parameter types in the request body. The cmdlet also already exists in the ``User.Actions`` module.
<img width="552" alt="image" src="https://github.com/user-attachments/assets/671591fd-bb56-45ea-b912-bad68e8e5652">

