### PR TITLE
Updates endpoint to use Devx API in Torus

### DIFF
--- a/tools/DownloadOpenApiDoc.ps1
+++ b/tools/DownloadOpenApiDoc.ps1
@@ -13,7 +13,7 @@ if (-not (Test-Path $OpenApiDocOutput)) {
     New-Item -Path $OpenApiDocOutput -Type Directory
 }
 
-$OpenApiBaseUrl = "https://graphexplorerapi.azurewebsites.net"
+$OpenApiBaseUrl = "https://devxapi-func-prod-eastus.azurewebsites.net"
 $OpenApiServiceUrl = ("$OpenApiBaseUrl/`$openapi?tags={0}&title=$ModuleName&openapiversion=3&style=Powershell&fileName=powershell_v2&graphVersion=$GraphVersion" -f $ModuleRegex)
 if ($ForceRefresh.IsPresent) {
     $OpenApiServiceUrl = "$OpenApiServiceUrl&forceRefresh=true"

--- a/tools/PostGeneration/NewCommandMetadata.ps1
+++ b/tools/PostGeneration/NewCommandMetadata.ps1
@@ -38,7 +38,7 @@ $OpenApiTagPattern = '\[OpenAPI\].s*(.*)=>(.*):\"(.*)\"'
 $ExternalDocsPattern = 'https://learn.microsoft.com/graph/api/(.*?(graph-rest-1.0|graph-rest-beta))'
 $AliasPattern = '\[global::System.Management.Automation.Alias(.*?)\]'
 $ActionFunctionFQNPattern = "\/Microsoft.Graph.(.*)$"
-$PermissionsUrl = "https://graphexplorerapi.azurewebsites.net/permissions"
+$PermissionsUrl = "https://devxapi-func-prod-eastus.azurewebsites.net/permissions"
 
 Write-Debug "Crawling cmdlets in $CmdletPathPattern."
 $Stopwatch = [system.diagnostics.stopwatch]::StartNew()


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #3020 
The change ensures that calls to fetch permissions and slicing of open API file based on tags, points to DevX API hosted in Torus.
