### PR TITLE
Re-enables generation of Get cmdlets for attack simulation.

### DIFF
--- a/src/Security/Security.md
+++ b/src/Security/Security.md
@@ -24,11 +24,6 @@ directive:
       verb: Get|Update
       subject: ^Security$
     remove: true
-# Removes overgenerated cmdlets. Related issue: https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2961
-  - where:
-      verb: Get
-      subject: ^(SecurityAuditLog|SecurityAuditLogQuery|SecurityAuditLogQueryCount|SecurityAuditLogQueryRecord|SecurityAuditLogQueryRecordCount)$
-    remove: true
   - where:
       verb: Update
       subject: ^SecurityAttackSimulation$


### PR DESCRIPTION
Fixes #3051 

Re-enabled generation of the below cmldets whose endpoints are now supported.
Get-MgBetaSecurityAuditLog
Get-MgBetaSecurityAuditLogQuery
Get-MgBetaSecurityAuditLogQueryCount
Get-MgBeta`SecurityAuditLogQueryRecord
Get-MgBetaSecurityAuditLogQueryRecordCount 