### PR TITLE
feat: add direct dependency on System.Text.Json

### DIFF
--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Azure.Identity.Broker" Version="1.1.0" />
     <PackageReference Include="Microsoft.Graph.Core" Version="3.1.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <Target Name="CopyFiles" AfterTargets="Build">
     <Copy SourceFiles="@(PreLoadAssemblies)" DestinationFolder="$(OutputPath)/publish" />


### PR DESCRIPTION
part of https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2774

Unblocks 
- conflicts with ExchangeOnlineManagement caused by using System.Text.Json 6.x
- security update since v6.x has CVEs

~EXO failing with a different error that doesn't signal conflicts, reached out to partner team to clarify~
Update: Issue was in my app registration permissions for EXO
Reference docs to set up app-only auth with EXO: https://learn.microsoft.com/en-us/powershell/exchange/app-only-auth-powershell-v2?view=exchange-ps

Importing MgGraph before EXO & Az.Accounts
![image (3)](https://github.com/user-attachments/assets/bafd0949-f5ad-4868-acf6-b9e95ded6cdd)


Import EXO before MgGraph & Az.Accounts
![image (4)](https://github.com/user-attachments/assets/56519295-d1e4-4627-affb-9f14e411018e)


