### PR TITLE
Drop unsupported net 6 and net 7 

### DIFF
--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -3,17 +3,6 @@
 
 steps:
   - task: UseDotNet@2
-    displayName: "Use .NET 6" # needed for ESRP signing
-    inputs:
-      version: 6.x
-
-  - task: UseDotNet@2
-    displayName: Use .NET SDK
-    inputs:
-      debugMode: false
-      version: 7.x
-  
-  - task: UseDotNet@2
     displayName: Use .NET SDK
     inputs:
       debugMode: false


### PR DESCRIPTION
﻿Fixes #3073 
Drops unsupported net 6 and net 7 from the CI pipeline.

