### PR TITLE
Adds directive to remove invalid path. ``/security/attackSimulation``

### DIFF
--- a/src/Security/Security.md
+++ b/src/Security/Security.md
@@ -18,7 +18,7 @@ require:
 ``` yaml
 directive:
 # Remove invalid paths.
-  - remove-path-by-operation: ^security(.case.ediscoveryCase.noncustodialDataSource_.*DataSource)$
+  - remove-path-by-operation: ^security(.case.ediscoveryCase.noncustodialDataSource_.*DataSource)$|^security_DeleteAttackSimulation$|^security_UpdateAttackSimulation$|^security_GetAttackSimulation$
 # Remove cmdlets
   - where:
       verb: Get|Update


### PR DESCRIPTION
Fixes #3065 
Based on the documentation provided [here](https://learn.microsoft.com/en-us/graph/api/simulation-get?view=graph-rest-beta&tabs=http), the correct path is ``/security/attackSimulation/simulations``.