### PR TITLE
Bumps versions for Azure.Identity, Azure.Identity.Broker and Microsoft.Graph.Core

### DIFF
--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -5,13 +5,8 @@ steps:
   - task: UseDotNet@2
     displayName: Use .NET SDK
     inputs:
-      version: 8.x
+      version: 8.x     
       
-  - task: UseDotNet@2
-    displayName: Use .NET SDK
-    inputs:
-      version: 9.x
-
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
 

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -5,8 +5,12 @@ steps:
   - task: UseDotNet@2
     displayName: Use .NET SDK
     inputs:
-      debugMode: false
       version: 8.x
+      
+  - task: UseDotNet@2
+    displayName: Use .NET SDK
+    inputs:
+      version: 9.x
 
   - task: NuGetToolInstaller@1
     displayName: Install Nuget

--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Repo.props" />
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;net472;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
     <RootNamespace>Microsoft.Graph.PowerShell.Authentication.Core</RootNamespace>
     <Version>2.25.0</Version>
   </PropertyGroup>
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.Graph.Core" Version="3.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Runtime" Version="9.0.0" />
   </ItemGroup>
   <Target Name="CopyFiles" AfterTargets="Build">
     <Copy SourceFiles="@(PreLoadAssemblies)" DestinationFolder="$(OutputPath)/publish" />

--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -2,9 +2,11 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Repo.props" />
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net472</TargetFrameworks>
     <RootNamespace>Microsoft.Graph.PowerShell.Authentication.Core</RootNamespace>
     <Version>2.25.0</Version>
+    <!-- Suppress .NET Target Framework Moniker (TFM) Support Build Warnings -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -2,18 +2,18 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Repo.props" />
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net9.0</TargetFrameworks>
     <RootNamespace>Microsoft.Graph.PowerShell.Authentication.Core</RootNamespace>
-    <Version>2.18.0</Version>
+    <Version>2.25.0</Version>
   </PropertyGroup>
   <PropertyGroup>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
-    <PackageReference Include="Azure.Identity.Broker" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Graph.Core" Version="3.1.13" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Identity.Broker" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="3.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>

--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -11,7 +11,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Azure.Identity.Broker" Version="1.2.0" />
     <PackageReference Include="Microsoft.Graph.Core" Version="3.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Repo.props" />
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net472</TargetFrameworks>
     <RootNamespace>Microsoft.Graph.PowerShell.Authentication.Core</RootNamespace>
     <Version>2.25.0</Version>
     <!-- Suppress .NET Target Framework Moniker (TFM) Support Build Warnings -->
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Azure.Identity.Broker" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Graph.Core" Version="3.2.3" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="3.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>

--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Graph.Core" Version="3.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Runtime" Version="9.0.0" />
   </ItemGroup>
   <Target Name="CopyFiles" AfterTargets="Build">
     <Copy SourceFiles="@(PreLoadAssemblies)" DestinationFolder="$(OutputPath)/publish" />

--- a/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
+++ b/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Core.Utilities
         {
             if (authContext is null)
                 throw new AuthenticationException(ErrorConstants.Message.MissingAuthContext);
-
+            //There is need for explicitly adding TenantId to the TokenCredentialOptions for EnvironmentCredential due to stricter security requirements.
+            authContext.TenantId = EnvironmentVariables.TenantId;
             var tokenCredentialOptions = new TokenCredentialOptions
             {
                 AuthorityHost = new Uri(GetAuthorityUrl(authContext))

--- a/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
+++ b/src/Authentication/Authentication.Core/Utilities/AuthenticationHelpers.cs
@@ -207,8 +207,8 @@ namespace Microsoft.Graph.PowerShell.Authentication.Core.Utilities
         {
             if (authContext is null)
                 throw new AuthenticationException(ErrorConstants.Message.MissingAuthContext);
-            var tokenCrdential = await GetTokenCredentialAsync(authContext, default).ConfigureAwait(false);
-            return new AzureIdentityAccessTokenProvider(credential: tokenCrdential, scopes: GetScopes(authContext));
+            var tokenCredential = await GetTokenCredentialAsync(authContext, default).ConfigureAwait(false);
+            return new AzureIdentityAccessTokenProvider(credential:tokenCredential, observabilityOptions: null,isCaeEnabled: true,scopes: GetScopes(authContext));
         }
 
         public static async Task<IAuthContext> AuthenticateAsync(IAuthContext authContext, CancellationToken cancellationToken)

--- a/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
+++ b/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Version>2.25.0</Version>
   </PropertyGroup>

--- a/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
+++ b/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Version>2.25.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <!-- As described in this post https://devblogs.microsoft.com/powershell/depending-on-the-right-powershell-nuget-package-in-your-net-project, reference the SDK for dotnetcore-->
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
+++ b/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net9.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Version>2.25.0</Version>
   </PropertyGroup>

--- a/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
+++ b/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <Version>2.8.0</Version>
+    <Version>2.25.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <!-- As described in this post https://devblogs.microsoft.com/powershell/depending-on-the-right-powershell-nuget-package-in-your-net-project, reference the SDK for dotnetcore-->
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.3" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
+++ b/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <!-- As described in this post https://devblogs.microsoft.com/powershell/depending-on-the-right-powershell-nuget-package-in-your-net-project, reference the SDK for dotnetcore-->
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
+++ b/src/Authentication/Authentication.Test/Microsoft.Graph.Authentication.Test.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Version>2.25.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <!-- As described in this post https://devblogs.microsoft.com/powershell/depending-on-the-right-powershell-nuget-package-in-your-net-project, reference the SDK for dotnetcore-->
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Authentication/Authentication/Helpers/HttpHelpers.cs
+++ b/src/Authentication/Authentication/Helpers/HttpHelpers.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                 : GraphClientFactory.Create(delegatingHandlers, finalHandler: new HttpClientHandler
                 {
                     AllowAutoRedirect = false,
-                    AutomaticDecompression = DecompressionMethods.None
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
                 });
             httpClient.Timeout = requestContext.ClientTimeout;
             return httpClient;

--- a/src/Authentication/Authentication/Helpers/HttpHelpers.cs
+++ b/src/Authentication/Authentication/Helpers/HttpHelpers.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Graph.PowerShell.Authentication.Helpers
                 new NationalCloudHandler(),
                 new ODataQueryOptionsHandler(),
                 new HttpVersionHandler(),
-                new CompressionHandler(),
                 new RetryHandler(new RetryHandlerOption{
                     Delay = requestContext.RetryDelay,
                     MaxRetry = requestContext.MaxRetry,

--- a/src/Authentication/Authentication/build-module.ps1
+++ b/src/Authentication/Authentication/build-module.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 $ModuleName = "Authentication"
 $ModulePrefix = "Microsoft.Graph"
 $netStandard = "netstandard2.0"
-$netApp = "net6.0"
+$netApp = "net8.0"
 $netFx = "net472"
 $copyExtensions = @('.dll', '.pdb')
 

--- a/src/Authentication/Authentication/build-module.ps1
+++ b/src/Authentication/Authentication/build-module.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 $ModuleName = "Authentication"
 $ModulePrefix = "Microsoft.Graph"
 $netStandard = "netstandard2.0"
-$netApp = "net8.0"
+$netApp = "net6.0"
 $netFx = "net472"
 $copyExtensions = @('.dll', '.pdb')
 

--- a/src/Authentication/Authentication/build-module.ps1
+++ b/src/Authentication/Authentication/build-module.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 $ModuleName = "Authentication"
 $ModulePrefix = "Microsoft.Graph"
 $netStandard = "netstandard2.0"
-$netApp = "net9.0"
+$netApp = "net8.0"
 $netFx = "net472"
 $copyExtensions = @('.dll', '.pdb')
 

--- a/src/Authentication/Authentication/build-module.ps1
+++ b/src/Authentication/Authentication/build-module.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 $ModuleName = "Authentication"
 $ModulePrefix = "Microsoft.Graph"
 $netStandard = "netstandard2.0"
-$netApp = "net6.0"
+$netApp = "net9.0"
 $netFx = "net472"
 $copyExtensions = @('.dll', '.pdb')
 

--- a/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
+++ b/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'Connect-MgGraph In Environment Variable Mode' {
             $Env:AZURE_CLIENT_SECRET = "Not_Valid"
             $Env:AZURE_TENANT_ID = "common"
             Connect-MgGraph -EnvironmentVariable -ErrorAction Stop
-        } | Should -Throw -ExpectedMessage "*ClientSecretCredential authentication failed: AADSTS700016: Application with identifier 'Not_Valid' was not found in the directory 'Microsoft'.*"
+        } | Should -Throw -ExpectedMessage "ClientSecretCredential authentication failed: "
     }
 }
 
@@ -95,7 +95,7 @@ Describe 'Connect-MgGraph In App Mode' {
 Describe 'Connect-MgGraph Dependency Resolution' {
     It 'Should load Mg module side by side with Az module.' {
         { Connect-AzAccount -ApplicationId $RandomClientId -CertificateThumbprint "Invalid" -Tenant "Invalid" -ErrorAction Stop } | Should -Throw -ExpectedMessage "*Could not find tenant id*"
-        { Connect-MgGraph -TenantId "thisdomaindoesnotexist.com" -ErrorAction Stop -UseDeviceAuthentication } | Should -Throw -ExpectedMessage "*AADSTS90002*"
+        { Connect-MgGraph -TenantId "thisdomaindoesnotexist.com" -ErrorAction Stop -UseDeviceAuthentication } | Should -Throw -ExpectedMessage "DeviceCodeCredential authentication failed: "
     }
 }
 

--- a/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
+++ b/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
@@ -8,8 +8,8 @@ BeforeAll {
     Import-Module $ModulePath -Force
     $RandomClientId = (New-Guid).Guid
     
-    $AvailableAzModule = Get-Module Az.Accounts -ListAvailable
-    if (-not($AvailableAzModule[0].Version -eq '4.0.2')) {
+    $AvailableAzModule = Get-InstalledModule Az.Accounts
+    if (-not($AvailableAzModule.Version -eq '4.0.2')) {
         Install-Module Az.Accounts -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
     }
 }

--- a/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
+++ b/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
@@ -7,11 +7,7 @@ BeforeAll {
     $ModulePath = Join-Path $PSScriptRoot "..\artifacts\$ModuleName.psd1"
     Import-Module $ModulePath -Force
     $RandomClientId = (New-Guid).Guid
-    
-    $AvailableAzModule = Get-InstalledModule Az.Accounts
-    if (-not($AvailableAzModule.Version -eq '4.0.2')) {
-        Install-Module Az.Accounts -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
-    }
+    Install-Module Az.Accounts -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
 }
 Describe 'Connect-MgGraph ParameterSets' {
     BeforeAll {

--- a/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
+++ b/src/Authentication/Authentication/test/Connect-MgGraph.Tests.ps1
@@ -9,7 +9,7 @@ BeforeAll {
     $RandomClientId = (New-Guid).Guid
     
     $AvailableAzModule = Get-Module Az.Accounts -ListAvailable
-    if ($AvailableAzModule.Count -lt 1) {
+    if (-not($AvailableAzModule[0].Version -eq '4.0.2')) {
         Install-Module Az.Accounts -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
     }
 }


### PR DESCRIPTION
Fixes #2997 
The obsolete compression handler has also been dropped since kiota now relies on HttpClientHandler.
It also drops unsupported net6 as the target framework.

<img width="1133" alt="image" src="https://github.com/user-attachments/assets/ecfefb45-405d-4af9-bd94-0be0a93bbf63" />

