### PR TITLE
Adds directive to remove invalid path``/teams/{team-id}/channels/{channel-id}/messages/$count``

### DIFF
--- a/src/Teams/Teams.md
+++ b/src/Teams/Teams.md
@@ -18,7 +18,7 @@ require:
 ``` yaml
 directive:
 # Remove invalid paths.
-  - remove-path-by-operation: ^(team_GetGroup|user\.joinedTeam.*|user_(Get|Update|Delete|Create)JoinedTeam|.*_UpdateInstalledApp)$
+  - remove-path-by-operation: ^(team_GetGroup|user\.joinedTeam.*|user_(Get|Update|Delete|Create)JoinedTeam|.*_UpdateInstalledApp)$|^team.channel.message_GetCount$
 # Remove cmdlets
   - where:
       verb: Remove


### PR DESCRIPTION
Fixes #2585
The Api path is undocumented and any request to it responds with http status code 404.

<img width="798" alt="image" src="https://github.com/user-attachments/assets/26d191e8-2baa-4f65-812e-3cfba6b8d083" />

