### PR TITLE
Adds `-ObjectId` parameter as an alias for `-ApplicationId`

### DIFF
--- a/src/Applications/Applications.md
+++ b/src/Applications/Applications.md
@@ -32,4 +32,11 @@ directive:
       subject: $1
 #Prevent paths from being generated to allow for aliasing as a result of breaking changes in 2.18.0 and 2.17.0
   - remove-path-by-operation: ^application_DeleteOwnerGraphBPreRef$|^application_DeleteAppManagementPolicyGraphBPreRef$|^application_DeleteTokenIssuancePolicyGraphBPreRef$|^application_DeleteTokenLifetimePolicyGraphBPreRef$|^servicePrincipal_DeleteClaimsMappingPolicyGraphBPreRef$|^servicePrincipal_DeleteHomeRealmDiscoveryPolicyGraphBPreRef$|^servicePrincipal_DeleteOwnerGraphBPreRef$|^onPremisesPublishingProfile.agentGroup.agent_DeleteAgentGroupGraphBPreRef$|^onPremisesPublishingProfile.connectorGroup_DeleteMemberGraphBPreRef$|^onPremisesPublishingProfile.connector_ListMemberGraphOPreGraphBPreRef$|^onPremisesPublishingProfile.publishedResource_DeleteAgentGroupGraphBPreRef$|^onPremisesPublishingProfile.agentGroup.publishedResource_DeleteAgentGroupGraphBPreRef$
+
+  # Set parameter alias
+  - where:
+      parameter-name: ApplicationId
+    set:
+      alias:
+        - ObjectId
 ```


### PR DESCRIPTION
Fixes #2513 
Updates AutoREST directive to add `-ObjectId` parameter as an alias for `-ApplicationId`


<img width="665" alt="image" src="https://github.com/user-attachments/assets/45621982-4eba-4a4e-9d94-6ef70a43ed4f" />

<img width="577" alt="image" src="https://github.com/user-attachments/assets/22ff6e93-228c-4b84-9670-76317442d474" />



