### PR TITLE
Allows serialization of null valued properties.

### DIFF
--- a/.azure-pipelines/generation-templates/authentication-module.yml
+++ b/.azure-pipelines/generation-templates/authentication-module.yml
@@ -30,6 +30,15 @@ steps:
           script: |
             . $(System.DefaultWorkingDirectory)/tools/GenerateAuthenticationModule.ps1 -Test
 
+  - ${{ if eq(parameters.Test, true) }}:
+      - task: PowerShell@2
+        displayName: Test Json Utilities
+        inputs:
+          pwsh: true
+          targetType: inline
+          script: dotnet test
+          workingDirectory: "$(System.DefaultWorkingDirectory)/tools/Tests/JsonUtilitiesTests"
+
   - ${{ if eq(parameters.Sign, true) }}:
       - template: ../common-templates/esrp/strongname.yml
         parameters:

--- a/.azure-pipelines/generation-templates/authentication-module.yml
+++ b/.azure-pipelines/generation-templates/authentication-module.yml
@@ -37,7 +37,7 @@ steps:
           pwsh: true
           targetType: inline
           script: dotnet test
-          workingDirectory: "$(System.DefaultWorkingDirectory)/tools/Tests/JsonUtilitiesTests"
+          workingDirectory: "$(System.DefaultWorkingDirectory)/tools/Tests/JsonUtilitiesTest"
 
   - ${{ if eq(parameters.Sign, true) }}:
       - template: ../common-templates/esrp/strongname.yml

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -337,8 +337,8 @@ directive:
 
         // Enables null valued properties
         $ = $.replace(/AddIf\(\s*null\s*!=\s*(this\._\w+)\s*\?\s*\(\s*Microsoft\.Graph\.PowerShell\.Runtime\.Json\.JsonNode\)\s*(.*)\s*:\s*null\s*,\s*"(.*?)"\s*,\s*container\.Add\s*\)/gm, 'container.Add("$3", $1 != null ? (Microsoft.Graph.PowerShell.Runtime.Json.JsonNode) $2 :"defaultnull")')
-        
-        $ = $.replace(/AddIf\(\s*null\s*!=\s*\(\(\(\(object\)\s*(this\._\w+)\)\)?.ToString\(\)\)\s*\?\s*\(\s*Microsoft\.Graph\.PowerShell\.Runtime\.Json\.JsonNode\)\s*new\s*Microsoft\.Graph\.PowerShell\.Runtime\.Json\.JsonString\((this\._\w+).ToString\(\)\)\s*:\s*null\s*,\s*"(.*?)"\s*,\s*container\.Add\s*\)/gm, 'container.Add("$3", $1 != null ? (Microsoft.Graph.PowerShell.Runtime.Json.JsonNode) new Microsoft.Graph.PowerShell.Runtime.Json.JsonString($2.ToString()) :"defaultnull)');
+
+        $ = $.replace(/AddIf\(\s*null\s*!=\s*\(\(\(\(object\)\s*(this\._\w+)\)\)?.ToString\(\)\)\s*\?\s*\(\s*Microsoft\.Graph\.PowerShell\.Runtime\.Json\.JsonNode\)\s*new\s*Microsoft\.Graph\.PowerShell\.Runtime\.Json\.JsonString\((this\._\w+).ToString\(\)\)\s*:\s*null\s*,\s*"(.*?)"\s*,\s*container\.Add\s*\)/gm, 'container.Add("$3", $1 != null ? (Microsoft.Graph.PowerShell.Runtime.Json.JsonNode) new Microsoft.Graph.PowerShell.Runtime.Json.JsonString($2.ToString()) :"defaultnull")');
 
         return $;
       }

--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -335,6 +335,11 @@ directive:
         let dateTimeToJsonRegex = /(\.Json\.JsonString\()(.*)\?(\.ToString\(@"yyyy'-'MM'-'dd'T'HH':'mm':'ss\.fffffffK")/gm
         $ = $.replace(dateTimeToJsonRegex, '$1System.DateTime.SpecifyKind($2.Value.ToUniversalTime(), System.DateTimeKind.Utc)$3');
 
+        // Enables null valued properties
+        $ = $.replace(/AddIf\(\s*null\s*!=\s*(this\._\w+)\s*\?\s*\(\s*Microsoft\.Graph\.PowerShell\.Runtime\.Json\.JsonNode\)\s*(.*)\s*:\s*null\s*,\s*"(.*?)"\s*,\s*container\.Add\s*\)/gm, 'container.Add("$3", $1 != null ? (Microsoft.Graph.PowerShell.Runtime.Json.JsonNode) $2 :"defaultnull")')
+        
+        $ = $.replace(/AddIf\(\s*null\s*!=\s*\(\(\(\(object\)\s*(this\._\w+)\)\)?.ToString\(\)\)\s*\?\s*\(\s*Microsoft\.Graph\.PowerShell\.Runtime\.Json\.JsonNode\)\s*new\s*Microsoft\.Graph\.PowerShell\.Runtime\.Json\.JsonString\((this\._\w+).ToString\(\)\)\s*:\s*null\s*,\s*"(.*?)"\s*,\s*container\.Add\s*\)/gm, 'container.Add("$3", $1 != null ? (Microsoft.Graph.PowerShell.Runtime.Json.JsonNode) new Microsoft.Graph.PowerShell.Runtime.Json.JsonString($2.ToString()) :"defaultnull)');
+
         return $;
       }
 # Modify generated .dictionary.cs model classes.

--- a/tools/Custom/JsonExtensions.cs
+++ b/tools/Custom/JsonExtensions.cs
@@ -2,7 +2,6 @@ namespace Microsoft.Graph.PowerShell.JsonUtilities
 {
     using Newtonsoft.Json.Linq;
     using System.Linq;
-    using static Microsoft.Graph.PowerShell.Runtime.Extensions;
 
     public static class JsonExtensions
     {

--- a/tools/Custom/JsonExtensions.cs
+++ b/tools/Custom/JsonExtensions.cs
@@ -6,11 +6,11 @@ namespace Microsoft.Graph.PowerShell.JsonUtilities
     public static class JsonExtensions
     {
         /// <summary>
-        /// Removes JSON properties that have a value of "defaultnull" and converts properties with values of "null" or empty strings ("") to actual JSON null values.
+        /// Removes JSON properties that have a value of "defaultnull" and converts properties with values of "null" to actual JSON null values.
         /// </summary>
         /// <param name="jsonObject">The JObject to process and clean.</param>
         /// <returns>
-        /// A JSON string representation of the cleaned JObject with "defaultnull" properties removed and "null" or empty string values converted to JSON null.
+        /// A JSON string representation of the cleaned JObject with "defaultnull" properties removed and "null" values converted to JSON null.
         /// </returns>
         /// <example>
         /// JObject json = JObject.Parse(@"{""name"": ""John"", ""email"": ""defaultnull"", ""address"": ""null""}");
@@ -42,7 +42,7 @@ namespace Microsoft.Graph.PowerShell.JsonUtilities
                     {
                         property.Remove();
                     }
-                    else if (property.Value.Type == JTokenType.String && (property.Value.ToString() == "null" || property.Value.ToString() == ""))
+                    else if (property.Value.Type == JTokenType.String && (property.Value.ToString() == "null"))
                     {
                         property.Value = JValue.CreateNull();
                     }

--- a/tools/Custom/JsonExtensions.cs
+++ b/tools/Custom/JsonExtensions.cs
@@ -1,0 +1,63 @@
+namespace Microsoft.Graph.PowerShell.JsonUtilities
+{
+    using Newtonsoft.Json.Linq;
+    using System.Linq;
+    using static Microsoft.Graph.PowerShell.Runtime.Extensions;
+
+    public static class JsonExtensions
+    {
+        /// <summary>
+        /// Removes JSON properties that have a value of "defaultnull" and converts properties with values of "null" or empty strings ("") to actual JSON null values.
+        /// </summary>
+        /// <param name="jsonObject">The JObject to process and clean.</param>
+        /// <returns>
+        /// A JSON string representation of the cleaned JObject with "defaultnull" properties removed and "null" or empty string values converted to JSON null.
+        /// </returns>
+        /// <example>
+        /// JObject json = JObject.Parse(@"{""name"": ""John"", ""email"": ""defaultnull"", ""address"": ""null""}");
+        /// string cleanedJson = json.RemoveDefaultNullProperties();
+        /// Console.WriteLine(cleanedJson);
+        /// // Output: { "name": "John", "address": null }
+        /// </example>
+        public static string RemoveDefaultNullProperties(this JObject jsonObject)
+        {
+            try
+            {
+                foreach (var property in jsonObject.Properties().ToList())
+                {
+                    if (property.Value.Type == JTokenType.Object)
+                    {
+                        RemoveDefaultNullProperties((JObject)property.Value);
+                    }
+                    else if (property.Value.Type == JTokenType.Array)
+                    {
+                        foreach (var item in property.Value)
+                        {
+                            if (item.Type == JTokenType.Object)
+                            {
+                                RemoveDefaultNullProperties((JObject)item);
+                            }
+                        }
+                    }
+                    else if (property.Value.Type == JTokenType.String && property.Value.ToString() == "defaultnull")
+                    {
+                        property.Remove();
+                    }
+                    else if (property.Value.Type == JTokenType.String && (property.Value.ToString() == "null" || property.Value.ToString() == ""))
+                    {
+                        property.Value = JValue.CreateNull();
+                    }
+                }
+            }
+            catch (System.Exception)
+            {
+                return jsonObject.ToString(); // Return the original string if parsing fails
+            }
+            return jsonObject.ToString();
+        }
+        public static string ReplaceAndRemoveSlashes(this string body)
+        {
+            return body.Replace("/", "").Replace("\\", "").Replace("rn", "").Replace("\"{", "{").Replace("}\"", "}");
+        }
+    }
+}

--- a/tools/Tests/JsonUtilitiesTest/JsonExtensionsTests.cs
+++ b/tools/Tests/JsonUtilitiesTest/JsonExtensionsTests.cs
@@ -1,0 +1,128 @@
+﻿namespace JsonUtilitiesTest;
+using System;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Microsoft.Graph.PowerShell.JsonUtilities;
+
+public class JsonExtensionsTests
+{
+    [Fact]
+    public void RemoveDefaultNullProperties_ShouldRemoveDefaultNullValues()
+    {
+        // Arrange
+        JObject json = JObject.Parse(@"{
+            ""displayname"": ""Tim"",
+            ""position"": ""defaultnull"",
+            ""salary"": 2000000,
+            ""team"": ""defaultnull""
+        }");
+
+        // Act
+        string cleanedJson = json.RemoveDefaultNullProperties();
+        JObject result = JObject.Parse(cleanedJson);
+
+        // Assert
+        Assert.False(result.ContainsKey("position"));
+        Assert.False(result.ContainsKey("team"));
+        Assert.Equal("Tim", result["displayname"]?.ToString());
+        Assert.Equal(2000000, result["salary"]?.ToObject<int>());
+    }
+
+    [Fact]
+    public void RemoveDefaultNullProperties_ShouldConvertStringNullToJsonNull()
+    {
+        // Arrange
+        JObject json = JObject.Parse(@"{
+            ""displayname"": ""Tim"",
+            ""position"": ""null"",
+            ""salary"": 2000000,
+            ""team"": """"
+        }");
+
+        // Act
+        string cleanedJson = json.RemoveDefaultNullProperties();
+        JObject result = JObject.Parse(cleanedJson);
+
+        // Assert
+        Assert.Null(result["position"]?.Value<string>());
+        Assert.Null(result["team"]?.Value<string>());
+        Assert.Equal("Tim", result["displayname"]?.ToString());
+        Assert.Equal(2000000, result["salary"]?.ToObject<int>());
+    }
+
+    [Fact]
+    public void RemoveDefaultNullProperties_ShouldHandleNestedObjects()
+    {
+        // Arrange
+        JObject json = JObject.Parse(@"{
+            ""displayname"": ""Tim"",
+            ""metadata"": {
+                ""phone"": ""defaultnull"",
+                ""location"": ""Nairobi""
+            }
+        }");
+
+        // Act
+        string cleanedJson = json.RemoveDefaultNullProperties();
+        JObject result = JObject.Parse(cleanedJson);
+
+        // Assert
+        Assert.False(result["metadata"]?.ToObject<JObject>()?.ContainsKey("phone"));
+        Assert.Equal("Nairobi", result["metadata"]?["location"]?.ToString());
+    }
+
+    [Fact]
+    public void RemoveDefaultNullProperties_ShouldHandleEmptyJsonObject()
+    {
+        // Arrange
+        JObject json = JObject.Parse(@"{}");
+
+        // Act
+        string cleanedJson = json.RemoveDefaultNullProperties();
+        JObject result = JObject.Parse(cleanedJson);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void RemoveDefaultNullProperties_ShouldHandleJsonArrays()
+    {
+        // Arrange
+        JObject json = JObject.Parse(@"{
+            ""users"": [
+                { ""displayname"": ""Tim"", ""email"": ""defaultnull"" },
+                { ""displayname"": ""Mayabi"", ""email"": ""mayabi@example.com"" }
+            ]
+        }");
+
+        // Act
+        string cleanedJson = json.RemoveDefaultNullProperties();
+        JObject result = JObject.Parse(cleanedJson);
+
+        // Assert
+        Assert.Equal("Tim", result["users"]?[0]?["displayname"]?.ToString());
+        Assert.Equal("mayabi@example.com", result["users"]?[1]?["email"]?.ToString());
+    }
+
+    [Fact]
+    public void RemoveDefaultNullProperties_ShouldNotAlterValidData()
+    {
+        // Arrange
+        JObject json = JObject.Parse(@"{
+            ""displayname"": ""Tim"",
+            ""email"": ""mayabi@example.com"",
+            ""salary"": 2000000
+        }");
+
+        // Act
+        string cleanedJson = json.RemoveDefaultNullProperties();
+        JObject result = JObject.Parse(cleanedJson);
+
+        // Assert
+        Assert.Equal("Tim", result["displayname"]?.ToString());
+        Assert.Equal("mayabi@example.com", result["email"]?.ToString());
+        Assert.Equal(2000000, result["salary"]?.ToObject<int>());
+    }
+}
+

--- a/tools/Tests/JsonUtilitiesTest/JsonExtensionsTests.cs
+++ b/tools/Tests/JsonUtilitiesTest/JsonExtensionsTests.cs
@@ -45,7 +45,7 @@ public class JsonExtensionsTests
 
         // Assert
         Assert.Null(result["position"]?.Value<string>());
-        Assert.Null(result["team"]?.Value<string>());
+        Assert.Equal("",result["team"]?.ToString());
         Assert.Equal("Tim", result["displayname"]?.ToString());
         Assert.Equal(2000000, result["salary"]?.ToObject<int>());
     }

--- a/tools/Tests/JsonUtilitiesTest/JsonUtilitiesTest.csproj
+++ b/tools/Tests/JsonUtilitiesTest/JsonUtilitiesTest.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../Custom/JsonExtensions.cs">
+        <Link>../../Custom/JsonExtensions.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #2609 and #3008 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Adds autorest directive to ensure that null valued properties are not omitted by default.
- Adds a custom JsonExtensions class containing an extension method that ensures properties explicitly defined as null in a PowerShell session are retained 
- Adds test project to test the above custom class.

This PR has a dependency on the autorest update done here which is part of addressing the issue here https://github.com/microsoftgraph/autorest.powershell/pull/9

<img width="782" alt="image" src="https://github.com/user-attachments/assets/a235c957-556b-49dd-940c-861ed02122e3" />

<img width="1275" alt="image" src="https://github.com/user-attachments/assets/83ded62c-e982-477c-bfd7-337dd9426375" />


