### PR TITLE
Removes sorting by unique name because it omits permissions with the same name but different permission type

### DIFF
--- a/tools/PostGeneration/NewCommandMetadata.ps1
+++ b/tools/PostGeneration/NewCommandMetadata.ps1
@@ -138,7 +138,6 @@ $ApiVersion | ForEach-Object {
                                 IsLeastPrivilege = $_.isLeastPrivilege
                             }
                         }
-                        $Permissions = $Permissions | Sort-Object -Property Name -Unique
                         $Permissions = $Permissions | Sort-Object -Property PermissionType
                         $Permissions = $Permissions | Sort-Object -Property IsLeastPrivilege
                         [array]::Reverse($Permissions)


### PR DESCRIPTION
Fixes #3122 

**Before**
<img width="583" alt="image" src="https://github.com/user-attachments/assets/f2826231-3da8-4d85-b886-3ecc1b95ffd2" />

**Expected result after fix**
![image](https://github.com/user-attachments/assets/47023cad-8707-46b6-b1af-aec51b9bc657)
