### PR TITLE
Roll back to .NET 6

### DIFF
--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -5,7 +5,12 @@ steps:
   - task: UseDotNet@2
     displayName: Use .NET SDK
     inputs:
-      version: 6.x     
+      version: 8.x 
+
+  - task: UseDotNet@2
+    displayName: Use .NET SDK
+    inputs:
+      version: 6.x 
       
   - task: NuGetToolInstaller@1
     displayName: Install Nuget

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -5,7 +5,7 @@ steps:
   - task: UseDotNet@2
     displayName: Use .NET SDK
     inputs:
-      version: 8.x     
+      version: 6.x     
       
   - task: NuGetToolInstaller@1
     displayName: Install Nuget

--- a/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
+++ b/src/Authentication/Authentication.Core/Microsoft.Graph.Authentication.Core.csproj
@@ -2,9 +2,9 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Repo.props" />
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net472</TargetFrameworks>
     <RootNamespace>Microsoft.Graph.PowerShell.Authentication.Core</RootNamespace>
-    <Version>2.25.0</Version>
+    <Version>2.26.1</Version>
     <!-- Suppress .NET Target Framework Moniker (TFM) Support Build Warnings -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>

--- a/src/Authentication/Authentication/build-module.ps1
+++ b/src/Authentication/Authentication/build-module.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 $ModuleName = "Authentication"
 $ModulePrefix = "Microsoft.Graph"
 $netStandard = "netstandard2.0"
-$netApp = "net8.0"
+$netApp = "net6.0"
 $netFx = "net472"
 $copyExtensions = @('.dll', '.pdb')
 


### PR DESCRIPTION
This PR rolls back the authentication module to .NET 6 due to the breaking change in the .NET SDK version 8.x. which is not compatible with Azure Automation Run Book's PowerShell 7.2 version.
