### PR TITLE
Adds aliases for renamed cmdlets and ensure backward compatibility

### DIFF
--- a/src/readme.graph.md
+++ b/src/readme.graph.md
@@ -962,5 +962,23 @@ directive:
       subject: ^(.*)(OnPremise)(.*)$
     set:
       alias: ^(.*)(OnPremises)(.*)$
+
+# Setting the alias below as per the request on issue [#3241](https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/3241)
+
+  - where:
+      verb: Get
+      subject: UserOnlineMeetingTranscript
+    set:
+      alias: Get-Mg${subject-prefix}AllUserOnlineMeetingTranscript
+  - where:
+      verb: Get
+      subject: UserEventDelta
+    set:
+      alias: Get-Mg${subject-prefix}UserCalendarEventDelta
+  - where:
+      verb: Get
+      subject: UserOnlineMeetingRecording
+    set:
+      alias: Get-Mg${subject-prefix}AllUserOnlineMeetingRecording
       
 ```


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #3241 

The PR adds aliases for the following cmdlets and ensures backward compatibility.

1. `Get-MgUserOnlineMeetingTranscript` aliased to `Get-MgAllUserOnlineMeetingTranscript`
2. `Get-MgUserEventDelta` aliased to `Get-MgUserCalendarEventDelta`
3. `Get-MgUserOnlineMeetingRecording` aliased to `Get-MgAllUserOnlineMeetingRecording`