### PR TITLE
Added directives to disable generation of invalid Service Announcement cmdlets

### DIFF
--- a/src/Devices.ServiceAnnouncement/Devices.ServiceAnnouncement.md
+++ b/src/Devices.ServiceAnnouncement/Devices.ServiceAnnouncement.md
@@ -18,7 +18,7 @@ require:
 ``` yaml
 directive:
 # Remove invalid paths.
-  - remove-path-by-operation: ^admin(?!\.serviceAnnouncement).*$
+  - remove-path-by-operation: ^admin(?!\.serviceAnnouncement).*$|^admin.serviceAnnouncement_CreateHealthOverview$|^admin.serviceAnnouncement.healthOverview_CreateIssue$|^admin.serviceAnnouncement_CreateIssue$|^admin.serviceAnnouncement_CreateMessage$|^admin.serviceAnnouncement.message_CreateAttachment$|^admin.serviceAnnouncement_DeleteHealthOverview$|^admin.serviceAnnouncement.healthOverview_DeleteIssue$|^admin.serviceAnnouncement_DeleteIssue$|^admin.serviceAnnouncement_DeleteMessage$|^admin.serviceAnnouncement.message_DeleteAttachment$|^admin.serviceAnnouncement_DeleteMessagesAttachmentsArchive$|^admin.serviceAnnouncement.message_DeleteAttachmentsContent$|^admin.serviceAnnouncement_UpdateHealthOverview$|^admin.serviceAnnouncement.healthOverview_UpdateIssue$|^admin.serviceAnnouncement_UpdateIssue$|^admin.serviceAnnouncement_UpdateMessage$|^admin.serviceAnnouncement.message_UpdateAttachment$|^admin.serviceAnnouncement_SetMessagesAttachmentsArchive$|^admin.serviceAnnouncement.message_SetAttachmentsContent$
 
 # Drop admin from command names.
   - where:


### PR DESCRIPTION
﻿<!-- Read me before you submit this pull request
First off, thank you for opening this pull request! We do appreciate it.
The commands and models for this SDK are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our AutoREST directives.
-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #3250 
The cmdlets highlighted in the image below are unsupported because serviceAnnouncement Apis do not support POST, PATCH, PUT and DELETE operations.
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/5dc720f0-4052-4baf-9ce4-77f82f9517c7" />

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

- Added AutoRest directives to remove unsupported cmdlets
- Update metadata file.


