### PR TITLE
Remove WindowsPrivacyAccessControl from module generation

### DIFF
--- a/src/DeviceManagement/DeviceManagement.md
+++ b/src/DeviceManagement/DeviceManagement.md
@@ -18,7 +18,7 @@ require:
 ``` yaml
 directive:
 # Remove invalid paths.
-  - remove-path-by-operation: ^deviceManagement.(deviceManagementScript.userRunState.deviceRunState_.*|groupPolicyConfiguration.definitionValue.presentationValue_.*|deviceShellScript.userRunState.deviceRunState_.*|deviceConfiguration_assignedAccessMultiModeProfile|microsoftTunnelSite.microsoftTunnelServer_createServerLogCollectionRequest|groupPolicyConfiguration_updateDefinitionValue|intent_updateSetting)$
+  - remove-path-by-operation: ^deviceManagement.(deviceManagementScript.userRunState.deviceRunState_.*|groupPolicyConfiguration.definitionValue.presentationValue_.*|deviceShellScript.userRunState.deviceRunState_.*|deviceConfiguration_assignedAccessMultiModeProfile|deviceConfiguration_windowsPrivacyAccessControl|microsoftTunnelSite.microsoftTunnelServer_createServerLogCollectionRequest|groupPolicyConfiguration_updateDefinitionValue|intent_updateSetting)$
 
 # Remove cmdlets.
   - where:


### PR DESCRIPTION
This PR excludes the `deviceManagement_windowsPrivacyAccessControl` resource from being generated into the DeviceManagement module. This is necessary because it otherwise is "merged" with the `Get-MgBetaDeviceManagementDeviceConfiguration` cmdlet, therefore resulting in a broken parameter set resolution. 

`deviceManagement_windowsPrivacyAccessControl` is assigned the `Get-MgBetaDeviceManagementDeviceConfiguration` command in `MgCommandMetadata.json`. There, also the variants `Access`, `AccessExpanded`, `AccessViaIdentity` and `AccessViaIdentityExpanded` are defined. Having this definition there forces the merge of the default `Get-MgBetaDeviceManagementDeviceConfiguration` cmdlet with this object, although this should have a dedicated cmdlet, or even better, simply be excluded because it doesn't serve a purpose in having it. 

- Fixes #3295 

### Changes proposed in this pull request

- Exclude the `deviceManagement_windowsPrivacyAccessControl` object from module generation.
