### PR TITLE
Update example cmdlet in New-MgDomainFederationConfiguration

### DIFF
--- a/src/Identity.DirectoryManagement/v1.0/examples/New-MgDomainFederationConfiguration.md
+++ b/src/Identity.DirectoryManagement/v1.0/examples/New-MgDomainFederationConfiguration.md
@@ -1,7 +1,7 @@
 ### Example 1: Configure federation settings for a federated domain
 
 ```powershell
-New-MgDomainFederationConfiguration -DomainId "contoso.com" -ActiveSignInUri "https://sts.contoso.com/adfs/services/trust/2005/usernamemixed" -DisplayName "Contoso" -IssuerUri "http://contoso.com/adfs/services/trust/" -MetadataExchangeUri "https://sts.contoso.com/adfs/services/trust/mex" -NextSigningCertificate "MIIC3jCCAcagAwIBAgIQEt0T0G5GPZ9" -PassiveSignInUri "https://sts.contoso.com/adfs/ls/" -SignOutUri "https://sts.contoso.com/adfs/ls/" -SigningCertificate "MIIC3jCCAcagAwIBAgIQFsO0R8deG4h" -FederatedIdpMfaBehavior "rejectMfaByFederatedIdp" | Format-List 
+New-MgDomainFederationConfiguration -DomainId "contoso.com" -ActiveSignInUri "https://sts.contoso.com/adfs/services/trust/2005/usernamemixed" -DisplayName "Contoso" -IssuerUri "http://contoso.com/adfs/services/trust/" -MetadataExchangeUri "https://sts.contoso.com/adfs/services/trust/mex" -NextSigningCertificate "MIIC3jCCAcagAwIBAgIQEt0T0G5GPZ9" -PassiveSignInUri "https://sts.contoso.com/adfs/ls/" -SignOutUri "https://sts.contoso.com/adfs/ls/" -SigningCertificate "MIIC3jCCAcagAwIBAgIQFsO0R8deG4h" -FederatedIdpMfaBehavior "acceptIfMfaDoneByFederatedIdp" -PreferredAuthenticationProtocol "wsFed" | Format-List 
 
 ActiveSignInUri                       : https://sts.deverett.info/adfs/services/trust/2005/usernamemixed 
 DisplayName                           : Contoso 


### PR DESCRIPTION
To properly configure a federation, PreferredAuthenticationProtocol option is required. This is explained in [Create internalDomainFederation](https://learn.microsoft.com/en-us/graph/api/domain-post-federationconfiguration?view=graph-rest-1.0&tabs=http) as below. As the sample cmdlet is missing this parameter. I added it to the example.

<img width="852" height="102" alt="image" src="https://github.com/user-attachments/assets/9e9eb9fc-76e3-45b5-81bf-d2e2e87e0f12" />

Also, most customers want to handle MFA at their IdP. The example has -FederatedIdpMfaBehavior "rejectMfaByFederatedIdp" set that means MFA done in their IdP is blocked by Entra ID. I would like to change it to "acceptIfMfaDoneByFederatedIdp" to cover more popular user scenarios.