### PR TITLE
Separate ci and release build pipelines

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -33,13 +33,12 @@ variables:
 trigger:
   branches:
     include:
-    - dev
+    - main
 
 pr:
   branches:
     include:
     - main
-    - dev
 resources:
   repositories:
   - repository: 1ESPipelineTemplates

--- a/.azure-pipelines/sdk-release.yml
+++ b/.azure-pipelines/sdk-release.yml
@@ -32,9 +32,6 @@ variables:
   PREVIEW_BRANCH: 'refs/heads/main'  # Updated to target your branch
 
 trigger:
-  branches:
-    include:
-    - main
   tags:
     include:
       - v*


### PR DESCRIPTION
Separating the CI build pipelines from the release pipeline. 
CI will only run on pushes into Dev and pull requests into Dev & Main. 
Release will only run on Tag commits as that is the only time we release to Nuget feed.  