### PR TITLE
fix: use private npm feed in CI to bypass network isolation

### DIFF
--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -29,7 +29,25 @@ steps:
     displayName: Install NodeJs
     inputs:
       versionSpec: 18.x
-      
+
+  - task: PowerShell@2
+    displayName: Configure private npm feed
+    inputs:
+      targetType: filePath
+      pwsh: true
+      filePath: $(Build.SourcesDirectory)/tools/Configure-PrivateNpmFeed.ps1
+      arguments: -SourcesDirectory "$(Build.SourcesDirectory)"
+
+  - task: npmAuthenticate@0
+    displayName: Authenticate to private npm feed
+    inputs:
+      workingFile: $(Build.SourcesDirectory)/.npmrc
+
+  - task: npmAuthenticate@0
+    displayName: Authenticate to private npm feed (Rush)
+    inputs:
+      workingFile: $(Build.SourcesDirectory)/autorest.powershell/common/config/rush/.npmrc
+
   - task: Npm@1
     displayName: Install AutoRest
     inputs:

--- a/tools/Configure-PrivateNpmFeed.ps1
+++ b/tools/Configure-PrivateNpmFeed.ps1
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Configures .npmrc files to use a private Azure Artifacts npm feed.
+
+.DESCRIPTION
+    Creates .npmrc files at the repository root and in the Rush config directory
+    to redirect npm and Rush package installations to a private feed. This is
+    used in CI pipelines where network isolation rules block the public npm registry.
+
+.PARAMETER SourcesDirectory
+    The root directory of the repository. Defaults to the current directory.
+
+.PARAMETER Registry
+    The private npm registry URL.
+#>
+param(
+    [Parameter()]
+    [string]$SourcesDirectory = (Get-Location).Path,
+
+    [Parameter()]
+    [string]$Registry = "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/"
+)
+
+$npmrcContent = "registry=$Registry`nalways-auth=true"
+
+# Create .npmrc at repo root for global npm installs (autorest, rush)
+$rootNpmrc = Join-Path $SourcesDirectory ".npmrc"
+Set-Content -Path $rootNpmrc -Value $npmrcContent -NoNewline
+Write-Host "Created $rootNpmrc"
+
+# Overwrite Rush .npmrc to use private feed for rush install
+$rushNpmrc = Join-Path $SourcesDirectory "autorest.powershell/common/config/rush/.npmrc"
+Set-Content -Path $rushNpmrc -Value $npmrcContent -NoNewline
+Write-Host "Updated $rushNpmrc"


### PR DESCRIPTION
## Summary
Fixes CI build failures in the command metadata refresh pipeline caused by network isolation rules blocking access to the public npm registry.

## Build Failure
https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=213646&view=logs&j=ede078fe-2a98-5bef-7d41-ce060c17395e&t=16397dbc-9b9b-5731-79d9-dd4acfa7ba0f

## Changes
- **\\	ools/Configure-PrivateNpmFeed.ps1\\** (new): Parameterized script that creates \\.npmrc\\ files pointing to the Azure Artifacts \\PowerShell_V2_Build\\ npm feed with \\lways-auth=true\\. Accepts \\-SourcesDirectory\\ and \\-Registry\\ parameters.
- **\\.azure-pipelines/common-templates/install-tools.yml\\**: Added 3 steps after NodeTool and before npm installs:
  1. \\PowerShell@2\\ — runs the script to create \\.npmrc\\ at repo root and overwrite Rush's \\.npmrc\\`n  2. \\
pmAuthenticate@0\\ — authenticates the root \\.npmrc\\`n  3. \\
pmAuthenticate@0\\ — authenticates the Rush \\.npmrc\\`n
## External Contributors
The Rush \\.npmrc\\ in the repo still defaults to \\egistry.npmjs.org\\, so external contributors can clone and install normally. The private feed is only configured at build time in CI.

Fixes #3563