### PR TITLE
fix: remove public npm registry calls for network isolation compliance

### DIFF
--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -53,18 +53,24 @@ steps:
     inputs:
       command: custom
       customCommand: install -g autorest@3.7.2
+      customRegistry: useNpmrc
+      customEndpoint: ''
     
   - task: Npm@1
     displayName: Install AutorestCore
     inputs:
       command: custom
       customCommand: install -g @autorest/core@3.10.4
+      customRegistry: useNpmrc
+      customEndpoint: ''
 
   - task: Npm@1
     displayName: Install Rush
     inputs:
       command: custom
       customCommand: install -g @microsoft/rush
+      customRegistry: useNpmrc
+      customEndpoint: ''
   
   - task: PowerShell@2
     displayName: Rush Build

--- a/.azure-pipelines/sdk-release.yml
+++ b/.azure-pipelines/sdk-release.yml
@@ -47,7 +47,7 @@ extends:
   parameters:
     pool: $(BuildAgent)
     settings:
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Restricted
     sdl:
       binskim:
         enabled: false


### PR DESCRIPTION
## Summary

The SDK release pipeline has been failing because outbound calls to the public npm registry (egistry.npmjs.org) are blocked by network isolation policies.

## Changes

### \.azure-pipelines/sdk-release.yml\
- Changed \
etworkIsolationPolicy\ from \Permissive\ to \Restricted\ to comply with org-level network isolation policies.

### \.azure-pipelines/common-templates/install-tools.yml\
- Added \customRegistry: useNpmrc\ to all three \Npm@1\ tasks (AutoRest, AutorestCore, Rush) so they explicitly route through the private Azure Artifacts feed configured by \Configure-PrivateNpmFeed.ps1\, instead of falling back to the public npm registry.

## Context

The \Configure-PrivateNpmFeed.ps1\ script and \
pmAuthenticate@0\ steps were already correctly setting up and authenticating the private feed — the gap was that the \Npm@1\ tasks were not instructed to use it via \customRegistry: useNpmrc\.