### PR TITLE
Ramsess/fix release pipeline

### DIFF
--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -52,18 +52,21 @@ steps:
     displayName: Install AutoRest
     inputs:
       command: custom
+      workingDir: $(Build.SourcesDirectory)
       customCommand: install -g autorest@3.7.2
-    
+
   - task: Npm@1
     displayName: Install AutorestCore
     inputs:
       command: custom
+      workingDir: $(Build.SourcesDirectory)
       customCommand: install -g @autorest/core@3.10.4
 
   - task: Npm@1
     displayName: Install Rush
     inputs:
       command: custom
+      workingDir: $(Build.SourcesDirectory)
       customCommand: install -g @microsoft/rush
   
   - task: PowerShell@2

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -66,14 +66,14 @@ steps:
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install -g autorest@3.7.2 --registry https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/
+      customCommand: install -g autorest@3.7.2
 
   - task: Npm@1
     displayName: Install AutorestCore
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install -g @autorest/core@3.10.4 --registry https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/
+      customCommand: install -g @autorest/core@3.10.4
 
   - task: PowerShell@2
     displayName: Pre-populate autorest extension cache
@@ -84,7 +84,7 @@ steps:
         # Autorest resolves extensions from ~/.autorest/<pkg>/<version>/node_modules/.
         # Pre-install every extension referenced by autorest-configuration.md so autorest
         # makes zero npm network calls during module generation.
-        $registry = "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/"
+        # Registry and auth are read from ~/.npmrc (copied from the authenticated .npmrc above).
         $extensions = @(
             "@autorest/core@3.10.4",
             "@autorest/modelerfour@4.24.3"
@@ -101,7 +101,7 @@ steps:
             }
             New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
             Write-Host "Pre-installing $ext into $cacheDir"
-            npm install $ext --prefix $cacheDir --registry $registry
+            npm install $ext --prefix $cacheDir
             if ($LASTEXITCODE -ne 0) { throw "Failed to pre-install $ext (exit $LASTEXITCODE)" }
             Write-Host "Done: $ext"
         }
@@ -111,7 +111,7 @@ steps:
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install -g @microsoft/rush --registry https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/
+      customCommand: install -g @microsoft/rush
   
   - task: PowerShell@2
     displayName: Rush Build

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -78,33 +78,9 @@ steps:
   - task: PowerShell@2
     displayName: Pre-populate autorest extension cache
     inputs:
-      targetType: inline
+      targetType: filePath
       pwsh: true
-      script: |
-        # Autorest resolves extensions from ~/.autorest/<pkg>/<version>/node_modules/.
-        # Pre-install every extension referenced by autorest-configuration.md so autorest
-        # makes zero npm network calls during module generation.
-        # Registry and auth are read from ~/.npmrc (copied from the authenticated .npmrc above).
-        $extensions = @(
-            "@autorest/core@3.10.4",
-            "@autorest/modelerfour@4.24.3"
-        )
-        foreach ($ext in $extensions) {
-            $parts   = $ext -split '@(?=[^@]+$)'   # split on last @
-            $pkg     = $parts[0]
-            $ver     = $parts[1]
-            $cacheDir = Join-Path $env:USERPROFILE ".autorest\$($pkg.Replace('/','\'))\$ver"
-            $nodeModules = Join-Path $cacheDir "node_modules\$($pkg.Replace('/','\'))"
-            if (Test-Path $nodeModules) {
-                Write-Host "Cache already present: $ext"
-                continue
-            }
-            New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
-            Write-Host "Pre-installing $ext into $cacheDir"
-            npm install $ext --prefix $cacheDir
-            if ($LASTEXITCODE -ne 0) { throw "Failed to pre-install $ext (exit $LASTEXITCODE)" }
-            Write-Host "Done: $ext"
-        }
+      filePath: $(Build.SourcesDirectory)/tools/utilities/PrePopulateAutorestCache.ps1
 
   - task: Npm@1
     displayName: Install Rush

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -66,14 +66,14 @@ steps:
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install autorest@3.7.2
+      customCommand: install --no-package-lock autorest@3.7.2
 
   - task: Npm@1
     displayName: Install AutorestCore
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install @autorest/core@3.10.4
+      customCommand: install --no-package-lock @autorest/core@3.10.4
 
   - task: PowerShell@2
     displayName: Pre-populate autorest extension cache
@@ -111,7 +111,7 @@ steps:
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install @microsoft/rush
+      customCommand: install --no-package-lock @microsoft/rush
   
   - task: PowerShell@2
     displayName: Rush Build
@@ -120,9 +120,9 @@ steps:
       pwsh: true
       workingDirectory: "autorest.powershell"
       script: |
-        npx rush install
+        npx --no-install rush install
         if ($LASTEXITCODE -ne 0) { throw "rush install failed with exit code $LASTEXITCODE" }
-        npx rush link
+        npx --no-install rush link
         if ($LASTEXITCODE -ne 0) { throw "rush link failed with exit code $LASTEXITCODE" }
-        npx rush rebuild
+        npx --no-install rush rebuild
         if ($LASTEXITCODE -ne 0) { throw "rush rebuild failed with exit code $LASTEXITCODE" }

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -75,6 +75,22 @@ steps:
       workingDir: $(Build.SourcesDirectory)
       customCommand: install -g @autorest/core@3.10.4 --registry https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/
 
+  - task: PowerShell@2
+    displayName: Pre-populate autorest core cache
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        # Autorest looks for @autorest/core in ~/.autorest/@autorest/core/<version>/node_modules/
+        # Pre-installing it here with the explicit registry flag means autorest never needs
+        # to make any npm calls during module generation.
+        $cacheDir = Join-Path $env:USERPROFILE ".autorest\@autorest\core\3.10.4"
+        New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+        Write-Host "Pre-installing @autorest/core@3.10.4 into autorest cache: $cacheDir"
+        npm install @autorest/core@3.10.4 --prefix $cacheDir --registry https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/
+        if ($LASTEXITCODE -ne 0) { throw "Failed to pre-install @autorest/core@3.10.4 into autorest cache (exit $LASTEXITCODE)" }
+        Write-Host "Autorest core cache pre-populated successfully"
+
   - task: Npm@1
     displayName: Install Rush
     inputs:

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -53,21 +53,21 @@ steps:
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install -g autorest@3.7.2
+      customCommand: install -g autorest@3.7.2 --registry https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/
 
   - task: Npm@1
     displayName: Install AutorestCore
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install -g @autorest/core@3.10.4
+      customCommand: install -g @autorest/core@3.10.4 --registry https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/
 
   - task: Npm@1
     displayName: Install Rush
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install -g @microsoft/rush
+      customCommand: install -g @microsoft/rush --registry https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/
   
   - task: PowerShell@2
     displayName: Rush Build

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -76,20 +76,35 @@ steps:
       customCommand: install -g @autorest/core@3.10.4 --registry https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/
 
   - task: PowerShell@2
-    displayName: Pre-populate autorest core cache
+    displayName: Pre-populate autorest extension cache
     inputs:
       targetType: inline
       pwsh: true
       script: |
-        # Autorest looks for @autorest/core in ~/.autorest/@autorest/core/<version>/node_modules/
-        # Pre-installing it here with the explicit registry flag means autorest never needs
-        # to make any npm calls during module generation.
-        $cacheDir = Join-Path $env:USERPROFILE ".autorest\@autorest\core\3.10.4"
-        New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
-        Write-Host "Pre-installing @autorest/core@3.10.4 into autorest cache: $cacheDir"
-        npm install @autorest/core@3.10.4 --prefix $cacheDir --registry https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/
-        if ($LASTEXITCODE -ne 0) { throw "Failed to pre-install @autorest/core@3.10.4 into autorest cache (exit $LASTEXITCODE)" }
-        Write-Host "Autorest core cache pre-populated successfully"
+        # Autorest resolves extensions from ~/.autorest/<pkg>/<version>/node_modules/.
+        # Pre-install every extension referenced by autorest-configuration.md so autorest
+        # makes zero npm network calls during module generation.
+        $registry = "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/"
+        $extensions = @(
+            "@autorest/core@3.10.4",
+            "@autorest/modelerfour@4.24.3"
+        )
+        foreach ($ext in $extensions) {
+            $parts   = $ext -split '@(?=[^@]+$)'   # split on last @
+            $pkg     = $parts[0]
+            $ver     = $parts[1]
+            $cacheDir = Join-Path $env:USERPROFILE ".autorest\$($pkg.Replace('/','\'))\$ver"
+            $nodeModules = Join-Path $cacheDir "node_modules\$($pkg.Replace('/','\'))"
+            if (Test-Path $nodeModules) {
+                Write-Host "Cache already present: $ext"
+                continue
+            }
+            New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+            Write-Host "Pre-installing $ext into $cacheDir"
+            npm install $ext --prefix $cacheDir --registry $registry
+            if ($LASTEXITCODE -ne 0) { throw "Failed to pre-install $ext (exit $LASTEXITCODE)" }
+            Write-Host "Done: $ext"
+        }
 
   - task: Npm@1
     displayName: Install Rush

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -48,6 +48,14 @@ steps:
     inputs:
       workingFile: $(Build.SourcesDirectory)/autorest.powershell/common/config/rush/.npmrc
 
+  - task: PowerShell@2
+    displayName: Set npm userconfig for all npm subprocesses
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        Write-Host "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Build.SourcesDirectory)/.npmrc"
+
   - task: Npm@1
     displayName: Install AutoRest
     inputs:

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -66,14 +66,14 @@ steps:
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install -g autorest@3.7.2
+      customCommand: install autorest@3.7.2
 
   - task: Npm@1
     displayName: Install AutorestCore
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install -g @autorest/core@3.10.4
+      customCommand: install @autorest/core@3.10.4
 
   - task: PowerShell@2
     displayName: Pre-populate autorest extension cache
@@ -111,7 +111,7 @@ steps:
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
-      customCommand: install -g @microsoft/rush
+      customCommand: install @microsoft/rush
   
   - task: PowerShell@2
     displayName: Rush Build
@@ -120,9 +120,9 @@ steps:
       pwsh: true
       workingDirectory: "autorest.powershell"
       script: |
-        rush install
+        npx rush install
         if ($LASTEXITCODE -ne 0) { throw "rush install failed with exit code $LASTEXITCODE" }
-        rush link
+        npx rush link
         if ($LASTEXITCODE -ne 0) { throw "rush link failed with exit code $LASTEXITCODE" }
-        rush rebuild
+        npx rush rebuild
         if ($LASTEXITCODE -ne 0) { throw "rush rebuild failed with exit code $LASTEXITCODE" }

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -49,12 +49,17 @@ steps:
       workingFile: $(Build.SourcesDirectory)/autorest.powershell/common/config/rush/.npmrc
 
   - task: PowerShell@2
-    displayName: Set npm userconfig for all npm subprocesses
+    displayName: Apply npm auth config to user profile
     inputs:
       targetType: inline
       pwsh: true
       script: |
-        Write-Host "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Build.SourcesDirectory)/.npmrc"
+        # Copy authenticated .npmrc to the user home dir so ALL npm subprocesses
+        # (including autorest's internal npm calls) use the private feed + auth tokens.
+        $src = "$(Build.SourcesDirectory)/.npmrc"
+        $dst = Join-Path $env:USERPROFILE ".npmrc"
+        Copy-Item -Path $src -Destination $dst -Force
+        Write-Host "Copied npm config to $dst"
 
   - task: Npm@1
     displayName: Install AutoRest
@@ -85,5 +90,8 @@ steps:
       workingDirectory: "autorest.powershell"
       script: |
         rush install
+        if ($LASTEXITCODE -ne 0) { throw "rush install failed with exit code $LASTEXITCODE" }
         rush link
+        if ($LASTEXITCODE -ne 0) { throw "rush link failed with exit code $LASTEXITCODE" }
         rush rebuild
+        if ($LASTEXITCODE -ne 0) { throw "rush rebuild failed with exit code $LASTEXITCODE" }

--- a/tools/Configure-PrivateNpmFeed.ps1
+++ b/tools/Configure-PrivateNpmFeed.ps1
@@ -35,3 +35,18 @@ Write-Host "Created $rootNpmrc"
 $rushNpmrc = Join-Path $SourcesDirectory "autorest.powershell/common/config/rush/.npmrc"
 Set-Content -Path $rushNpmrc -Value $npmrcContent -NoNewline
 Write-Host "Updated $rushNpmrc"
+
+# Create NuGet.config to redirect dotnet restore to the private feed
+$nugetFeed = $Registry -replace "/npm/registry/$", "/nuget/v3/index.json"
+$nugetConfig = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="PowerShell_V2_Build" value="$nugetFeed" />
+  </packageSources>
+</configuration>
+"@
+$nugetConfigPath = Join-Path $SourcesDirectory "NuGet.config"
+Set-Content -Path $nugetConfigPath -Value $nugetConfig -NoNewline
+Write-Host "Created $nugetConfigPath"

--- a/tools/Configure-PrivateNpmFeed.ps1
+++ b/tools/Configure-PrivateNpmFeed.ps1
@@ -41,7 +41,7 @@ Write-Host "Updated $rushNpmrc"
 $normalizedRegistry = $Registry.TrimEnd('/')
 $npmSuffix = "/npm/registry"
 if (-not $normalizedRegistry.EndsWith($npmSuffix)) {
-    throw "Cannot derive NuGet feed URL: Registry '$Registry' does not end with '$npmSuffix'. Pass an explicit Azure Artifacts npm registry URL or add a -NugetFeed parameter."
+    throw "Cannot derive NuGet feed URL: Registry '$Registry' does not end with '$npmSuffix'. Pass an explicit Azure Artifacts npm registry URL using the -Registry parameter."
 }
 $nugetFeed = $normalizedRegistry.Substring(0, $normalizedRegistry.Length - $npmSuffix.Length) + "/nuget/v3/index.json"
 $nugetConfig = @"

--- a/tools/Configure-PrivateNpmFeed.ps1
+++ b/tools/Configure-PrivateNpmFeed.ps1
@@ -37,7 +37,13 @@ Set-Content -Path $rushNpmrc -Value $npmrcContent -NoNewline
 Write-Host "Updated $rushNpmrc"
 
 # Create NuGet.config to redirect dotnet restore to the private feed
-$nugetFeed = $Registry -replace "/npm/registry/$", "/nuget/v3/index.json"
+# Normalize the registry URL and validate the expected suffix before transforming
+$normalizedRegistry = $Registry.TrimEnd('/')
+$npmSuffix = "/npm/registry"
+if (-not $normalizedRegistry.EndsWith($npmSuffix)) {
+    throw "Cannot derive NuGet feed URL: Registry '$Registry' does not end with '$npmSuffix'. Pass an explicit Azure Artifacts npm registry URL or add a -NugetFeed parameter."
+}
+$nugetFeed = $normalizedRegistry.Substring(0, $normalizedRegistry.Length - $npmSuffix.Length) + "/nuget/v3/index.json"
 $nugetConfig = @"
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -32,10 +32,6 @@ if (-not $Isolated) {
 # Module import.
 Import-Module PowerShellGet
 
-# Install Powershell-yaml
-if (!(Get-Module -Name powershell-yaml -ListAvailable)) {
-    Install-Module powershell-yaml -Repository PSGallery -Scope CurrentUser -Force
-}
 
 $ScriptRoot = $PSScriptRoot
 $ModulesSrc = Join-Path $ScriptRoot "..\src\"

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -63,10 +63,22 @@ if (Test-Path $coreCacheDir) {
 } else {
     Write-Host "WARNING: Autorest core cache directory not found at $coreCacheDir"
 }
+$modelerfourCacheDir = Join-Path $autorestHome "@autorest\modelerfour"
+if (Test-Path $modelerfourCacheDir) {
+    Write-Host "Autorest modelerfour cache versions: $(Get-ChildItem $modelerfourCacheDir -Directory | Select-Object -ExpandProperty Name)"
+    $modelerfourNodeModules = Join-Path $modelerfourCacheDir "4.24.3\node_modules\@autorest\modelerfour"
+    Write-Host "Cache modelerfour 4.24.3 node_modules present: $(Test-Path $modelerfourNodeModules)"
+} else {
+    Write-Host "WARNING: Autorest modelerfour cache directory not found at $modelerfourCacheDir"
+}
 Write-Host "npm registry: $(npm config get registry 2>&1)"
+Write-Host "npm_config_registry env: $env:npm_config_registry"
 Write-Host "NPM_CONFIG_USERCONFIG: $env:NPM_CONFIG_USERCONFIG"
 $userNpmrc = Join-Path $env:USERPROFILE ".npmrc"
 Write-Host "~/.npmrc exists: $(Test-Path $userNpmrc)"
+if (Test-Path $userNpmrc) {
+    Write-Host "~/.npmrc registry line: $(Select-String -Path $userNpmrc -Pattern '^registry=' | Select-Object -First 1 -ExpandProperty Line)"
+}
 Write-Host "--- End diagnostics ---"
 
 $RequiredGraphModules = @()

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -48,7 +48,7 @@ if (-not (Test-Path $ModuleMappingPath)) {
 
 # Build AutoREST.PowerShell submodule.
 Set-Location (Join-Path $ScriptRoot "../autorest.powershell")
-rush update --purge
+rush install
 rush build
 
 $RequiredGraphModules = @()

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -49,7 +49,14 @@ if (-not (Test-Path $ModuleMappingPath)) {
 # Build AutoREST.PowerShell submodule.
 Set-Location (Join-Path $ScriptRoot "../autorest.powershell")
 npx --no-install rush install
+if ($LASTEXITCODE -ne 0) {
+    throw "Command 'npx --no-install rush install' failed with exit code $LASTEXITCODE."
+}
+
 npx --no-install rush build
+if ($LASTEXITCODE -ne 0) {
+    throw "Command 'npx --no-install rush build' failed with exit code $LASTEXITCODE."
+}
 
 # Diagnostic: show autorest cache state and npm registry config before generation.
 # Gated behind ENABLE_AUTOREST_DIAGNOSTICS to avoid npm calls in network-isolated release pipelines.

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -48,38 +48,43 @@ if (-not (Test-Path $ModuleMappingPath)) {
 
 # Build AutoREST.PowerShell submodule.
 Set-Location (Join-Path $ScriptRoot "../autorest.powershell")
-npx rush install
-npx rush build
+npx --no-install rush install
+npx --no-install rush build
 
 # Diagnostic: show autorest cache state and npm registry config before generation.
-Write-Host "--- Autorest/npm diagnostics ---"
-$autorestHome = if ($env:AUTOREST_HOME) { $env:AUTOREST_HOME } else { Join-Path $env:USERPROFILE ".autorest" }
-Write-Host "AUTOREST_HOME: $autorestHome"
-$coreCacheDir = Join-Path $autorestHome "@autorest\core"
-if (Test-Path $coreCacheDir) {
-    Write-Host "Autorest core cache versions: $(Get-ChildItem $coreCacheDir -Directory | Select-Object -ExpandProperty Name)"
-    $nodeModulesDir = Join-Path $coreCacheDir "3.10.4\node_modules\@autorest\core"
-    Write-Host "Cache 3.10.4 node_modules present: $(Test-Path $nodeModulesDir)"
+# Gated behind ENABLE_AUTOREST_DIAGNOSTICS to avoid npm calls in network-isolated release pipelines.
+if ($env:ENABLE_AUTOREST_DIAGNOSTICS) {
+    Write-Host "--- Autorest/npm diagnostics ---"
+    $autorestHome = if ($env:AUTOREST_HOME) { $env:AUTOREST_HOME } else { Join-Path $env:USERPROFILE ".autorest" }
+    Write-Host "AUTOREST_HOME: $autorestHome"
+    $coreCacheDir = Join-Path $autorestHome "@autorest\core"
+    if (Test-Path $coreCacheDir) {
+        Write-Host "Autorest core cache versions: $(Get-ChildItem $coreCacheDir -Directory | Select-Object -ExpandProperty Name)"
+        $nodeModulesDir = Join-Path $coreCacheDir "3.10.4\node_modules\@autorest\core"
+        Write-Host "Cache 3.10.4 node_modules present: $(Test-Path $nodeModulesDir)"
+    } else {
+        Write-Host "WARNING: Autorest core cache directory not found at $coreCacheDir"
+    }
+    $modelerfourCacheDir = Join-Path $autorestHome "@autorest\modelerfour"
+    if (Test-Path $modelerfourCacheDir) {
+        Write-Host "Autorest modelerfour cache versions: $(Get-ChildItem $modelerfourCacheDir -Directory | Select-Object -ExpandProperty Name)"
+        $modelerfourNodeModules = Join-Path $modelerfourCacheDir "4.24.3\node_modules\@autorest\modelerfour"
+        Write-Host "Cache modelerfour 4.24.3 node_modules present: $(Test-Path $modelerfourNodeModules)"
+    } else {
+        Write-Host "WARNING: Autorest modelerfour cache directory not found at $modelerfourCacheDir"
+    }
+    Write-Host "npm registry: $(npm config get registry 2>&1)"
+    Write-Host "npm_config_registry env: $env:npm_config_registry"
+    Write-Host "NPM_CONFIG_USERCONFIG: $env:NPM_CONFIG_USERCONFIG"
+    $userNpmrc = Join-Path $env:USERPROFILE ".npmrc"
+    Write-Host "~/.npmrc exists: $(Test-Path $userNpmrc)"
+    if (Test-Path $userNpmrc) {
+        Write-Host "~/.npmrc registry line: $(Select-String -Path $userNpmrc -Pattern '^registry=' | Select-Object -First 1 -ExpandProperty Line)"
+    }
+    Write-Host "--- End diagnostics ---"
 } else {
-    Write-Host "WARNING: Autorest core cache directory not found at $coreCacheDir"
+    Write-Host "Autorest diagnostics skipped (set ENABLE_AUTOREST_DIAGNOSTICS=1 to enable)"
 }
-$modelerfourCacheDir = Join-Path $autorestHome "@autorest\modelerfour"
-if (Test-Path $modelerfourCacheDir) {
-    Write-Host "Autorest modelerfour cache versions: $(Get-ChildItem $modelerfourCacheDir -Directory | Select-Object -ExpandProperty Name)"
-    $modelerfourNodeModules = Join-Path $modelerfourCacheDir "4.24.3\node_modules\@autorest\modelerfour"
-    Write-Host "Cache modelerfour 4.24.3 node_modules present: $(Test-Path $modelerfourNodeModules)"
-} else {
-    Write-Host "WARNING: Autorest modelerfour cache directory not found at $modelerfourCacheDir"
-}
-Write-Host "npm registry: $(npm config get registry 2>&1)"
-Write-Host "npm_config_registry env: $env:npm_config_registry"
-Write-Host "NPM_CONFIG_USERCONFIG: $env:NPM_CONFIG_USERCONFIG"
-$userNpmrc = Join-Path $env:USERPROFILE ".npmrc"
-Write-Host "~/.npmrc exists: $(Test-Path $userNpmrc)"
-if (Test-Path $userNpmrc) {
-    Write-Host "~/.npmrc registry line: $(Select-String -Path $userNpmrc -Pattern '^registry=' | Select-Object -First 1 -ExpandProperty Line)"
-}
-Write-Host "--- End diagnostics ---"
 
 $RequiredGraphModules = @()
 $AuthModuleManifest = Join-Path $ModulesSrc "Authentication" "Authentication" "artifacts" "Microsoft.Graph.Authentication.psd1"

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -51,6 +51,24 @@ Set-Location (Join-Path $ScriptRoot "../autorest.powershell")
 rush install
 rush build
 
+# Diagnostic: show autorest cache state and npm registry config before generation.
+Write-Host "--- Autorest/npm diagnostics ---"
+$autorestHome = if ($env:AUTOREST_HOME) { $env:AUTOREST_HOME } else { Join-Path $env:USERPROFILE ".autorest" }
+Write-Host "AUTOREST_HOME: $autorestHome"
+$coreCacheDir = Join-Path $autorestHome "@autorest\core"
+if (Test-Path $coreCacheDir) {
+    Write-Host "Autorest core cache versions: $(Get-ChildItem $coreCacheDir -Directory | Select-Object -ExpandProperty Name)"
+    $nodeModulesDir = Join-Path $coreCacheDir "3.10.4\node_modules\@autorest\core"
+    Write-Host "Cache 3.10.4 node_modules present: $(Test-Path $nodeModulesDir)"
+} else {
+    Write-Host "WARNING: Autorest core cache directory not found at $coreCacheDir"
+}
+Write-Host "npm registry: $(npm config get registry 2>&1)"
+Write-Host "NPM_CONFIG_USERCONFIG: $env:NPM_CONFIG_USERCONFIG"
+$userNpmrc = Join-Path $env:USERPROFILE ".npmrc"
+Write-Host "~/.npmrc exists: $(Test-Path $userNpmrc)"
+Write-Host "--- End diagnostics ---"
+
 $RequiredGraphModules = @()
 $AuthModuleManifest = Join-Path $ModulesSrc "Authentication" "Authentication" "artifacts" "Microsoft.Graph.Authentication.psd1"
 $LoadedAuthModule = Import-Module $AuthModuleManifest -PassThru -ErrorAction SilentlyContinue

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -48,8 +48,8 @@ if (-not (Test-Path $ModuleMappingPath)) {
 
 # Build AutoREST.PowerShell submodule.
 Set-Location (Join-Path $ScriptRoot "../autorest.powershell")
-rush install
-rush build
+npx rush install
+npx rush build
 
 # Diagnostic: show autorest cache state and npm registry config before generation.
 Write-Host "--- Autorest/npm diagnostics ---"

--- a/tools/GenerateServiceModule.ps1
+++ b/tools/GenerateServiceModule.ps1
@@ -69,6 +69,10 @@ $ApiVersion | ForEach-Object {
             else {
                 $FullModuleVersion = $ModuleMetadata.versions[$CurrentApiVersion].version
             }
+            # Route autorest's internal npm registry calls (fetchPackageMetadata for extension
+            # resolution) through the private feed. The public npm registry is DNS-blocked by
+            # 1ES supply-chain security enforcement on release pipelines.
+            $env:npm_config_registry = "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/"
             $autorestLog = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "autorest-$($ModuleFullName -replace '[^a-zA-Z0-9-]', '-').log")
             npx autorest --verbose --max-memory-size=$MaxMemorySize --module-version:$FullModuleVersion --module-name:$ModuleFullName --service-name:$Module --input-file:$OpenApiFile $AutoRestModuleConfig --max-cpu=2 --network-calls=2 2>&1 | Out-File -FilePath $autorestLog -Encoding utf8
             $autorestExitCode = $LASTEXITCODE

--- a/tools/GenerateServiceModule.ps1
+++ b/tools/GenerateServiceModule.ps1
@@ -69,10 +69,15 @@ $ApiVersion | ForEach-Object {
             else {
                 $FullModuleVersion = $ModuleMetadata.versions[$CurrentApiVersion].version
             }
-            npx autorest --max-memory-size=$MaxMemorySize --module-version:$FullModuleVersion --module-name:$ModuleFullName --service-name:$Module --input-file:$OpenApiFile $AutoRestModuleConfig --max-cpu=2 --network-calls=2
-            if ($LastExitCode -ne 0) {
-                Write-Host -ForegroundColor Red "AutoREST failed to generate '$ModuleFullName' module."
-                return $LastExitCode
+            $autorestLog = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "autorest-$($ModuleFullName -replace '[^a-zA-Z0-9-]', '-').log")
+            npx autorest --verbose --max-memory-size=$MaxMemorySize --module-version:$FullModuleVersion --module-name:$ModuleFullName --service-name:$Module --input-file:$OpenApiFile $AutoRestModuleConfig --max-cpu=2 --network-calls=2 2>&1 | Out-File -FilePath $autorestLog -Encoding utf8
+            $autorestExitCode = $LASTEXITCODE
+            if ($autorestExitCode -ne 0) {
+                Write-Host -ForegroundColor Red "AutoREST failed (exit $autorestExitCode) generating '$ModuleFullName'."
+                Write-Host -ForegroundColor Yellow "=== AutoREST log: $autorestLog ==="
+                if (Test-Path $autorestLog) { Get-Content $autorestLog | ForEach-Object { Write-Host $_ } }
+                Write-Host -ForegroundColor Yellow "=== End AutoREST log ==="
+                return $autorestExitCode
             }
             Write-Debug "AutoRest generated '$ModuleFullName' successfully."
 

--- a/tools/GenerateServiceModule.ps1
+++ b/tools/GenerateServiceModule.ps1
@@ -69,12 +69,23 @@ $ApiVersion | ForEach-Object {
             else {
                 $FullModuleVersion = $ModuleMetadata.versions[$CurrentApiVersion].version
             }
-            # Route autorest's internal npm registry calls (fetchPackageMetadata for extension
-            # resolution) through the private feed. The public npm registry is DNS-blocked by
-            # 1ES supply-chain security enforcement on release pipelines.
-            $env:npm_config_registry = "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/"
+            # Pass @autorest/modelerfour as a local --use:<path> argument so autorest loads it
+            # directly from the pre-populated cache without calling fetchPackageMetadata.
+            # fetchPackageMetadata is called unconditionally before the cache check inside
+            # ExtensionManager.findPackage, and it hits the npm registry which is DNS-blocked
+            # by 1ES supply-chain security on release pipelines. A local --use path bypasses
+            # findPackage entirely: the extension goes straight into localExtensions, and when
+            # use-extension in autorest-configuration.md is processed, resolveExtension finds
+            # it there without any registry call.
+            $autorestHome = if ($env:AUTOREST_HOME) { $env:AUTOREST_HOME } else { Join-Path $env:USERPROFILE ".autorest" }
+            $modelerFourPath = Join-Path $autorestHome "@autorest" "modelerfour" "4.24.3" "node_modules" "@autorest" "modelerfour"
+            $modelerFourUseFlag = if (Test-Path $modelerFourPath) { @("--use:$modelerFourPath") } else { @() }
+            if ($modelerFourUseFlag.Count -eq 0) {
+                Write-Host -ForegroundColor Yellow "WARNING: @autorest/modelerfour local cache not found at $modelerFourPath — autorest will attempt npm registry lookup (may fail in network-isolated environment)"
+            }
+
             $autorestLog = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "autorest-$($ModuleFullName -replace '[^a-zA-Z0-9-]', '-').log")
-            npx autorest --verbose --max-memory-size=$MaxMemorySize --module-version:$FullModuleVersion --module-name:$ModuleFullName --service-name:$Module --input-file:$OpenApiFile $AutoRestModuleConfig --max-cpu=2 --network-calls=2 2>&1 | Out-File -FilePath $autorestLog -Encoding utf8
+            npx autorest @modelerFourUseFlag --verbose --max-memory-size=$MaxMemorySize --module-version:$FullModuleVersion --module-name:$ModuleFullName --service-name:$Module --input-file:$OpenApiFile $AutoRestModuleConfig --max-cpu=2 --network-calls=2 2>&1 | Out-File -FilePath $autorestLog -Encoding utf8
             $autorestExitCode = $LASTEXITCODE
             if ($autorestExitCode -ne 0) {
                 Write-Host -ForegroundColor Red "AutoREST failed (exit $autorestExitCode) generating '$ModuleFullName'."

--- a/tools/GenerateServiceModule.ps1
+++ b/tools/GenerateServiceModule.ps1
@@ -79,7 +79,10 @@ $ApiVersion | ForEach-Object {
             # it there without any registry call.
             $autorestHome = if ($env:AUTOREST_HOME) { $env:AUTOREST_HOME } else { Join-Path $env:USERPROFILE ".autorest" }
             $modelerFourPath = Join-Path $autorestHome "@autorest" "modelerfour" "4.24.3" "node_modules" "@autorest" "modelerfour"
-            $modelerFourUseFlag = if (Test-Path $modelerFourPath) { @("--use:$modelerFourPath") } else { @() }
+            # @(if ...) always produces [object[]], preventing PowerShell from unwrapping the
+            # single-element array to a [string] scalar. A scalar string splatted with @
+            # enumerates IEnumerable<char>, passing each character as a separate argument.
+            $modelerFourUseFlag = @(if (Test-Path $modelerFourPath) { "--use:$modelerFourPath" })
             if ($modelerFourUseFlag.Count -eq 0) {
                 Write-Host -ForegroundColor Yellow "WARNING: @autorest/modelerfour local cache not found at $modelerFourPath — autorest will attempt npm registry lookup (may fail in network-isolated environment)"
             }

--- a/tools/GenerateServiceModule.ps1
+++ b/tools/GenerateServiceModule.ps1
@@ -88,7 +88,7 @@ $ApiVersion | ForEach-Object {
             }
 
             $autorestLog = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "autorest-$($ModuleFullName -replace '[^a-zA-Z0-9-]', '-').log")
-            npx autorest @modelerFourUseFlag --verbose --max-memory-size=$MaxMemorySize --module-version:$FullModuleVersion --module-name:$ModuleFullName --service-name:$Module --input-file:$OpenApiFile $AutoRestModuleConfig --max-cpu=2 --network-calls=2 2>&1 | Out-File -FilePath $autorestLog -Encoding utf8
+            npx --no-install autorest @modelerFourUseFlag --verbose --max-memory-size=$MaxMemorySize --module-version:$FullModuleVersion --module-name:$ModuleFullName --service-name:$Module --input-file:$OpenApiFile $AutoRestModuleConfig --max-cpu=2 --network-calls=2 2>&1 | Out-File -FilePath $autorestLog -Encoding utf8
             $autorestExitCode = $LASTEXITCODE
             if ($autorestExitCode -ne 0) {
                 Write-Host -ForegroundColor Red "AutoREST failed (exit $autorestExitCode) generating '$ModuleFullName'."

--- a/tools/ManageGeneratedModule.ps1
+++ b/tools/ManageGeneratedModule.ps1
@@ -47,7 +47,7 @@ foreach ($Package in $NugetPackagesToRemove) {
 # Add nuget packages from generate modules.
 foreach ($Package in $NugetPackagesToAdd) {
     Write-Debug "Executing: dotnet add $ModuleCsProj package $Package"
-    dotnet add $ModuleCsProj package $Package -s https://api.nuget.org/v3/index.json | Out-Null
+    dotnet add $ModuleCsProj package $Package | Out-Null
     if ($LastExitCode) {
         Write-Error "Failed to execute: dotnet add $ModuleCsProj package $Package"
     }

--- a/tools/ReadModuleReadMe.ps1
+++ b/tools/ReadModuleReadMe.ps1
@@ -6,12 +6,24 @@ param(
     [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string] $FieldToRead
 ) 
 $ErrorActionPreference = "Stop"
+
+function ConvertFrom-SimpleYaml {
+    param([string]$Yaml)
+    $result = @{}
+    $Yaml -split "`n" | ForEach-Object {
+        if ($_.Trim() -match '^([^:]+):\s*(.*)$') {
+            $result[$Matches[1].Trim()] = $Matches[2].Trim()
+        }
+    }
+    return $result
+}
+
 $FieldValue = $null
 # Read readme.md.
 $ReadMeContent = Get-Content $ReadMePath -Delimiter "### Versioning"
 if ($ReadMeContent.Length -eq 2) {
     # Convert versioning section to yaml.
-    $VersioningSection = $ReadMeContent[1].Replace("``", "").Replace("yaml", "") | ConvertFrom-Yaml
+    $VersioningSection = $ReadMeContent[1].Replace("``", "").Replace("yaml", "") | ConvertFrom-SimpleYaml
     $FieldValue = $VersioningSection[$FieldToRead]
 }
 return $FieldValue

--- a/tools/ReadModuleReadMe.ps1
+++ b/tools/ReadModuleReadMe.ps1
@@ -6,17 +6,7 @@ param(
     [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string] $FieldToRead
 ) 
 $ErrorActionPreference = "Stop"
-
-function ConvertFrom-SimpleYaml {
-    param([string]$Yaml)
-    $result = @{}
-    $Yaml -split "`n" | ForEach-Object {
-        if ($_.Trim() -match '^([^:]+):\s*(.*)$') {
-            $result[$Matches[1].Trim()] = $Matches[2].Trim()
-        }
-    }
-    return $result
-}
+. "$PSScriptRoot\utilities\utils.ps1"
 
 $FieldValue = $null
 # Read readme.md.

--- a/tools/Utilities/PrePopulateAutorestCache.ps1
+++ b/tools/Utilities/PrePopulateAutorestCache.ps1
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Pre-populates the autorest extension cache so that autorest makes zero npm
+    network calls during module generation.
+
+.DESCRIPTION
+    Autorest resolves extensions from ~/.autorest/<pkg>/<version>/node_modules/.
+    This script pre-installs every extension referenced by
+    autorest-configuration.md into that cache layout.
+    Registry and auth are read from ~/.npmrc (copied from the authenticated
+    .npmrc earlier in the pipeline).
+#>
+
+[CmdletBinding()]
+param()
+
+$extensions = @(
+    "@autorest/core@3.10.4",
+    "@autorest/modelerfour@4.24.3"
+)
+
+foreach ($ext in $extensions) {
+    $parts   = $ext -split '@(?=[^@]+$)'   # split on last @
+    $pkg     = $parts[0]
+    $ver     = $parts[1]
+    $cacheDir = Join-Path $env:USERPROFILE ".autorest\$($pkg.Replace('/','\'))\$ver"
+    $nodeModules = Join-Path $cacheDir "node_modules\$($pkg.Replace('/','\'))"
+
+    if (Test-Path $nodeModules) {
+        Write-Host "Cache already present: $ext"
+        continue
+    }
+
+    New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+    Write-Host "Pre-installing $ext into $cacheDir"
+    npm install $ext --prefix $cacheDir
+    if ($LASTEXITCODE -ne 0) { throw "Failed to pre-install $ext (exit $LASTEXITCODE)" }
+    Write-Host "Done: $ext"
+}

--- a/tools/Utilities/utils.ps1
+++ b/tools/Utilities/utils.ps1
@@ -25,3 +25,17 @@ Function Get-LocalCertificate {
     }
     return $global:DefaultCertificate
 }
+
+<#
+    Converts a simple single-level YAML string into a hashtable.
+#>
+Function ConvertFrom-SimpleYaml {
+    param([string]$Yaml)
+    $result = @{}
+    $Yaml -split "`n" | ForEach-Object {
+        if ($_.Trim() -match '^([^:]+):\s*(.*)$') {
+            $result[$Matches[1].Trim()] = $Matches[2].Trim()
+        }
+    }
+    return $result
+}

--- a/tools/WriteToModuleReadMe.ps1
+++ b/tools/WriteToModuleReadMe.ps1
@@ -7,12 +7,24 @@ param(
     [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string] $NewFieldValue
 ) 
 $ErrorActionPreference = "Stop"
+
+function ConvertFrom-SimpleYaml {
+    param([string]$Yaml)
+    $result = @{}
+    $Yaml -split "`n" | ForEach-Object {
+        if ($_.Trim() -match '^([^:]+):\s*(.*)$') {
+            $result[$Matches[1].Trim()] = $Matches[2].Trim()
+        }
+    }
+    return $result
+}
+
 # Read readme.md.
 $ReadMeContent = Get-Content $ReadMePath -Delimiter "### Versioning"
 if ($ReadMeContent.Length -eq 2) {
     # Convert versioning section to yaml.
     $UpdatedVersionSection = "### Versioning" + $ReadMeContent[1]
-    $VersioningSection = $ReadMeContent[1].Replace("``", "").Replace("yaml", "") | ConvertFrom-Yaml
+    $VersioningSection = $ReadMeContent[1].Replace("``", "").Replace("yaml", "") | ConvertFrom-SimpleYaml
     $FieldValue = $VersioningSection[$FieldName]
     $RegexPattern = "$FieldName`:\s*$FieldValue"
     $UpdatedVersionSection = $UpdatedVersionSection -replace $RegexPattern, "$FieldName`: $NewFieldValue"

--- a/tools/WriteToModuleReadMe.ps1
+++ b/tools/WriteToModuleReadMe.ps1
@@ -26,7 +26,9 @@ if ($ReadMeContent.Length -eq 2) {
     $UpdatedVersionSection = "### Versioning" + $ReadMeContent[1]
     $VersioningSection = $ReadMeContent[1].Replace("``", "").Replace("yaml", "") | ConvertFrom-SimpleYaml
     $FieldValue = $VersioningSection[$FieldName]
-    $RegexPattern = "$FieldName`:\s*$FieldValue"
+    $EscapedFieldName = [regex]::Escape($FieldName)
+    $EscapedFieldValue = [regex]::Escape($FieldValue)
+    $RegexPattern = "$EscapedFieldName`:\s*$EscapedFieldValue"
     $UpdatedVersionSection = $UpdatedVersionSection -replace $RegexPattern, "$FieldName`: $NewFieldValue"
     
     $ReadMeContent[0] = $ReadMeContent[0].Trim()

--- a/tools/WriteToModuleReadMe.ps1
+++ b/tools/WriteToModuleReadMe.ps1
@@ -7,17 +7,7 @@ param(
     [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string] $NewFieldValue
 ) 
 $ErrorActionPreference = "Stop"
-
-function ConvertFrom-SimpleYaml {
-    param([string]$Yaml)
-    $result = @{}
-    $Yaml -split "`n" | ForEach-Object {
-        if ($_.Trim() -match '^([^:]+):\s*(.*)$') {
-            $result[$Matches[1].Trim()] = $Matches[2].Trim()
-        }
-    }
-    return $result
-}
+. "$PSScriptRoot\utilities\utils.ps1"
 
 # Read readme.md.
 $ReadMeContent = Get-Content $ReadMePath -Delimiter "### Versioning"


### PR DESCRIPTION
Ensure all npm calls are skipped during autorest generation release by pre-downloading dependencies from private registry so that the pipeline is compliant with network isolation policies in release job workflow. 