### PR TITLE
fix: Add CredScan suppression for DeviceManagement.Administration v1.0 example

### DIFF
--- a/.azure-pipelines/config/credscan/credscan-suppressions.json
+++ b/.azure-pipelines/config/credscan/credscan-suppressions.json
@@ -58,6 +58,12 @@
     },
     {
       "file": [
+        "src\\DeviceManagement.Administration\\v1.0\\examples\\Update-MgDeviceManagementVirtualEndpointOnPremiseConnectionAdDomainPassword.md"
+      ],
+      "_justification": "[DeviceManagement.Administration] Examples contain random values recognized as secret"
+    },
+    {
+      "file": [
         "src\\Users.Actions\\v1.0\\examples\\Reset-MgUserAuthenticationMethodPassword.md"
       ],
       "_justification": "[Users.Actions] Examples contain random values recognized as secret"


### PR DESCRIPTION
## Summary

Adds a CredScan suppression entry for the v1.0 example file:
- \src/DeviceManagement.Administration/v1.0/examples/Update-MgDeviceManagementVirtualEndpointOnPremiseConnectionAdDomainPassword.md\

This file contains a **placeholder password** (\AdDomainPassword_XXXX\) in its code snippet, which is not a real credential. The suppression follows the existing pattern used for similar example files (e.g., the beta counterpart under DeviceManagement.Actions).

## Changes
- Updated \.azure-pipelines/config/credscan/credscan-suppressions.json\ to suppress the false positive.