### PR TITLE
Address auth ALC review comments

### DIFF
--- a/src/Authentication/Authentication/Microsoft.Graph.Authentication.psm1
+++ b/src/Authentication/Authentication/Microsoft.Graph.Authentication.psm1
@@ -53,7 +53,7 @@ namespace Microsoft.Graph.PowerShell.Authentication.Loader
 
         private static Assembly Resolve(AssemblyLoadContext context, AssemblyName assemblyName)
         {
-            if (context == null || assemblyName == null)
+            if (context == null || assemblyName == null || string.IsNullOrWhiteSpace(assemblyName.Name))
             {
                 return null;
             }
@@ -91,7 +91,7 @@ function Import-GraphAuthenticationAssembly {
     )
 
     if ($PSEdition -ne 'Core' -or -not ('System.Runtime.Loader.AssemblyLoadContext' -as [type])) {
-        return Import-Module -Name $ModulePath -PassThru
+        return Import-Module -LiteralPath $ModulePath -PassThru
     }
 
     $loadContextName = Get-GraphAuthenticationLoadContextName -ModulePath $ModulePath

--- a/src/Authentication/Authentication/test/Microsoft.Graph.Authentication.Tests.ps1
+++ b/src/Authentication/Authentication/test/Microsoft.Graph.Authentication.Tests.ps1
@@ -117,9 +117,7 @@ public static class GraphAuthenticationAssemblyLoadContextTestHelper
 
             $dependencyAssembly.GetName().Name | Should -Be 'Azure.Core'
             $dependencyContext.Name | Should -Be $loadContext.Name
-            [System.Runtime.Loader.AssemblyLoadContext]::Default.Assemblies |
-                Where-Object { $_.GetName().Name -eq 'Azure.Core' } |
-                Should -BeNullOrEmpty
+            [object]::ReferenceEquals($dependencyContext, [System.Runtime.Loader.AssemblyLoadContext]::Default) | Should -BeFalse
         }
     }
 }


### PR DESCRIPTION
### Changes proposed in this pull request

- Guard `assemblyName.Name` before using it in the managed ALC resolver.
- Use `Import-Module -LiteralPath` for the Desktop/no-ALC fallback path.
- Relax the worker-thread dependency resolution test so it does not assume `Azure.Core` is absent from `AssemblyLoadContext.Default`.

### Why

This addresses the inline Copilot review comments from #3633 and the earlier test flakiness concern from #3632.

The production resolver should treat a missing assembly name as an ordinary resolution miss and return `null`. The Desktop fallback should import the exact DLL path instead of allowing wildcard interpretation. The test only needs to prove that the dependency resolved by the worker thread lands in the same non-default Graph authentication ALC; it should not fail merely because another test loaded `Azure.Core` in the default context.

### Validation

- `pwsh -NoProfile -Command 'Invoke-Pester .\src\Authentication\Authentication\test\Microsoft.Graph.Authentication.Tests.ps1 -Output Detailed'`
  - 8 tests passed
- PowerShell parser validation for `Microsoft.Graph.Authentication.psm1`
- `git diff --check`

### Other links

- Follow-up to #3633
- Addresses #3633 Copilot comments:
  - https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/3633#discussion_r3359266266
  - https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/3633#discussion_r3359266277
- Also addresses earlier Copilot test-flakiness concern from #3632:
  - https://github.com/microsoftgraph/msgraph-sdk-powershell/pull/3632#discussion_r3359241275