### PR TITLE
ci: upgrade to Node 20 for Windows long path support

### DIFF
--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -28,7 +28,7 @@ steps:
   - task: NodeTool@0
     displayName: Install NodeJs
     inputs:
-      versionSpec: 18.x
+      versionSpec: 20.x
 
   - task: PowerShell@2
     displayName: Configure private npm feed
@@ -96,6 +96,7 @@ steps:
       pwsh: true
       workingDirectory: "autorest.powershell"
       script: |
+        $env:RUSH_ALLOW_UNSUPPORTED_NODEJS = '1'
         npx --no-install rush install
         if ($LASTEXITCODE -ne 0) { throw "rush install failed with exit code $LASTEXITCODE" }
         npx --no-install rush link

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -31,6 +31,70 @@ steps:
       versionSpec: 20.x
 
   - task: PowerShell@2
+    displayName: Enable Win32 long paths for Node.js
+    inputs:
+      targetType: inline
+      pwsh: true
+      script: |
+        # 1. Enable long paths at the OS level
+        reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+        if ($LASTEXITCODE -ne 0) { Write-Warning "Failed to set LongPathsEnabled registry key (may require admin)" }
+
+        # 2. Patch node.exe manifest to declare longPathAware
+        $nodePath = (Get-Command node).Source
+        Write-Host "Node.js path: $nodePath"
+        Write-Host "Node.js version: $(node --version)"
+
+        $manifestContent = @"
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+          <application xmlns="urn:schemas-microsoft-com:asm.v3">
+            <windowsSettings>
+              <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+            </windowsSettings>
+          </application>
+        </assembly>
+        "@
+
+        $manifestPath = Join-Path ([System.IO.Path]::GetTempPath()) "node-longpath.manifest"
+        $manifestContent | Set-Content -Path $manifestPath -Encoding UTF8
+
+        # Find mt.exe from Windows SDK
+        $mtCandidates = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter "mt.exe" -ErrorAction SilentlyContinue |
+            Where-Object { $_.DirectoryName -match 'x64' } |
+            Sort-Object { $_.DirectoryName } -Descending
+        
+        if ($mtCandidates) {
+            $mtPath = $mtCandidates[0].FullName
+            Write-Host "Using mt.exe: $mtPath"
+            & $mtPath -manifest $manifestPath -outputresource:"$nodePath;#1" -nologo
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "Successfully patched node.exe manifest for long path support"
+            } else {
+                Write-Warning "mt.exe failed with exit code $LASTEXITCODE - trying external manifest approach"
+                Copy-Item $manifestPath -Destination "$nodePath.manifest" -Force
+                Write-Host "Placed external manifest at $nodePath.manifest"
+                # Enable external manifest preference
+                reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\SideBySide" /v PreferExternalManifest /t REG_DWORD /d 1 /f
+            }
+        } else {
+            Write-Warning "mt.exe not found - using external manifest approach"
+            Copy-Item $manifestPath -Destination "$nodePath.manifest" -Force
+            Write-Host "Placed external manifest at $nodePath.manifest"
+            reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\SideBySide" /v PreferExternalManifest /t REG_DWORD /d 1 /f
+        }
+
+        # 3. Verify: try creating a file with a long name
+        $testDir = Join-Path ([System.IO.Path]::GetTempPath()) "longpath-test"
+        New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+        $longName = "A" * 250 + ".txt"
+        $testPath = Join-Path $testDir $longName
+        Write-Host "Testing long path creation (total length: $($testPath.Length) chars)..."
+        $result = node -e "const fs = require('fs'); try { fs.writeFileSync('$($testPath -replace '\\','\\\\')','test'); console.log('SUCCESS: Long path write works'); fs.unlinkSync('$($testPath -replace '\\','\\\\')'); } catch(e) { console.error('FAILED:', e.message); process.exit(1); }"
+        Write-Host $result
+        Remove-Item $testDir -Recurse -Force -ErrorAction SilentlyContinue
+
+  - task: PowerShell@2
     displayName: Configure private npm feed
     inputs:
       targetType: filePath

--- a/.azure-pipelines/generation-templates/individual-workload-module.yml
+++ b/.azure-pipelines/generation-templates/individual-workload-module.yml
@@ -26,7 +26,7 @@ steps:
       targetType: inline
       pwsh: true
       script: |
-        . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -EnableSigning:$${{ parameters.Sign }} -Build -ExcludeExampleTemplates -ExcludeNotesSection -ModuleToGenerate ${{ parameters.ModuleName }} -ApiVersion ${{ parameters.ModuleVersion }}
+        . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -EnableSigning:$${{ parameters.Sign }} -Build -ExcludeExampleTemplates -ExcludeNotesSection -ModuleToGenerate ${{ parameters.ModuleName }} -ApiVersion ${{ parameters.ModuleVersion }} -AllowUnsupportedNode
   - template: ../common-templates/guardian-analyzer.yml
 
   - task: PowerShell@2
@@ -36,7 +36,7 @@ steps:
       targetType: inline
       pwsh: true
       script: |
-        . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -SkipGeneration -Test -ModuleToGenerate ${{ parameters.ModuleName }} -ApiVersion ${{ parameters.ModuleVersion }}
+        . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -SkipGeneration -Test -ModuleToGenerate ${{ parameters.ModuleName }} -ApiVersion ${{ parameters.ModuleVersion }} -AllowUnsupportedNode
 
   - task: PowerShell@2
     displayName: Find Duplicate Commands

--- a/.azure-pipelines/generation-templates/workload-modules.yml
+++ b/.azure-pipelines/generation-templates/workload-modules.yml
@@ -19,7 +19,7 @@ steps:
       targetType: inline
       pwsh: true
       script: |
-        . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -EnableSigning:$${{ parameters.Sign }} -Build -ExcludeExampleTemplates -ExcludeNotesSection
+        . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -EnableSigning:$${{ parameters.Sign }} -Build -ExcludeExampleTemplates -ExcludeNotesSection -AllowUnsupportedNode
 
   - template: ../common-templates/guardian-analyzer.yml
 
@@ -30,7 +30,7 @@ steps:
       targetType: inline
       pwsh: true
       script: |
-        . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -SkipGeneration -Test
+        . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -SkipGeneration -Test -AllowUnsupportedNode
 
   - task: PowerShell@2
     displayName: Find Duplicate Commands
@@ -93,4 +93,4 @@ steps:
           targetType: inline
           pwsh: true
           script: |
-            . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -SkipGeneration -Pack -ArtifactsLocation $(Build.ArtifactStagingDirectory)
+            . $(System.DefaultWorkingDirectory)/tools/GenerateModules.ps1 -SkipGeneration -Pack -ArtifactsLocation $(Build.ArtifactStagingDirectory) -AllowUnsupportedNode

--- a/openApiDocs/beta/Identity.Governance.yml
+++ b/openApiDocs/beta/Identity.Governance.yml
@@ -5700,6 +5700,48 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/identityGovernance/accessReviews/decisions/{accessReviewInstanceDecisionItem-id}/instance/microsoft.graph.batchApplyCustomDataProvidedResourceDecisions':
+    post:
+      tags:
+        - identityGovernance.accessReviewSet
+      summary: Invoke action batchApplyCustomDataProvidedResourceDecisions
+      description: 'Enables reviewers to set the applyResult and applyDescription on all accessReviewInstanceDecisionItem objects in batches by using customDataProvidedResourceId. NOTE: The access review instance must be in an Applying state.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/accessreviewinstance-batchapplycustomdataprovidedresourcedecisions?view=graph-rest-beta
+      operationId: identityGovernance.accessReview.decision.instance_batchApplyCustomDataProvidedResourceDecision
+      parameters:
+        - name: accessReviewInstanceDecisionItem-id
+          in: path
+          description: The unique identifier of accessReviewInstanceDecisionItem
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstanceDecisionItem
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                applyResult:
+                  $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItemApplyResult'
+                applyDescription:
+                  type: string
+                  nullable: true
+                customDataProvidedResourceId:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   '/identityGovernance/accessReviews/decisions/{accessReviewInstanceDecisionItem-id}/instance/microsoft.graph.batchRecordDecisions':
     post:
       tags:
@@ -9051,6 +9093,64 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances/{accessReviewInstance-id}/decisions/{accessReviewInstanceDecisionItem-id}/instance/microsoft.graph.batchApplyCustomDataProvidedResourceDecisions':
+    post:
+      tags:
+        - identityGovernance.accessReviewSet
+      summary: Invoke action batchApplyCustomDataProvidedResourceDecisions
+      description: 'Enables reviewers to set the applyResult and applyDescription on all accessReviewInstanceDecisionItem objects in batches by using customDataProvidedResourceId. NOTE: The access review instance must be in an Applying state.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/accessreviewinstance-batchapplycustomdataprovidedresourcedecisions?view=graph-rest-beta
+      operationId: identityGovernance.accessReview.definition.instance.decision.instance_batchApplyCustomDataProvidedResourceDecision
+      parameters:
+        - name: accessReviewScheduleDefinition-id
+          in: path
+          description: The unique identifier of accessReviewScheduleDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewScheduleDefinition
+        - name: accessReviewInstance-id
+          in: path
+          description: The unique identifier of accessReviewInstance
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstance
+        - name: accessReviewInstanceDecisionItem-id
+          in: path
+          description: The unique identifier of accessReviewInstanceDecisionItem
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstanceDecisionItem
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                applyResult:
+                  $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItemApplyResult'
+                applyDescription:
+                  type: string
+                  nullable: true
+                customDataProvidedResourceId:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   '/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances/{accessReviewInstance-id}/decisions/{accessReviewInstanceDecisionItem-id}/instance/microsoft.graph.batchRecordDecisions':
     post:
       tags:
@@ -11048,6 +11148,56 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: accessReviewInstance
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances/{accessReviewInstance-id}/microsoft.graph.batchApplyCustomDataProvidedResourceDecisions':
+    post:
+      tags:
+        - identityGovernance.accessReviewSet
+      summary: Invoke action batchApplyCustomDataProvidedResourceDecisions
+      description: 'Enables reviewers to set the applyResult and applyDescription on all accessReviewInstanceDecisionItem objects in batches by using customDataProvidedResourceId. NOTE: The access review instance must be in an Applying state.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/accessreviewinstance-batchapplycustomdataprovidedresourcedecisions?view=graph-rest-beta
+      operationId: identityGovernance.accessReview.definition.instance_batchApplyCustomDataProvidedResourceDecision
+      parameters:
+        - name: accessReviewScheduleDefinition-id
+          in: path
+          description: The unique identifier of accessReviewScheduleDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewScheduleDefinition
+        - name: accessReviewInstance-id
+          in: path
+          description: The unique identifier of accessReviewInstance
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstance
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                applyResult:
+                  $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItemApplyResult'
+                applyDescription:
+                  type: string
+                  nullable: true
+                customDataProvidedResourceId:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
       responses:
         2XX:
           description: Success
@@ -13920,6 +14070,72 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances/{accessReviewInstance-id}/stages/{accessReviewStage-id}/decisions/{accessReviewInstanceDecisionItem-id}/instance/microsoft.graph.batchApplyCustomDataProvidedResourceDecisions':
+    post:
+      tags:
+        - identityGovernance.accessReviewSet
+      summary: Invoke action batchApplyCustomDataProvidedResourceDecisions
+      description: 'Enables reviewers to set the applyResult and applyDescription on all accessReviewInstanceDecisionItem objects in batches by using customDataProvidedResourceId. NOTE: The access review instance must be in an Applying state.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/accessreviewinstance-batchapplycustomdataprovidedresourcedecisions?view=graph-rest-beta
+      operationId: identityGovernance.accessReview.definition.instance.stage.decision.instance_batchApplyCustomDataProvidedResourceDecision
+      parameters:
+        - name: accessReviewScheduleDefinition-id
+          in: path
+          description: The unique identifier of accessReviewScheduleDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewScheduleDefinition
+        - name: accessReviewInstance-id
+          in: path
+          description: The unique identifier of accessReviewInstance
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstance
+        - name: accessReviewStage-id
+          in: path
+          description: The unique identifier of accessReviewStage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewStage
+        - name: accessReviewInstanceDecisionItem-id
+          in: path
+          description: The unique identifier of accessReviewInstanceDecisionItem
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstanceDecisionItem
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                applyResult:
+                  $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItemApplyResult'
+                applyDescription:
+                  type: string
+                  nullable: true
+                customDataProvidedResourceId:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   '/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances/{accessReviewInstance-id}/stages/{accessReviewStage-id}/decisions/{accessReviewInstanceDecisionItem-id}/instance/microsoft.graph.batchRecordDecisions':
     post:
       tags:
@@ -16707,6 +16923,56 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/identityGovernance/accessReviews/instances/{accessReviewInstance-id}/decisions/{accessReviewInstanceDecisionItem-id}/instance/microsoft.graph.batchApplyCustomDataProvidedResourceDecisions':
+    post:
+      tags:
+        - identityGovernance.accessReviewSet
+      summary: Invoke action batchApplyCustomDataProvidedResourceDecisions
+      description: 'Enables reviewers to set the applyResult and applyDescription on all accessReviewInstanceDecisionItem objects in batches by using customDataProvidedResourceId. NOTE: The access review instance must be in an Applying state.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/accessreviewinstance-batchapplycustomdataprovidedresourcedecisions?view=graph-rest-beta
+      operationId: identityGovernance.accessReview.instance.decision.instance_batchApplyCustomDataProvidedResourceDecision
+      parameters:
+        - name: accessReviewInstance-id
+          in: path
+          description: The unique identifier of accessReviewInstance
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstance
+        - name: accessReviewInstanceDecisionItem-id
+          in: path
+          description: The unique identifier of accessReviewInstanceDecisionItem
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstanceDecisionItem
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                applyResult:
+                  $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItemApplyResult'
+                applyDescription:
+                  type: string
+                  nullable: true
+                customDataProvidedResourceId:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   '/identityGovernance/accessReviews/instances/{accessReviewInstance-id}/decisions/{accessReviewInstanceDecisionItem-id}/instance/microsoft.graph.batchRecordDecisions':
     post:
       tags:
@@ -18440,6 +18706,48 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: accessReviewInstance
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/identityGovernance/accessReviews/instances/{accessReviewInstance-id}/microsoft.graph.batchApplyCustomDataProvidedResourceDecisions':
+    post:
+      tags:
+        - identityGovernance.accessReviewSet
+      summary: Invoke action batchApplyCustomDataProvidedResourceDecisions
+      description: 'Enables reviewers to set the applyResult and applyDescription on all accessReviewInstanceDecisionItem objects in batches by using customDataProvidedResourceId. NOTE: The access review instance must be in an Applying state.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/accessreviewinstance-batchapplycustomdataprovidedresourcedecisions?view=graph-rest-beta
+      operationId: identityGovernance.accessReview.instance_batchApplyCustomDataProvidedResourceDecision
+      parameters:
+        - name: accessReviewInstance-id
+          in: path
+          description: The unique identifier of accessReviewInstance
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstance
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                applyResult:
+                  $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItemApplyResult'
+                applyDescription:
+                  type: string
+                  nullable: true
+                customDataProvidedResourceId:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
       responses:
         2XX:
           description: Success
@@ -20910,6 +21218,64 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: accessReviewInstanceDecisionItem
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/identityGovernance/accessReviews/instances/{accessReviewInstance-id}/stages/{accessReviewStage-id}/decisions/{accessReviewInstanceDecisionItem-id}/instance/microsoft.graph.batchApplyCustomDataProvidedResourceDecisions':
+    post:
+      tags:
+        - identityGovernance.accessReviewSet
+      summary: Invoke action batchApplyCustomDataProvidedResourceDecisions
+      description: 'Enables reviewers to set the applyResult and applyDescription on all accessReviewInstanceDecisionItem objects in batches by using customDataProvidedResourceId. NOTE: The access review instance must be in an Applying state.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/accessreviewinstance-batchapplycustomdataprovidedresourcedecisions?view=graph-rest-beta
+      operationId: identityGovernance.accessReview.instance.stage.decision.instance_batchApplyCustomDataProvidedResourceDecision
+      parameters:
+        - name: accessReviewInstance-id
+          in: path
+          description: The unique identifier of accessReviewInstance
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstance
+        - name: accessReviewStage-id
+          in: path
+          description: The unique identifier of accessReviewStage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewStage
+        - name: accessReviewInstanceDecisionItem-id
+          in: path
+          description: The unique identifier of accessReviewInstanceDecisionItem
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessReviewInstanceDecisionItem
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                applyResult:
+                  $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItemApplyResult'
+                applyDescription:
+                  type: string
+                  nullable: true
+                customDataProvidedResourceId:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
       responses:
         2XX:
           description: Success
@@ -24847,6 +25213,7 @@ paths:
       tags:
         - identityGovernance.accessPackageCatalog
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -25275,6 +25642,420 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get the number of the resource
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -25416,6 +26197,7 @@ paths:
       tags:
         - identityGovernance.accessPackageCatalog
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -25788,6 +26570,372 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get the number of the resource
+      operationId: identityGovernance.catalog.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -27307,6 +28455,7 @@ paths:
       tags:
         - identityGovernance.accessPackageCatalog
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -27791,6 +28940,468 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get the number of the resource
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -27956,6 +29567,7 @@ paths:
       tags:
         - identityGovernance.accessPackageCatalog
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -28384,6 +29996,420 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get the number of the resource
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -29627,6 +31653,7 @@ paths:
       tags:
         - identityGovernance.accessPackageCatalog
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -30111,6 +32138,468 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get the number of the resource
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -30276,6 +32765,7 @@ paths:
       tags:
         - identityGovernance.accessPackageCatalog
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -30704,6 +33194,420 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get the number of the resource
+      operationId: identityGovernance.catalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -30845,6 +33749,7 @@ paths:
       tags:
         - identityGovernance.accessPackageCatalog
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.catalog.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -30940,7 +33845,11 @@ paths:
     get:
       tags:
         - identityGovernance.accessPackageCatalog
-      summary: Get uploadSessions from identityGovernance
+      summary: List customDataProvidedResourceUploadSession objects
+      description: Get a list of the customDataProvidedResourceUploadSession objects and their properties.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/accesspackageresource-list-uploadsessions?view=graph-rest-beta
       operationId: identityGovernance.catalog.accessPackageResource_ListUploadSession
       parameters:
         - name: accessPackageCatalog-id
@@ -31011,7 +33920,11 @@ paths:
     post:
       tags:
         - identityGovernance.accessPackageCatalog
-      summary: Create new navigation property to uploadSessions for identityGovernance
+      summary: Create customDataProvidedResourceUploadSession
+      description: 'Create a customDataProvidedResourceUploadSession object. Only one upload session is allowed per reference instance (for example, access review instance) and customDataProvidedResource pair. Once you create an upload session, upload files, and complete the session, the data is processed and you cannot create another upload session for that same pair. If you encounter errors with files uploaded or need to start fresh, you can delete the active upload session to create a new one.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/customdataprovidedresource-post-uploadsessions?view=graph-rest-beta
       operationId: identityGovernance.catalog.accessPackageResource_CreateUploadSession
       parameters:
         - name: accessPackageCatalog-id
@@ -31056,7 +33969,11 @@ paths:
     get:
       tags:
         - identityGovernance.accessPackageCatalog
-      summary: Get uploadSessions from identityGovernance
+      summary: Get customDataProvidedResourceUploadSession
+      description: Read the properties and relationships of a customDataProvidedResourceUploadSession object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/customdataprovidedresourceuploadsession-get?view=graph-rest-beta
       operationId: identityGovernance.catalog.accessPackageResource_GetUploadSession
       parameters:
         - name: accessPackageCatalog-id
@@ -31121,7 +34038,11 @@ paths:
     patch:
       tags:
         - identityGovernance.accessPackageCatalog
-      summary: Update the navigation property uploadSessions in identityGovernance
+      summary: Update customDataProvidedResourceUploadSession
+      description: Update the properties of a customDataProvidedResourceUploadSession created for a customDataProvidedResource object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/customdataprovidedresourceuploadsession-update?view=graph-rest-beta
       operationId: identityGovernance.catalog.accessPackageResource_UpdateUploadSession
       parameters:
         - name: accessPackageCatalog-id
@@ -31173,7 +34094,11 @@ paths:
     delete:
       tags:
         - identityGovernance.accessPackageCatalog
-      summary: Delete navigation property uploadSessions for identityGovernance
+      summary: Delete customDataProvidedResourceUploadSession
+      description: Delete a customDataProvidedResourceUploadSession object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/accesspackageresource-delete-uploadsessions?view=graph-rest-beta
       operationId: identityGovernance.catalog.accessPackageResource_DeleteUploadSession
       parameters:
         - name: accessPackageCatalog-id
@@ -31217,6 +34142,372 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get the number of the resource
+      operationId: identityGovernance.catalog.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -32656,6 +35947,7 @@ paths:
       tags:
         - identityGovernance.accessPackageCatalog
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -33084,6 +36376,420 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get the number of the resource
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -33543,6 +37249,7 @@ paths:
       tags:
         - identityGovernance.accessPackageCatalog
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -33915,6 +37622,372 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.accessPackageCatalog
+      summary: Get the number of the resource
+      operationId: identityGovernance.catalog.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/catalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -38500,6 +42573,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignmentResourceRole-id
@@ -38837,6 +42911,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -38939,6 +43349,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignmentResourceRole-id
@@ -39220,6 +43631,294 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -40220,6 +44919,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignmentResourceRole-id
@@ -40557,6 +45257,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -40899,6 +45935,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignmentResourceRole-id
@@ -41180,6 +46217,294 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -44580,6 +49905,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignment-id
@@ -44973,6 +50299,390 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -45099,6 +50809,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignment-id
@@ -45436,6 +51147,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -46628,6 +52675,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignment-id
@@ -47021,6 +53069,390 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -47435,6 +53867,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignment-id
@@ -47772,6 +54205,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackage/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -52126,6 +58895,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignment-id
@@ -52519,6 +59289,390 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -52645,6 +59799,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignment-id
@@ -52982,6 +60137,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -54174,6 +61665,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignment-id
@@ -54567,6 +62059,390 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -54981,6 +62857,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageAssignment-id
@@ -55318,6 +63195,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageAssignment.accessPackageAssignmentResourceRole.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageAssignment-id
+          in: path
+          description: The unique identifier of accessPackageAssignment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignment
+        - name: accessPackageAssignmentResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageAssignmentResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageAssignmentResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageAssignments/{accessPackageAssignment-id}/accessPackageAssignmentResourceRoles/{accessPackageAssignmentResourceRole-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -58233,6 +66446,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -58661,6 +66875,420 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -58802,6 +67430,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -59174,6 +67803,372 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -60697,6 +69692,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -61181,6 +70177,468 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -61346,6 +70804,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -61774,6 +71233,420 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -63017,6 +72890,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -63501,6 +73375,468 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -63666,6 +74002,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -64094,6 +74431,420 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -64235,6 +74986,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -64330,8 +75082,7 @@ paths:
     get:
       tags:
         - identityGovernance.entitlementManagement
-      summary: Get customDataProvidedResourceUploadSession
-      description: Read the properties and relationships of a customDataProvidedResourceUploadSession object.
+      summary: Get uploadSessions from identityGovernance
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource_ListUploadSession
       parameters:
         - name: accessPackageCatalog-id
@@ -64402,11 +75153,7 @@ paths:
     post:
       tags:
         - identityGovernance.entitlementManagement
-      summary: Create customDataProvidedResourceUploadSession
-      description: Create a new customDataProvidedResourceUploadSession object.
-      externalDocs:
-        description: Find more info here
-        url: https://learn.microsoft.com/graph/api/customdataprovidedresource-post-uploadsessions?view=graph-rest-beta
+      summary: Create new navigation property to uploadSessions for identityGovernance
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource_CreateUploadSession
       parameters:
         - name: accessPackageCatalog-id
@@ -64451,11 +75198,7 @@ paths:
     get:
       tags:
         - identityGovernance.entitlementManagement
-      summary: Get customDataProvidedResourceUploadSession
-      description: Read the properties and relationships of a customDataProvidedResourceUploadSession object.
-      externalDocs:
-        description: Find more info here
-        url: https://learn.microsoft.com/graph/api/customdataprovidedresourceuploadsession-get?view=graph-rest-beta
+      summary: Get uploadSessions from identityGovernance
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource_GetUploadSession
       parameters:
         - name: accessPackageCatalog-id
@@ -64520,11 +75263,7 @@ paths:
     patch:
       tags:
         - identityGovernance.entitlementManagement
-      summary: Update customDataProvidedResourceUploadSession
-      description: Update the properties of a customDataProvidedResourceUploadSession created for a customDataProvidedResource object.
-      externalDocs:
-        description: Find more info here
-        url: https://learn.microsoft.com/graph/api/customdataprovidedresourceuploadsession-update?view=graph-rest-beta
+      summary: Update the navigation property uploadSessions in identityGovernance
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource_UpdateUploadSession
       parameters:
         - name: accessPackageCatalog-id
@@ -64620,6 +75359,372 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -66059,6 +77164,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -66487,6 +77593,420 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -66946,6 +78466,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageCatalog-id
@@ -67318,6 +78839,372 @@ paths:
         date: '2023-03-01'
         version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
+  '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageCatalog.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageCatalog-id
+          in: path
+          description: The unique identifier of accessPackageCatalog
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageCatalog
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2023-12-31'
+        date: '2023-03-01'
+        version: 2022-10/PrivatePreview:MicrosofEntitlementManagementCustomextensions
   '/identityGovernance/entitlementManagement/accessPackageCatalogs/{accessPackageCatalog-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -70231,6 +82118,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageResourceRoleScope-id
@@ -70568,6 +82456,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -70670,6 +82894,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageResourceRoleScope-id
@@ -70951,6 +83176,294 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -71951,6 +84464,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageResourceRoleScope-id
@@ -72288,6 +84802,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -72630,6 +85480,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageResourceRoleScope-id
@@ -72911,6 +85762,294 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -74080,6 +87219,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageResource-id
@@ -74473,6 +87613,390 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -74599,6 +88123,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageResource-id
@@ -74936,6 +88461,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -75906,6 +89767,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageResource-id
@@ -76299,6 +90161,390 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -76425,6 +90671,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageResource-id
@@ -76762,6 +91009,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -76864,6 +91447,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackageResource-id
@@ -77145,6 +91729,294 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackageResource-id
+          in: path
+          description: The unique identifier of accessPackageResource
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResource
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackageResources/{accessPackageResource-id}/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -80246,6 +95118,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackage-id
@@ -80639,6 +95512,390 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/accessPackageResourceScopes/{accessPackageResourceScope-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -80765,6 +96022,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackage-id
@@ -81102,6 +96360,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceRole/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -82294,6 +97888,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackage-id
@@ -82687,6 +98282,390 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.accessPackageResourceRole.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: accessPackageResourceRole-id
+          in: path
+          description: The unique identifier of accessPackageResourceRole
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRole
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/accessPackageResourceRoles/{accessPackageResourceRole-id}/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -83101,6 +99080,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnector from identityGovernance
+      description: The connector that integrates with external origin systems to provision access to resources from those systems. Read-only. Nullable.
       operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource_GetExternalOriginResourceConnector
       parameters:
         - name: accessPackage-id
@@ -83438,6 +99418,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_ListFile
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get files from identityGovernance
+      description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_GetFile
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/{customDataProvidedResourceFile-id}/$value':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get media content for the navigation property files from identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_GetFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Update media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_SetFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Delete media content for the navigation property files in identityGovernance
+      description: The unique identifier for an entity. Read-only.
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession_DeleteFilesContent
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - name: customDataProvidedResourceFile-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceFile
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceFile
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/files/$count':
+    get:
+      tags:
+        - identityGovernance.entitlementManagement
+      summary: Get the number of the resource
+      operationId: identityGovernance.entitlementManagement.accessPackage.accessPackageResourceRoleScope.accessPackageResourceScope.accessPackageResource.uploadSession.file_GetCount
+      parameters:
+        - name: accessPackage-id
+          in: path
+          description: The unique identifier of accessPackage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackage
+        - name: accessPackageResourceRoleScope-id
+          in: path
+          description: The unique identifier of accessPackageResourceRoleScope
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: accessPackageResourceRoleScope
+        - name: customDataProvidedResourceUploadSession-id
+          in: path
+          description: The unique identifier of customDataProvidedResourceUploadSession
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: customDataProvidedResourceUploadSession
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}/accessPackageResourceRoleScopes/{accessPackageResourceRoleScope-id}/accessPackageResourceScope/accessPackageResource/uploadSessions/{customDataProvidedResourceUploadSession-id}/microsoft.graph.uploadFile':
     post:
       tags:
@@ -86943,7 +103259,11 @@ paths:
     get:
       tags:
         - identityGovernance.entitlementManagement
-      summary: Get externalOriginResourceConnectors from identityGovernance
+      summary: List externalOriginResourceConnectors
+      description: Get a list of externalOriginResourceConnector objects and their properties.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/entitlementmanagement-list-externaloriginresourceconnectors?view=graph-rest-beta
       operationId: identityGovernance.entitlementManagement_ListExternalOriginResourceConnector
       parameters:
         - $ref: '#/components/parameters/top'
@@ -86993,7 +103313,11 @@ paths:
     post:
       tags:
         - identityGovernance.entitlementManagement
-      summary: Create new navigation property to externalOriginResourceConnectors for identityGovernance
+      summary: Create externalOriginResourceConnector
+      description: Creates a new externalOriginResourceConnector object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/entitlementmanagement-post-externaloriginresourceconnectors?view=graph-rest-beta
       operationId: identityGovernance.entitlementManagement_CreateExternalOriginResourceConnector
       requestBody:
         description: New navigation property
@@ -87017,6 +103341,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get externalOriginResourceConnectors from identityGovernance
+      description: Represents the connectors used to communicate with external resource systems.
       operationId: identityGovernance.entitlementManagement_GetExternalOriginResourceConnector
       parameters:
         - name: externalOriginResourceConnector-id
@@ -87060,7 +103385,11 @@ paths:
     patch:
       tags:
         - identityGovernance.entitlementManagement
-      summary: Update the navigation property externalOriginResourceConnectors in identityGovernance
+      summary: Update externalOriginResourceConnector
+      description: Update the properties of an externalOriginResourceConnector object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/externaloriginresourceconnector-update?view=graph-rest-beta
       operationId: identityGovernance.entitlementManagement_UpdateExternalOriginResourceConnector
       parameters:
         - name: externalOriginResourceConnector-id
@@ -87091,7 +103420,11 @@ paths:
     delete:
       tags:
         - identityGovernance.entitlementManagement
-      summary: Delete navigation property externalOriginResourceConnectors for identityGovernance
+      summary: Delete externalOriginResourceConnector
+      description: Delete an externalOriginResourceConnector object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/externaloriginresourceconnector-delete?view=graph-rest-beta
       operationId: identityGovernance.entitlementManagement_DeleteExternalOriginResourceConnector
       parameters:
         - name: externalOriginResourceConnector-id
@@ -87218,7 +103551,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Get accessPackageSubject
-      description: Get the properties of an existing accessPackageSubject object.
+      description: Get the properties of an external directory user represented by an existing accessPackageSubject object.
       externalDocs:
         description: Find more info here
         url: https://learn.microsoft.com/graph/api/accesspackagesubject-get?view=graph-rest-beta
@@ -87340,7 +103673,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Update accessPackageSubject
-      description: Update an existing accessPackageSubject object to change the subject lifecycle.
+      description: Update an external directory user represented by an existing accessPackageSubject object to change the subject lifecycle.
       externalDocs:
         description: Find more info here
         url: https://learn.microsoft.com/graph/api/accesspackagesubject-update?view=graph-rest-beta
@@ -87493,7 +103826,7 @@ paths:
       tags:
         - identityGovernance.entitlementManagement
       summary: Update accessPackageSubject
-      description: Update an existing accessPackageSubject object to change the subject lifecycle.
+      description: Update an external directory user represented by an existing accessPackageSubject object to change the subject lifecycle.
       externalDocs:
         description: Find more info here
         url: https://learn.microsoft.com/graph/api/accesspackagesubject-update?view=graph-rest-beta
@@ -87887,7 +104220,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.customTaskExtension.createdBy_GetMailboxSetting
       parameters:
         - name: customTaskExtension-id
@@ -88089,7 +104422,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.customTaskExtension.lastModifiedBy_GetMailboxSetting
       parameters:
         - name: customTaskExtension-id
@@ -88631,7 +104964,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.createdBy_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -88969,7 +105302,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.lastModifiedBy_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -89196,6 +105529,48 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/identityGovernance/lifecycleWorkflows/deletedItems/workflows/{workflow-id}/microsoft.graph.identityGovernance.cancelProcessing':
+    post:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Invoke action cancelProcessing
+      description: Cancel one or more workflow runs that are currently in queued or inProgress status. Currently limited to canceling one run per request.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/identitygovernance-workflow-cancelprocessing?view=graph-rest-beta
+      operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow_cancelProcessing
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                scope:
+                  $ref: '#/components/schemas/microsoft.graph.identityGovernance.cancelScope'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-10-28'
+        date: '2025-10-28'
+        version: 2025-11/PrivatePreview:cancelWorkflows
+      x-ms-docs-operation-type: action
   '/identityGovernance/lifecycleWorkflows/deletedItems/workflows/{workflow-id}/microsoft.graph.identityGovernance.createNewVersion':
     post:
       tags:
@@ -89237,6 +105612,97 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/identityGovernance/lifecycleWorkflows/deletedItems/workflows/{workflow-id}/microsoft.graph.identityGovernance.previewTaskFailures':
+    post:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Invoke action previewTaskFailures
+      description: 'Validate the tasks configured in a workflow to check for configuration errors. This action identifies any tasks that would fail during execution, allowing you to fix issues before running the workflow. Returns an empty collection if no task failures are detected.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/identitygovernance-workflow-previewtaskfailures?view=graph-rest-beta
+      operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow_previewTaskFailure
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.identityGovernance.previewFailedTask'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-02-28'
+        date: '2025-08-12'
+        version: 2025-01/PrivatePreview:organizationalUnit
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/identityGovernance/lifecycleWorkflows/deletedItems/workflows/{workflow-id}/microsoft.graph.identityGovernance.previewWorkflow':
+    post:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Invoke action previewWorkflow
+      description: 'Run a workflow in preview mode for selected directory objects without affecting production users. This action triggers workflow processing in preview mode, and results can be retrieved using the List userProcessingResults operation with $filter=workflowExecutionType eq ''previewMode''.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/identitygovernance-workflow-previewworkflow?view=graph-rest-beta
+      operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow_previewWorkflow
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subjects:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.directoryObject'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-02-28'
+        date: '2025-08-12'
+        version: 2025-01/PrivatePreview:organizationalUnit
+      x-ms-docs-operation-type: action
   '/identityGovernance/lifecycleWorkflows/deletedItems/workflows/{workflow-id}/microsoft.graph.identityGovernance.restore':
     post:
       tags:
@@ -89266,6 +105732,157 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/identityGovernance/lifecycleWorkflows/deletedItems/workflows/{workflow-id}/previewScope':
+    get:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Get previewScope from identityGovernance
+      description: A read-only collection of directory objects that are currently in-scope for the workflow based on its execution conditions. This property helps preview which users would be affected before running the workflow. Nullable. Read-only. Returned only on $expand. Supports $expand.
+      operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow_ListPreviewScope
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.directoryObjectCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-02-28'
+        date: '2025-08-12'
+        version: 2025-01/PrivatePreview:organizationalUnit
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/lifecycleWorkflows/deletedItems/workflows/{workflow-id}/previewScope/{directoryObject-id}':
+    get:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Get previewScope from identityGovernance
+      description: A read-only collection of directory objects that are currently in-scope for the workflow based on its execution conditions. This property helps preview which users would be affected before running the workflow. Nullable. Read-only. Returned only on $expand. Supports $expand.
+      operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow_GetPreviewScope
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+        - name: directoryObject-id
+          in: path
+          description: The unique identifier of directoryObject
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: directoryObject
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.directoryObject'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-02-28'
+        date: '2025-08-12'
+        version: 2025-01/PrivatePreview:organizationalUnit
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/lifecycleWorkflows/deletedItems/workflows/{workflow-id}/previewScope/$count':
+    get:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Get the number of the resource
+      operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.previewScope_GetCount
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-02-28'
+        date: '2025-08-12'
+        version: 2025-01/PrivatePreview:organizationalUnit
   '/identityGovernance/lifecycleWorkflows/deletedItems/workflows/{workflow-id}/runs':
     get:
       tags:
@@ -89796,7 +106413,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.run.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -90484,7 +107101,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.run.userProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -90987,7 +107604,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.run.userProcessingResult.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -91966,7 +108583,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.taskReport.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -92812,7 +109429,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.task.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -93474,7 +110091,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.userProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -93913,7 +110530,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.userProcessingResult.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -94633,7 +111250,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.version.createdBy_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -94890,7 +111507,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.version.lastModifiedBy_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -95658,7 +112275,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.deletedItem.workflow.version.task.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -96937,7 +113554,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.createdBy_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -97275,7 +113892,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.lastModifiedBy_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -97502,6 +114119,48 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}/microsoft.graph.identityGovernance.cancelProcessing':
+    post:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Invoke action cancelProcessing
+      description: Cancel one or more workflow runs that are currently in queued or inProgress status. Currently limited to canceling one run per request.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/identitygovernance-workflow-cancelprocessing?view=graph-rest-beta
+      operationId: identityGovernance.lifecycleWorkflow.workflow_cancelProcessing
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                scope:
+                  $ref: '#/components/schemas/microsoft.graph.identityGovernance.cancelScope'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-10-28'
+        date: '2025-10-28'
+        version: 2025-11/PrivatePreview:cancelWorkflows
+      x-ms-docs-operation-type: action
   '/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}/microsoft.graph.identityGovernance.createNewVersion':
     post:
       tags:
@@ -97543,6 +114202,97 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}/microsoft.graph.identityGovernance.previewTaskFailures':
+    post:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Invoke action previewTaskFailures
+      description: 'Validate the tasks configured in a workflow to check for configuration errors. This action identifies any tasks that would fail during execution, allowing you to fix issues before running the workflow. Returns an empty collection if no task failures are detected.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/identitygovernance-workflow-previewtaskfailures?view=graph-rest-beta
+      operationId: identityGovernance.lifecycleWorkflow.workflow_previewTaskFailure
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.identityGovernance.previewFailedTask'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-02-28'
+        date: '2025-08-12'
+        version: 2025-01/PrivatePreview:organizationalUnit
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}/microsoft.graph.identityGovernance.previewWorkflow':
+    post:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Invoke action previewWorkflow
+      description: 'Run a workflow in preview mode for selected directory objects without affecting production users. This action triggers workflow processing in preview mode, and results can be retrieved using the List userProcessingResults operation with $filter=workflowExecutionType eq ''previewMode''.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/identitygovernance-workflow-previewworkflow?view=graph-rest-beta
+      operationId: identityGovernance.lifecycleWorkflow.workflow_previewWorkflow
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subjects:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.directoryObject'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-02-28'
+        date: '2025-08-12'
+        version: 2025-01/PrivatePreview:organizationalUnit
+      x-ms-docs-operation-type: action
   '/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}/microsoft.graph.identityGovernance.restore':
     post:
       tags:
@@ -97572,6 +114322,157 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}/previewScope':
+    get:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Get previewScope from identityGovernance
+      description: A read-only collection of directory objects that are currently in-scope for the workflow based on its execution conditions. This property helps preview which users would be affected before running the workflow. Nullable. Read-only. Returned only on $expand. Supports $expand.
+      operationId: identityGovernance.lifecycleWorkflow.workflow_ListPreviewScope
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.directoryObjectCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-02-28'
+        date: '2025-08-12'
+        version: 2025-01/PrivatePreview:organizationalUnit
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}/previewScope/{directoryObject-id}':
+    get:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Get previewScope from identityGovernance
+      description: A read-only collection of directory objects that are currently in-scope for the workflow based on its execution conditions. This property helps preview which users would be affected before running the workflow. Nullable. Read-only. Returned only on $expand. Supports $expand.
+      operationId: identityGovernance.lifecycleWorkflow.workflow_GetPreviewScope
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+        - name: directoryObject-id
+          in: path
+          description: The unique identifier of directoryObject
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: directoryObject
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.directoryObject'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-02-28'
+        date: '2025-08-12'
+        version: 2025-01/PrivatePreview:organizationalUnit
+      x-ms-docs-operation-type: operation
+  '/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}/previewScope/$count':
+    get:
+      tags:
+        - identityGovernance.lifecycleWorkflowsContainer
+      summary: Get the number of the resource
+      operationId: identityGovernance.lifecycleWorkflow.workflow.previewScope_GetCount
+      parameters:
+        - name: workflow-id
+          in: path
+          description: The unique identifier of workflow
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workflow
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+      deprecated: true
+      x-ms-deprecation:
+        removalDate: '2026-02-28'
+        date: '2025-08-12'
+        version: 2025-01/PrivatePreview:organizationalUnit
   '/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}/runs':
     get:
       tags:
@@ -97856,7 +114757,7 @@ paths:
     get:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
-      summary: List taskProcessingResults
+      summary: List taskProcessingResults (from a run)
       description: Get the taskProcessingResult resources for a run.
       externalDocs:
         description: Find more info here
@@ -98111,7 +115012,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.run.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -98805,7 +115706,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.run.userProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -99024,7 +115925,7 @@ paths:
     get:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
-      summary: List taskProcessingResults
+      summary: List taskProcessingResults (for a user)
       description: Get the task processing result from a userProcessingResult either directly or through a run.
       externalDocs:
         description: Find more info here
@@ -99311,7 +116212,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.run.userProcessingResult.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -100297,7 +117198,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.taskReport.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -101147,7 +118048,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.task.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -101812,7 +118713,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.userProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -101999,7 +118900,7 @@ paths:
     get:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
-      summary: List taskProcessingResults
+      summary: List taskProcessingResults (for a user)
       description: Get the task processing result from a userProcessingResult either directly or through a run.
       externalDocs:
         description: Find more info here
@@ -102254,7 +119155,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.userProcessingResult.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -102980,7 +119881,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.version.createdBy_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -103237,7 +120138,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.version.lastModifiedBy_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -104011,7 +120912,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflow.version.task.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflow-id
@@ -104927,7 +121828,7 @@ paths:
       tags:
         - identityGovernance.lifecycleWorkflowsContainer
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: identityGovernance.lifecycleWorkflow.workflowTemplate.task.taskProcessingResult.subject_GetMailboxSetting
       parameters:
         - name: workflowTemplate-id
@@ -148366,6 +165267,16 @@ components:
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
+    microsoft.graph.accessReviewInstanceDecisionItemApplyResult:
+      title: accessReviewInstanceDecisionItemApplyResult
+      enum:
+        - new
+        - appliedSuccessfully
+        - appliedWithUnknownFailure
+        - appliedSuccessfullyButObjectNotFound
+        - applyNotSupported
+        - unknownFutureValue
+      type: string
     microsoft.graph.accessReviewStage:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -148700,6 +165611,8 @@ components:
               description: 'The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
               format: date-time
               nullable: true
+            privilegeLevel:
+              $ref: '#/components/schemas/microsoft.graph.privilegeLevel'
             uniqueName:
               type: string
               nullable: true
@@ -148780,8 +165693,10 @@ components:
               nullable: true
             originSystem:
               type: string
-              description: 'The type of the resource in the origin system, such as SharePointOnline, AadApplication or AadGroup.'
+              description: 'The type of the resource in the origin system, such as SharePointOnline, AadApplication, AzureResources or AadGroup.'
               nullable: true
+            type:
+              $ref: '#/components/schemas/microsoft.graph.roleType'
             accessPackageResource:
               $ref: '#/components/schemas/microsoft.graph.accessPackageResource'
           additionalProperties:
@@ -148825,7 +165740,7 @@ components:
               nullable: true
             originSystem:
               type: string
-              description: 'The type of the resource in the origin system, such as SharePointOnline, AadApplication, AadGroup or CustomDataProvidedResource. Supports $filter (eq).'
+              description: 'The type of the resource in the origin system, such as SharePointOnline, AadApplication, AadGroup or CustomDataProvidedResource. Supports $filter and $expand (eq).'
               nullable: true
             resourceType:
               type: string
@@ -148932,11 +165847,11 @@ components:
               nullable: true
             originId:
               type: string
-              description: The unique identifier for the scope in the resource as defined in the origin system.
+              description: 'The unique identifier of the resource in the origin system. If a Microsoft Entra group, originId is the identifier of the group. Supports $filter (eq).'
               nullable: true
             originSystem:
               type: string
-              description: The origin system for the scope.
+              description: 'The type of the resource in the origin system, such as SharePointOnline, AadApplication, AadGroup, AzureResources, or CustomDataProvidedResource. Supports $filter (eq).'
               nullable: true
             roleOriginId:
               type: string
@@ -148962,24 +165877,30 @@ components:
               $ref: '#/components/schemas/microsoft.graph.connectorType'
             createdBy:
               type: string
+              description: The identifier of the user or application that created the connector.
               nullable: true
             createdDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
+              description: The date and time when the connector was created.
               format: date-time
               nullable: true
             description:
               type: string
+              description: A description of the connector.
               nullable: true
             displayName:
               type: string
+              description: The display name of the connector.
               nullable: true
             modifiedBy:
               type: string
+              description: The identifier of the user or application that last modified the connector.
               nullable: true
             modifiedDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
+              description: The date and time when the connector was last modified.
               format: date-time
               nullable: true
           additionalProperties:
@@ -148993,13 +165914,17 @@ components:
             createdDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: DateTime when the upload session was created. Read-only.
+              description: DateTime when the upload session was created. Read-only. Supports $orderby.
               format: date-time
             data:
               $ref: '#/components/schemas/microsoft.graph.customExtensionData'
             isUploadDone:
               type: boolean
               description: Indicates if all the necessary files have been uploaded to this session.
+            referenceId:
+              type: string
+              description: 'The ID of the context for which data is being uploaded, for example, the Access Review instance ID. Supports $filter (eq).'
+              nullable: true
             source:
               type: string
               description: The source of the access data. This should be set to the customdataprovidedresource's name when creating the session.
@@ -149012,6 +165937,32 @@ components:
               type: string
               description: 'Schematized form of the expected CSV columns in the uploaded file. The only possible value currently is: accessReviewDataUploadTriggerCallbackData'
               nullable: true
+            files:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
+              description: The files uploaded during this upload session. Supports $expand and $expand with nested $filter and $orderby.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.customDataProvidedResourceFile:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: customDataProvidedResourceFile
+          type: object
+          properties:
+            name:
+              type: string
+              description: 'Name of the uploaded file, including the file extension. Required.  Supports $filter (eq, ne)  and $orderby.'
+            size:
+              type: number
+              description: 'Size of the file in bytes. Read-only.  Supports $filter (eq, ne, gt, ge, lt, le) and $orderby.'
+              format: int64
+            uploadedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Timestamp when the file was uploaded. Read-only.  Supports $filter (eq, ne, gt, ge, lt, le) and $orderby.'
+              format: date-time
           additionalProperties:
             type: object
     microsoft.graph.accessPackage:
@@ -149219,6 +166170,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalOriginResourceConnector'
+              description: Represents the connectors used to communicate with external resource systems.
               x-ms-navigationProperty: true
             settings:
               $ref: '#/components/schemas/microsoft.graph.entitlementManagementSettings'
@@ -149607,6 +166559,10 @@ components:
         - createdBy
         - approver
         - unknownFutureValue
+        - targetOrRequestor
+        - targetManager
+        - requestForOthers
+        - targetAgentIdentitySponsorOrOwner
       type: string
     microsoft.graph.accessPackageAssignmentResourceRole:
       allOf:
@@ -149724,6 +166680,8 @@ components:
         - target
         - createdBy
         - unknownFutureValue
+        - targetManager
+        - targetAgentIdentitySponsorOrOwner
       type: string
     microsoft.graph.accessPackageResourceRequest:
       allOf:
@@ -149945,7 +166903,7 @@ components:
           properties:
             aboutMe:
               type: string
-              description: A freeform text entry field for users to describe themselves. Returned only on $select.
+              description: A freeform text entry field for users to describe themselves. Requires $select to retrieve.
               nullable: true
             accountEnabled:
               type: boolean
@@ -149970,7 +166928,7 @@ components:
             birthday:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'The birthday of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z Returned only on $select.'
+              description: 'The birthday of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z Requires $select to retrieve.'
               format: date-time
             businessPhones:
               type: array
@@ -150068,13 +167026,15 @@ components:
             hireDate:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'The hire date of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.  Returned only on $select.  Note: This property is specific to SharePoint Online. We recommend using the native employeeHireDate property to set and update hire date values using Microsoft Graph APIs.'
+              description: 'The hire date of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.  Requires $select to retrieve.  Note: This property is specific to SharePoint Online. We recommend using the native employeeHireDate property to set and update hire date values using Microsoft Graph APIs.'
               format: date-time
             identities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.objectIdentity'
               description: 'Represents the identities that can be used to sign in to this user account. An identity can be provided by Microsoft (also known as a local account), by organizations, or by social identity providers such as Facebook, Google, and Microsoft and tied to a user account. It may contain multiple items with the same signInType value.  Supports $filter (eq) with limitations.'
+            identityGovernance:
+              $ref: '#/components/schemas/microsoft.graph.identityGovernanceUserSettings'
             identityParentId:
               type: string
               description: 'The object ID of the parent identity for agent users. Always null for regular user accounts. For agentUser resources, this property references the object ID of the associated agent identity.'
@@ -150095,7 +167055,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for users to describe their interests. Returned only on $select.
+              description: A list for users to describe their interests. Requires $select to retrieve.
             isLicenseReconciliationNeeded:
               type: boolean
               description: Indicates whether the user is pending an exchange mailbox license assignment.  Read-only.  Supports $filter (eq where true only).
@@ -150106,7 +167066,7 @@ components:
               nullable: true
             isResourceAccount:
               type: boolean
-              description: Do not use – reserved for future use.
+              description: Do not use. Reserved for future use.
               nullable: true
             jobTitle:
               type: string
@@ -150115,18 +167075,18 @@ components:
             lastPasswordChangeDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'When this Microsoft Entra user last changed their password or when their password was created, whichever date the latest action was performed. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only. Returned only on $select.'
+              description: 'When this Microsoft Entra user last changed their password or when their password was created, whichever date the latest action was performed. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only. Requires $select to retrieve.'
               format: date-time
               nullable: true
             legalAgeGroupClassification:
               type: string
-              description: 'Used by enterprise applications to determine the legal age group of the user. This property is read-only and calculated based on ageGroup and consentProvidedForMinor properties. Allowed values: null, Undefined, MinorWithOutParentalConsent, MinorWithParentalConsent, MinorNoParentalConsentRequired, NotAdult, and Adult. For more information, see legal age group property definitions. Returned only on $select.'
+              description: 'Used by enterprise applications to determine the legal age group of the user. This property is read-only and calculated based on ageGroup and consentProvidedForMinor properties. Allowed values: null, Undefined, MinorWithOutParentalConsent, MinorWithParentalConsent, MinorNoParentalConsentRequired, NotAdult, and Adult. For more information, see legal age group property definitions. Requires $select to retrieve.'
               nullable: true
             licenseAssignmentStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseAssignmentState'
-              description: State of license assignments for this user. It also indicates licenses that are directly assigned and the ones the user inherited through group memberships. Read-only. Returned only on $select.
+              description: State of license assignments for this user. It also indicates licenses that are directly assigned and the ones the user inherited through group memberships. Read-only. Requires $select to retrieve.
             mail:
               type: string
               description: 'The SMTP address for the user, for example, admin@contoso.com. Changes to this property also update the user''s proxyAddresses collection to include the value as an SMTP address. This property can''t contain accent characters.  NOTE: We don''t recommend updating this property for Azure AD B2C user profiles. Use the otherMails property instead.  Supports $filter (eq, ne, not, ge, le, in, startsWith, endsWith, and eq on null values).'
@@ -150143,7 +167103,7 @@ components:
               nullable: true
             mySite:
               type: string
-              description: The URL for the user's site. Returned only on $select.
+              description: The URL for the user's site. Requires $select to retrieve.
               nullable: true
             officeLocation:
               type: string
@@ -150208,7 +167168,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for users to enumerate their past projects. Returned only on $select.
+              description: A list for users to enumerate their past projects. Requires $select to retrieve.
             postalCode:
               type: string
               description: 'The postal code for the user''s postal address. The postal code is specific to the user''s country/region. In the United States of America, this attribute contains the ZIP code. Maximum length is 40 characters. Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values).'
@@ -150223,7 +167183,7 @@ components:
               nullable: true
             preferredName:
               type: string
-              description: The preferred name for the user. Not Supported. This attribute returns an empty string.Returned only on $select.
+              description: The preferred name for the user. Not Supported. This attribute returns an empty string.Requires $select to retrieve.
               nullable: true
             print:
               $ref: '#/components/schemas/microsoft.graph.userPrint'
@@ -150248,13 +167208,13 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for the user to enumerate their responsibilities. Returned only on $select.
+              description: A list for the user to enumerate their responsibilities. Requires $select to retrieve.
             schools:
               type: array
               items:
                 type: string
                 nullable: true
-              description: A list for the user to enumerate the schools they have attended. Returned only on $select.
+              description: A list for the user to enumerate the schools they have attended. Requires $select to retrieve.
             securityIdentifier:
               type: string
               description: 'Security identifier (SID) of the user, used in Windows scenarios. Read-only. Returned by default. Supports $select and $filter (eq, not, ge, le, startsWith).'
@@ -150281,7 +167241,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for the user to enumerate their skills. Returned only on $select.
+              description: A list for the user to enumerate their skills. Requires $select to retrieve.
             state:
               type: string
               description: 'The state or province in the user''s address. Maximum length is 128 characters. Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values).'
@@ -150376,6 +167336,12 @@ components:
               x-ms-navigationProperty: true
             cloudClipboard:
               $ref: '#/components/schemas/microsoft.graph.cloudClipboardRoot'
+            cloudPcPools:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudPcPool'
+              description: The user's Cloud PC pools. Read-only. Nullable.
+              x-ms-navigationProperty: true
             cloudPCs:
               type: array
               items:
@@ -150732,6 +167698,12 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.identityGovernance.userProcessingResult'
               description: The list of users that meet the workflowExecutionConditions of a workflow.
               x-ms-navigationProperty: true
+            previewScope:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.directoryObject'
+              description: A read-only collection of directory objects that are currently in-scope for the workflow based on its execution conditions. This property helps preview which users would be affected before running the workflow. Nullable. Read-only. Returned only on $expand. Supports $expand.
+              x-ms-navigationProperty: true
             runs:
               type: array
               items:
@@ -150844,6 +167816,29 @@ components:
       type: object
       additionalProperties:
         type: object
+    microsoft.graph.identityGovernance.cancelScope:
+      title: cancelScope
+      type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.identityGovernance.previewFailedTask:
+      title: previewFailedTask
+      type: object
+      properties:
+        definitionId:
+          type: string
+          description: The identifier of the task definition of the task that failed during the preview operation of a workflow.
+        failureReason:
+          type: string
+          description: The reason why the task failed in the preview operation of a workflow.
+        name:
+          type: string
+          description: The name of the task that failed within the preview operation of a workflow.
+        taskId:
+          type: string
+          description: The identifier of the task that failed during the preview operation of a workflow.
+      additionalProperties:
+        type: object
     microsoft.graph.identityGovernance.run:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -150953,14 +167948,18 @@ components:
               format: date-time
             failureReason:
               type: string
-              description: Describes why the taskProcessingResult has failed.
+              description: Describes why the taskProcessingResult failed.
+              nullable: true
+            processingInfo:
+              type: string
+              description: 'Additional human-readable context about the task processing outcome. This property contains information about edge cases where the task completed successfully but the expected action wasn''t performed because the target was already in the desired state, such as when the user was already a member of the specified group. Returns null when no additional context is needed. Nullable.'
               nullable: true
             processingStatus:
               $ref: '#/components/schemas/microsoft.graph.identityGovernance.lifecycleWorkflowProcessingStatus'
             startedDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'The date time when taskProcessingResult execution started. Value is null if task execution has not yet started.Supports $filter(lt, le, gt, ge, eq, ne) and $orderby.'
+              description: 'The date time when taskProcessingResult execution started. Value is null if task execution hasn''t started yet.Supports $filter(lt, le, gt, ge, eq, ne) and $orderby.'
               format: date-time
               nullable: true
             subject:
@@ -151822,21 +168821,21 @@ components:
               $ref: '#/components/schemas/microsoft.graph.groupAccessType'
             allowExternalSenders:
               type: boolean
-              description: 'Indicates if people external to the organization can send messages to the group. The default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates if people external to the organization can send messages to the group. The default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             assignedLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignedLabel'
-              description: 'The list of sensitivity label pairs (label ID, label name) associated with a Microsoft 365 group. Returned only on $select. This property can be updated only in delegated scenarios where the caller requires both the Microsoft Graph permission and a supported administrator role.'
+              description: 'The list of sensitivity label pairs (label ID, label name) associated with a Microsoft 365 group. Requires $select to retrieve. This property can be updated only in delegated scenarios where the caller requires both the Microsoft Graph permission and a supported administrator role.'
             assignedLicenses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignedLicense'
-              description: The licenses that are assigned to the group. Returned only on $select. Supports $filter (eq). Read-only.
+              description: The licenses that are assigned to the group. Requires $select to retrieve. Supports $filter (eq). Read-only.
             autoSubscribeNewMembers:
               type: boolean
-              description: 'Indicates if new members added to the group are auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; don''t set it in the initial POST request that creates the group. Default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates if new members added to the group are auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; don''t set it in the initial POST request that creates the group. Default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             classification:
               type: string
@@ -151879,11 +168878,11 @@ components:
               nullable: true
             hideFromAddressLists:
               type: boolean
-              description: 'true if the group isn''t displayed in certain parts of the Outlook user interface: in the Address Book, in address lists for selecting message recipients, and in the Browse Groups dialog for searching groups; false otherwise. The default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'true if the group isn''t displayed in certain parts of the Outlook user interface: in the Address Book, in address lists for selecting message recipients, and in the Browse Groups dialog for searching groups; false otherwise. The default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             hideFromOutlookClients:
               type: boolean
-              description: 'true if the group isn''t displayed in Outlook clients, such as Outlook for Windows and Outlook on the web, false otherwise. The default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'true if the group isn''t displayed in Outlook clients, such as Outlook for Windows and Outlook on the web, false otherwise. The default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             infoCatalogs:
               type: array
@@ -151908,7 +168907,7 @@ components:
               nullable: true
             isSubscribedByMail:
               type: boolean
-              description: 'Indicates whether the signed-in user is subscribed to receive email conversations. The default value is true. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates whether the signed-in user is subscribed to receive email conversations. The default value is true. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             licenseProcessingState:
               $ref: '#/components/schemas/microsoft.graph.licenseProcessingState'
@@ -151938,6 +168937,8 @@ components:
               type: string
               description: 'Contains the on-premises domain FQDN, also called dnsDomainName synchronized from the on-premises directory. The property is only populated for customers synchronizing their on-premises directory to Microsoft Entra ID via Microsoft Entra Connect.Returned by default. Read-only.'
               nullable: true
+            onPremisesExtensionAttributes:
+              $ref: '#/components/schemas/microsoft.graph.onPremisesExtensionAttributes'
             onPremisesLastSyncDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
@@ -151996,7 +168997,7 @@ components:
               type: array
               items:
                 type: string
-              description: 'Specifies the group resources that are associated with the Microsoft 365 group. The possible value is Team. For more information, see Microsoft 365 group behaviors and provisioning options. Returned by default. Supports $filter (eq, not, startsWith.'
+              description: 'Specifies the group resources that are associated with the Microsoft 365 group. The possible value is Team. For more information, see Microsoft 365 group behaviors and provisioning options. Returned by default. Supports $filter (eq, not, startsWith).'
             securityEnabled:
               type: boolean
               description: 'Specifies whether the group is a security group. Required.Returned by default. Supports $filter (eq, ne, not, in).'
@@ -152022,21 +169023,21 @@ components:
               maximum: 2147483647
               minimum: -2147483648
               type: number
-              description: Count of conversations delivered one or more new posts since the signed-in user's last visit to the group. This property is the same as unseenCount. Returned only on $select.
+              description: Count of conversations delivered one or more new posts since the signed-in user's last visit to the group. This property is the same as unseenCount. Requires $select to retrieve.
               format: int32
               nullable: true
             unseenCount:
               maximum: 2147483647
               minimum: -2147483648
               type: number
-              description: 'Count of conversations that have received new posts since the signed-in user last visited the group. This property is the same as unseenConversationsCount.Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Count of conversations that have received new posts since the signed-in user last visited the group. This property is the same as unseenConversationsCount.Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               format: int32
               nullable: true
             unseenMessagesCount:
               maximum: 2147483647
               minimum: -2147483648
               type: number
-              description: Count of new posts that have been delivered to the group's conversations since the signed-in user's last visit to the group. Returned only on $select.
+              description: Count of new posts that have been delivered to the group's conversations since the signed-in user's last visit to the group. Requires $select to retrieve.
               format: int32
               nullable: true
             visibility:
@@ -152045,7 +169046,7 @@ components:
               nullable: true
             welcomeMessageEnabled:
               type: boolean
-              description: 'Indicates whether a welcome message is sent to new members when they are added to the group. The default value is true. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates whether a welcome message is sent to new members when they are added to the group. The default value is true. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             writebackConfiguration:
               $ref: '#/components/schemas/microsoft.graph.groupWritebackConfiguration'
@@ -154264,6 +171265,13 @@ components:
               description: 'The status of the request. Not nullable. The possible values are: Canceled, Denied, Failed, Granted, PendingAdminDecision, PendingApproval, PendingProvisioning, PendingScheduleCreation, Provisioned, Revoked, and ScheduleCreated. Not nullable.'
           additionalProperties:
             type: object
+    microsoft.graph.privilegeLevel:
+      title: privilegeLevel
+      enum:
+        - standard
+        - privileged
+        - unknownFutureValue
+      type: string
     microsoft.graph.customExtensionAuthenticationConfiguration:
       title: customExtensionAuthenticationConfiguration
       type: object
@@ -154294,6 +171302,15 @@ components:
       type: object
       additionalProperties:
         type: object
+    microsoft.graph.roleType:
+      title: roleType
+      enum:
+        - active
+        - eligible
+        - application
+        - delegated
+        - unknownFutureValue
+      type: string
     microsoft.graph.accessPackageResourceAttribute:
       title: accessPackageResourceAttribute
       type: object
@@ -154794,11 +171811,11 @@ components:
       properties:
         costCenter:
           type: string
-          description: The cost center associated with the user. Returned only on $select. Supports $filter.
+          description: The cost center associated with the user. Requires $select to retrieve. Supports $filter.
           nullable: true
         division:
           type: string
-          description: The name of the division in which the user works. Returned only on $select. Supports $filter.
+          description: The name of the division in which the user works. Requires $select to retrieve. Supports $filter.
           nullable: true
       additionalProperties:
         type: object
@@ -154818,6 +171835,14 @@ components:
           type: string
           description: 'Specifies the user sign-in types in your directory, such as emailAddress, userName, federated, or userPrincipalName. federated represents a unique identifier for a user from an issuer that can be in any format chosen by the issuer. Setting or updating a userPrincipalName identity updates the value of the userPrincipalName property on the user object. The validations performed on the userPrincipalName property on the user object, for example, verified domains and acceptable characters, are performed when setting or updating a userPrincipalName identity. Extra validation is enforced on issuerAssignedId when the sign-in type is set to emailAddress or userName. This property can also be set to any custom string.  For more information about filtering behavior for this property, see Filtering on the identities property of a user.'
           nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.identityGovernanceUserSettings:
+      title: identityGovernanceUserSettings
+      type: object
+      properties:
+        approverDelegate:
+          $ref: '#/components/schemas/microsoft.graph.approverDelegate'
       additionalProperties:
         type: object
     microsoft.graph.licenseAssignmentState:
@@ -155219,7 +172244,7 @@ components:
               description: 'The roles exposed by the application, which this service principal represents. For more information, see the appRoles property definition on the application entity. Not nullable.'
             createdByAppId:
               type: string
-              description: The appId (called Application (client) ID on the Microsoft Entra admin center) of the application used to create the service principal. Set internally by Microsoft Entra ID. Read-only.
+              description: The appId of the application that created this service principal. Set internally by Microsoft Entra ID. Read-only.
               nullable: true
             customSecurityAttributes:
               $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeValue'
@@ -155513,7 +172538,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalAuthenticationMethod'
-              description: Represents the external methods registered to a user for authentication.
+              description: Represents the external MFA registered to a user for authentication.
               x-ms-navigationProperty: true
             fido2Methods:
               type: array
@@ -155994,6 +173019,12 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
               x-ms-navigationProperty: true
+            targetedMessages:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+              description: A collection of targeted messages in the chat that are visible only to specific users. Nullable.
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudClipboardRoot:
@@ -156007,6 +173038,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudClipboardItem'
               description: Represents a collection of Cloud Clipboard items.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.cloudPcPool:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: cloudPcPool
+          type: object
+          properties:
+            capabilities:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcPoolCapabilityConfiguration'
+            cloudPcConfiguration:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcConfiguration'
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time when the pool was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2026 is 2026-01-01T00:00:00Z. Read-only.'
+              format: date-time
+            description:
+              type: string
+              description: The description of the pool. The maximum length is 512 characters.
+              nullable: true
+            displayName:
+              type: string
+              description: The display name of the pool. The name is unique across Cloud PC pools in an organization. The maximum length is 60 characters.
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time when the pool was last modified. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2026 is 2026-01-01T00:00:00Z. Read-only.'
+              format: date-time
+            networkConfiguration:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcNetworkConfiguration'
+            assignments:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudPcPoolAssignment'
+              description: The collection of assignments that grant user or service principal identities access to this pool.
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
@@ -156109,6 +173177,7 @@ components:
               items:
                 type: string
                 nullable: true
+              description: 'The scope IDs of the corresponding permission. Currently, it''s the Intune scope tag ID. Read-only.'
             servicePlanId:
               type: string
               description: The service plan ID of the Cloud PC.
@@ -156590,7 +173659,7 @@ components:
               nullable: true
             onPremisesSecurityIdentifier:
               type: string
-              description: The on-premises security identifier (SID) for the user who was synchronized from on-premises to the cloud. Read-only. Returned only on $select. Supports $filter (eq).
+              description: The on-premises security identifier (SID) for the user who was synchronized from on-premises to the cloud. Read-only. Requires $select to retrieve. Supports $filter (eq).
               nullable: true
             onPremisesSyncEnabled:
               type: boolean
@@ -156757,6 +173826,8 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.learningCourseActivity'
               x-ms-navigationProperty: true
+            storyline:
+              $ref: '#/components/schemas/microsoft.graph.storyline'
           additionalProperties:
             type: object
           description: Represents a container that exposes navigation properties for employee experience user resources.
@@ -157803,7 +174874,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.internetMessageHeader'
-              description: A collection of message headers defined by RFC5322. The set includes message headers indicating the network path taken by a message from the sender to the recipient. It can also contain custom message headers that hold app data for the message.  Returned only on applying a $select query option. Read-only.
+              description: A collection of message headers defined by RFC5322. The set includes message headers indicating the network path taken by a message from the sender to the recipient. It can also contain custom message headers that hold app data for the message.  Requires $select to retrieve. Read-only.
             internetMessageId:
               type: string
               description: The message ID in the format specified by RFC5322. Updatable only if isDraft is true.
@@ -158654,6 +175725,12 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
               x-ms-navigationProperty: true
+            sections:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSection'
+              description: The sections in the user's chat list.
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todo:
@@ -158885,6 +175962,7 @@ components:
         - canceled
         - failed
         - unknownFutureValue
+        - canceling
       type: string
     microsoft.graph.identityGovernance.workflowExecutionType:
       title: workflowExecutionType
@@ -158893,6 +175971,7 @@ components:
         - onDemand
         - unknownFutureValue
         - activatedWithScope
+        - preview
       type: string
     microsoft.graph.identityGovernance.customTaskExtensionOperationStatus:
       title: customTaskExtensionOperationStatus
@@ -159815,6 +176894,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceUploadSession'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.customDataProvidedResourceFileCollectionResponse:
+      title: Collection of customDataProvidedResourceFile
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFile'
         '@odata.nextLink':
           type: string
           nullable: true
@@ -161142,6 +178234,16 @@ components:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
           additionalProperties:
             type: object
+    microsoft.graph.approverDelegate:
+      title: approverDelegate
+      type: object
+      properties:
+        delegate:
+          $ref: '#/components/schemas/microsoft.graph.userSet'
+        schedule:
+          $ref: '#/components/schemas/microsoft.graph.requestSchedule'
+      additionalProperties:
+        type: object
     microsoft.graph.printerShare:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.printerBase'
@@ -161499,7 +178601,7 @@ components:
           nullable: true
         key:
           type: string
-          description: 'Value for the key credential. Should be a Base64 encoded value. Returned only on $select for a single object, that is, GET applications/{applicationId}?$select=keyCredentials or GET servicePrincipals/{servicePrincipalId}?$select=keyCredentials; otherwise, it''s always null.  From a .cer certificate, you can read the key using the Convert.ToBase64String() method. For more information, see Get the certificate key.'
+          description: 'Value for the key credential. Should be a Base64 encoded value. Requires $select to retrieve; only available for single object requests (GET /applications/{applicationId}?$select=keyCredentials or GET /servicePrincipals/{servicePrincipalId}?$select=keyCredentials); otherwise, it''s always null.  From a .cer certificate, you can read the key using the Convert.ToBase64String() method. For more information, see Get the certificate key.'
           format: base64url
           nullable: true
         keyId:
@@ -161778,12 +178880,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvedClientApp'
+              description: The collection of approved client apps that are associated with the RDS configuration. Supports $expand.
               x-ms-navigationProperty: true
             targetDeviceGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetDeviceGroup'
-              description: The collection of target device groups that are associated with the RDS security configuration that will be enabled for SSO when a client connects to the target device over RDP using the new Microsoft Entra ID RDS authentication protocol. <br/<Supports $expand.
+              description: The collection of target device groups that are associated with the RDS security configuration that will be enabled for SSO when a client connects to the target device over RDP using the new Microsoft Entra ID RDS authentication protocol.
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
@@ -161869,7 +178972,7 @@ components:
               description: A unique identifier used to manage the external auth method within Microsoft Entra ID.
             displayName:
               type: string
-              description: Custom name given to the registered external authentication method.
+              description: Custom name given to the registered external MFA.
           additionalProperties:
             type: object
     microsoft.graph.fido2AuthenticationMethod:
@@ -162698,6 +179801,16 @@ components:
               $ref: '#/components/schemas/microsoft.graph.teamsApp'
           additionalProperties:
             type: object
+    microsoft.graph.targetedChatMessage:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        - title: targetedChatMessage
+          type: object
+          properties:
+            recipient:
+              $ref: '#/components/schemas/microsoft.graph.identity'
+          additionalProperties:
+            type: object
     microsoft.graph.cloudClipboardItem:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -162725,6 +179838,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudClipboardItemPayload'
               description: A cloudClipboardItem can have multiple cloudClipboardItemPayload objects in the payloads. A window can place more than one clipboard object on the clipboard. Each one represents the same information in a different clipboard format.
+          additionalProperties:
+            type: object
+    microsoft.graph.cloudPcPoolCapabilityConfiguration:
+      title: cloudPcPoolCapabilityConfiguration
+      type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.cloudPcConfiguration:
+      title: cloudPcConfiguration
+      type: object
+      properties:
+        imageDisplayName:
+          type: string
+          description: The display name of the image. Read-only.
+          nullable: true
+        imageId:
+          type: string
+          description: 'The unique identifier of the operating system image used for provisioning new Cloud PCs. The format for a gallery type image is: {publisherNameofferNameskuName}.'
+        imageType:
+          $ref: '#/components/schemas/microsoft.graph.cloudPcProvisioningPolicyImageType'
+        osLocale:
+          type: string
+          description: The operating system locale for the Cloud PC.
+      additionalProperties:
+        type: object
+    microsoft.graph.cloudPcNetworkConfiguration:
+      title: cloudPcNetworkConfiguration
+      type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.cloudPcPoolAssignment:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: cloudPcPoolAssignment
+          type: object
           additionalProperties:
             type: object
     microsoft.graph.cloudPcConnectionSetting:
@@ -163651,6 +180799,13 @@ components:
               type: string
               description: The displayable title of the list.
               nullable: true
+            itemCount:
+              maximum: 2147483647
+              minimum: -2147483648
+              type: number
+              description: The total count of items in the list. Read-only.
+              format: int32
+              nullable: true
             list:
               $ref: '#/components/schemas/microsoft.graph.listInfo'
             sharepointIds:
@@ -163757,6 +180912,27 @@ components:
               $ref: '#/components/schemas/microsoft.graph.courseStatus'
           additionalProperties:
             type: object
+    microsoft.graph.storyline:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: storyline
+          type: object
+          properties:
+            followers:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.storylineFollower'
+              description: The users who are following this user.
+              x-ms-navigationProperty: true
+            followings:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.storylineFollowing'
+              description: The users that this user is following.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+          description: User's storyline singleton container.
     microsoft.graph.deleted:
       title: deleted
       type: object
@@ -164646,6 +181822,11 @@ components:
               x-ms-navigationProperty: true
             filesFolder:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
+            joinedUsers:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
@@ -166719,6 +183900,10 @@ components:
               type: string
               description: Current anti malware version
               nullable: true
+            controlledConfigurationEnabled:
+              type: boolean
+              description: 'When TRUE indicates the Windows Defender controlled configuration feature is enabled, when FALSE indicates the Windows Defender controlled configuration feature is not enabled. Defaults to setting on client device.'
+              nullable: true
             deviceState:
               $ref: '#/components/schemas/microsoft.graph.windowsDeviceHealthState'
             engineVersion:
@@ -167236,6 +184421,8 @@ components:
               $ref: '#/components/schemas/microsoft.graph.chatInfo'
             chatRestrictions:
               $ref: '#/components/schemas/microsoft.graph.chatRestrictions'
+            cloudVideoInteropInfo:
+              $ref: '#/components/schemas/microsoft.graph.cloudVideoInteropInfo'
             expiryDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
@@ -167791,9 +184978,10 @@ components:
               nullable: true
             hasChat:
               type: boolean
+              description: 'Read-only. This value is true if the task has chat messages associated with it. Otherwise, false.'
             hasDescription:
               type: boolean
-              description: 'Read-only. This value is true if the details object of the task has a nonempty description. Otherwise,false.'
+              description: 'Read-only. This value is true if the details object of the task has a nonempty description. Otherwise, false.'
               nullable: true
             isArchived:
               type: boolean
@@ -167814,11 +185002,12 @@ components:
             lastModifiedDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
+              description: 'Read-only. Date and time at which this is last modified. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z'
               format: date-time
               nullable: true
             orderHint:
               type: string
-              description: 'The hint used to order items of this type in a list view. For more information, see Using order hints in plannern.'
+              description: 'The hint used to order items of this type in a list view. For more information, see Using order hints in planner.'
               nullable: true
             percentComplete:
               maximum: 2147483647
@@ -167866,6 +185055,12 @@ components:
               $ref: '#/components/schemas/microsoft.graph.plannerBucketTaskBoardTaskFormat'
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerTaskDetails'
+            messages:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+              description: Read-only. Nullable. Chat messages associated with the task.
+              x-ms-navigationProperty: true
             progressTaskBoardFormat:
               $ref: '#/components/schemas/microsoft.graph.plannerProgressTaskBoardTaskFormat'
           additionalProperties:
@@ -168524,6 +185719,7 @@ components:
           properties:
             inPlaceArchiveMailboxId:
               type: string
+              description: The unique identifier for the user's In-Place Archive mailbox.
               nullable: true
             primaryMailboxId:
               type: string
@@ -168660,6 +185856,49 @@ components:
               $ref: '#/components/schemas/microsoft.graph.chat'
           additionalProperties:
             type: object
+    microsoft.graph.teamworkSection:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: teamworkSection
+          type: object
+          properties:
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the section was created. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            displayIcon:
+              $ref: '#/components/schemas/microsoft.graph.sectionDisplayIcon'
+            displayName:
+              type: string
+              description: 'The display name of the section. Required. Maximum length is 50 characters. Display names are case-sensitive and must be unique within a user''s sections. The following names are reserved for system-defined sections and can''t be used when creating a user-defined section: RecentChats, QuickViews, TeamsAndChannels, MutedChats, MeetingChats, EngageCommunities.'
+            isExpanded:
+              type: boolean
+              description: Indicates whether the section is expanded in the user interface. The default value is true.
+              nullable: true
+            isHierarchicalViewEnabled:
+              type: boolean
+              description: Indicates whether the hierarchical view is enabled for the section. Read-only.
+              nullable: true
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the section was last modified. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            sectionType:
+              $ref: '#/components/schemas/microsoft.graph.sectionType'
+            sortType:
+              $ref: '#/components/schemas/microsoft.graph.sectionSortType'
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSectionItem'
+              description: 'The items (chats, channels, meetings, or communities) organized within the section.'
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
     microsoft.graph.todoTaskList:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -168683,6 +185922,12 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
+              x-ms-navigationProperty: true
+            singleValueExtendedProperties:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.singleValueExtendedProperty'
+              description: The collection of single-value extended properties defined for the task list. Read-only. Nullable.
               x-ms-navigationProperty: true
             tasks:
               type: array
@@ -169367,6 +186612,7 @@ components:
           properties:
             displayName:
               type: string
+              description: Display name for the client application.
               nullable: true
           additionalProperties:
             type: object
@@ -170092,6 +187338,13 @@ components:
           description: For a list of possible values see formatName values.
       additionalProperties:
         type: object
+    microsoft.graph.cloudPcProvisioningPolicyImageType:
+      title: cloudPcProvisioningPolicyImageType
+      enum:
+        - gallery
+        - custom
+        - unknownFutureValue
+      type: string
     microsoft.graph.cloudPcHealthCheckItem:
       title: cloudPcHealthCheckItem
       type: object
@@ -170121,6 +187374,8 @@ components:
         - availableWithWarning
         - unavailable
         - unknownFutureValue
+        - underServiceMaintenance
+        - inUse
       type: string
     microsoft.graph.cloudPcDisasterRecoveryCapabilityType:
       title: cloudPcDisasterRecoveryCapabilityType
@@ -170554,8 +187809,12 @@ components:
       title: file
       type: object
       properties:
+        archiveStatus:
+          $ref: '#/components/schemas/microsoft.graph.fileArchiveStatus'
         hashes:
           $ref: '#/components/schemas/microsoft.graph.hashes'
+        lockInfo:
+          $ref: '#/components/schemas/microsoft.graph.lockInfo'
         mimeType:
           type: string
           description: The MIME type for the file. This is determined by logic on the server and might not be the value provided when the file was uploaded. Read-only.
@@ -171161,6 +188420,28 @@ components:
         - completed
         - unknownFutureValue
       type: string
+    microsoft.graph.storylineFollower:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: storylineFollower
+          type: object
+          properties:
+            follower:
+              $ref: '#/components/schemas/microsoft.graph.engagementIdentitySet'
+          additionalProperties:
+            type: object
+          description: Engagement storyline follower.
+    microsoft.graph.storylineFollowing:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: storylineFollowing
+          type: object
+          properties:
+            following:
+              $ref: '#/components/schemas/microsoft.graph.engagementIdentitySet'
+          additionalProperties:
+            type: object
+          description: Engagement storyline following.
     microsoft.graph.siteArchivalDetails:
       title: siteArchivalDetails
       type: object
@@ -171170,6 +188451,7 @@ components:
         archivedDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
+          description: 'Time when the container was archived. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
           format: date-time
           nullable: true
         archiveStatus:
@@ -171713,6 +188995,8 @@ components:
           properties:
             group:
               $ref: '#/components/schemas/microsoft.graph.identity'
+            sharePointGroup:
+              $ref: '#/components/schemas/microsoft.graph.sharePointGroupIdentity'
             siteGroup:
               $ref: '#/components/schemas/microsoft.graph.sharePointIdentity'
             siteUser:
@@ -174062,6 +191346,21 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.cloudVideoInteropInfo:
+      title: cloudVideoInteropInfo
+      type: object
+      properties:
+        moreInfoWebUrl:
+          type: string
+          nullable: true
+        tenantKey:
+          type: string
+          nullable: true
+        videoTeleconferenceId:
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.joinMeetingIdSettings:
       title: joinMeetingIdSettings
       type: object
@@ -174235,6 +191534,11 @@ components:
               type: string
               description: Email address of the user associated with this attendance record.
               nullable: true
+            engagements:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.meetingEngagement'
+              description: The list of real-time participant interaction behaviors during a meeting.
             externalRegistrationInformation:
               $ref: '#/components/schemas/microsoft.graph.virtualEventExternalRegistrationInformation'
             identity:
@@ -174600,6 +191904,51 @@ components:
               $ref: '#/components/schemas/microsoft.graph.plannerExternalReferences'
           additionalProperties:
             type: object
+    microsoft.graph.plannerTaskChatMessage:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: plannerTaskChatMessage
+          type: object
+          properties:
+            content:
+              type: string
+              description: The content of the chat message. Supports plain text and sanitized HTML.
+              nullable: true
+            createdBy:
+              $ref: '#/components/schemas/microsoft.graph.identitySet'
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time when the message was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+            deletedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              format: date-time
+              nullable: true
+            editedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              format: date-time
+              nullable: true
+            mentions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMention'
+              description: The list of mentions in the message.
+            messageType:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessageType'
+            parentEntityId:
+              type: string
+              description: The ID of the parent plannerTask that this message belongs to.
+              nullable: true
+            reactions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatReaction'
+              description: The reactions on the message.
+          additionalProperties:
+            type: object
     microsoft.graph.plannerProgressTaskBoardTaskFormat:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.plannerDelta'
@@ -174727,7 +192076,7 @@ components:
       properties:
         abbreviation:
           type: string
-          description: 'Shortened name of the degree or program (example: PhD, MBA)'
+          description: 'Shortened name of the degree or program, for example, PhD and MBA.'
           nullable: true
         activities:
           type: array
@@ -174754,14 +192103,14 @@ components:
           items:
             type: string
             nullable: true
-          description: Majors and minors associated with the program. (if applicable)
+          description: 'Majors and minors associated with the program, if applicable.'
         grade:
           type: string
-          description: 'The final grade, class, GPA, or score.'
+          description: 'The final grade, class, grade point average (GPA), or score.'
           nullable: true
         notes:
           type: string
-          description: More notes the user provided.
+          description: More notes provided by the user.
           nullable: true
         webUrl:
           type: string
@@ -175262,6 +192611,63 @@ components:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
             type: object
+    microsoft.graph.sectionDisplayIcon:
+      title: sectionDisplayIcon
+      type: object
+      properties:
+        contentUrl:
+          type: string
+          description: The URL to a custom icon image. Applicable when iconType is custom.
+          nullable: true
+        displayName:
+          type: string
+          description: The human-readable name of the icon.
+          nullable: true
+        iconType:
+          type: string
+          description: 'The type of icon. Use an emoji character such as 👍 for an emoji icon, or custom for a custom image icon.'
+        skinTone:
+          $ref: '#/components/schemas/microsoft.graph.sectionIconSkinTone'
+      additionalProperties:
+        type: object
+    microsoft.graph.sectionType:
+      title: sectionType
+      enum:
+        - userDefined
+        - systemDefined
+        - unknownFutureValue
+      type: string
+    microsoft.graph.sectionSortType:
+      title: sectionSortType
+      enum:
+        - mostRecent
+        - unreadThenMostRecent
+        - nameAlphabetical
+        - userDefinedCustomOrder
+        - unknownFutureValue
+      type: string
+    microsoft.graph.teamworkSectionItem:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: teamworkSectionItem
+          type: object
+          properties:
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the item was added to the section. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            itemType:
+              $ref: '#/components/schemas/microsoft.graph.sectionItemType'
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the item was last modified. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+          additionalProperties:
+            type: object
     microsoft.graph.wellknownListName:
       title: wellknownListName
       enum:
@@ -175270,6 +192676,18 @@ components:
         - flaggedEmails
         - unknownFutureValue
       type: string
+    microsoft.graph.singleValueExtendedProperty:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: singleValueExtendedProperty
+          type: object
+          properties:
+            value:
+              type: string
+              description: The value of the property.
+              nullable: true
+          additionalProperties:
+            type: object
     microsoft.graph.todoTask:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -175382,6 +192800,12 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.virtualEventExternalInformation'
               description: 'The external information of a virtual event. Returned only for event organizers or coorganizers; otherwise, null.'
+            isRegistrationEnabled:
+              type: boolean
+              nullable: true
+            isRegistrationRequired:
+              type: boolean
+              nullable: true
             settings:
               $ref: '#/components/schemas/microsoft.graph.virtualEventSettings'
             startDateTime:
@@ -175426,13 +192850,6 @@ components:
         - $ref: '#/components/schemas/microsoft.graph.virtualEventRegistrationConfiguration'
         - title: virtualEventWebinarRegistrationConfiguration
           type: object
-          properties:
-            isManualApprovalEnabled:
-              type: boolean
-              nullable: true
-            isWaitlistEnabled:
-              type: boolean
-              nullable: true
           additionalProperties:
             type: object
     microsoft.graph.virtualEventRegistration:
@@ -176123,12 +193540,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.keyCredentialConfiguration'
-          x-ms-navigationProperty: true
+          description: Collection of certificate restrictions settings to be applied to an application or service principal.
         passwordCredentials:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.passwordCredentialConfiguration'
-          x-ms-navigationProperty: true
+          description: Collection of password restrictions settings to be applied to an application or service principal.
       additionalProperties:
         type: object
     microsoft.graph.customAppManagementApplicationConfiguration:
@@ -176676,7 +194093,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.processContentMetadataBase'
-          description: A collection of content entries to be processed. Each entry contains the content itself and its metadata. Use conversation metadata for content like prompts and responses and file metadata for files. Required.
+          description: 'A collection of content entries to be processed. Each entry contains the content itself and its metadata. Use conversation metadata for content like prompts and responses, file metadata for files, and content activity metadata for enforcement result status entries. Required.'
         deviceMetadata:
           $ref: '#/components/schemas/microsoft.graph.deviceMetadata'
         integratedAppMetadata:
@@ -176868,6 +194285,14 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.fileArchiveStatus:
+      title: fileArchiveStatus
+      enum:
+        - notArchived
+        - fullyArchived
+        - reactivating
+        - unknownFutureValue
+      type: string
     microsoft.graph.hashes:
       title: hashes
       type: object
@@ -176888,6 +194313,28 @@ components:
           type: string
           description: This property isn't supported. Don't use.
           nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.lockInfo:
+      title: lockInfo
+      type: object
+      properties:
+        createdDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        expirationDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        lockType:
+          $ref: '#/components/schemas/microsoft.graph.lockType'
+        owners:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.userIdentity'
       additionalProperties:
         type: object
     microsoft.graph.folderView:
@@ -177276,6 +194723,19 @@ components:
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
+    microsoft.graph.engagementIdentitySet:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.identitySet'
+        - title: engagementIdentitySet
+          type: object
+          properties:
+            audience:
+              $ref: '#/components/schemas/microsoft.graph.identity'
+            group:
+              $ref: '#/components/schemas/microsoft.graph.identity'
+          additionalProperties:
+            type: object
+          description: The Viva Engage identities.
     microsoft.graph.siteArchiveStatus:
       title: siteArchiveStatus
       enum:
@@ -177527,6 +194987,22 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.webPart'
               description: The set of web parts in this section.
               x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.sharePointGroupIdentity:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.identity'
+        - title: sharePointGroupIdentity
+          type: object
+          properties:
+            principalId:
+              type: string
+              description: The principal ID of the SharePoint group in the tenant. Read-only.
+              nullable: true
+            title:
+              type: string
+              description: The title of the SharePoint group. Read-only.
+              nullable: true
           additionalProperties:
             type: object
     microsoft.graph.sharePointIdentity:
@@ -178546,6 +196022,24 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.meetingEngagement:
+      title: meetingEngagement
+      type: object
+      properties:
+        dateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The UTC date and time when the engagement event occurred, in ISO 8601 format.'
+          format: date-time
+          nullable: true
+        engagementSubType:
+          type: string
+          description: 'The specific engagement action within the type (e.g., like, love, applause, laugh, surprised for reactions; raiseHand for hand; cameraOn for camera; unmute, mute for microphone).'
+          nullable: true
+        engagementType:
+          $ref: '#/components/schemas/microsoft.graph.meetingEngagementType'
+      additionalProperties:
+        type: object
     microsoft.graph.virtualEventExternalRegistrationInformation:
       title: virtualEventExternalRegistrationInformation
       type: object
@@ -178836,6 +196330,45 @@ components:
       type: object
       additionalProperties:
         type: object
+    microsoft.graph.plannerTaskChatMention:
+      title: plannerTaskChatMention
+      type: object
+      properties:
+        mentioned:
+          type: string
+          description: The ID of the mentioned user.
+          nullable: true
+        mentionType:
+          $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMentionType'
+        position:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: The zero-based position of the mention in the message content.
+          format: int32
+      additionalProperties:
+        type: object
+    microsoft.graph.plannerTaskChatMessageType:
+      title: plannerTaskChatMessageType
+      enum:
+        - richTextHtml
+        - plainText
+        - unknownFutureValue
+      type: string
+    microsoft.graph.plannerTaskChatReaction:
+      title: plannerTaskChatReaction
+      type: object
+      properties:
+        reactionEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.plannerTaskChatReactionEvent'
+        reactionType:
+          type: string
+          description: 'The type of reaction, such as like, heart, or emoji characters.'
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.allowedAudiences:
       title: allowedAudiences
       enum:
@@ -178972,6 +196505,25 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.sectionIconSkinTone:
+      title: sectionIconSkinTone
+      enum:
+        - light
+        - mediumLight
+        - medium
+        - mediumDark
+        - dark
+        - unknownFutureValue
+      type: string
+    microsoft.graph.sectionItemType:
+      title: sectionItemType
+      enum:
+        - chat
+        - channel
+        - meeting
+        - community
+        - unknownFutureValue
+      type: string
     microsoft.graph.attachmentBase:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -179076,18 +196628,6 @@ components:
               nullable: true
           additionalProperties:
             type: object
-    microsoft.graph.singleValueExtendedProperty:
-      allOf:
-        - $ref: '#/components/schemas/microsoft.graph.entity'
-        - title: singleValueExtendedProperty
-          type: object
-          properties:
-            value:
-              type: string
-              description: The value of the property.
-              nullable: true
-          additionalProperties:
-            type: object
     microsoft.graph.communicationsIdentitySet:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.identitySet'
@@ -179157,6 +196697,13 @@ components:
         - title: virtualEventSession
           type: object
           properties:
+            capacity:
+              maximum: 2147483647
+              minimum: -2147483648
+              type: number
+              description: Represents the expected number of attendees for town hall session.
+              format: int32
+              nullable: true
             endDateTime:
               $ref: '#/components/schemas/microsoft.graph.dateTimeTimeZone'
             startDateTime:
@@ -179189,6 +196736,14 @@ components:
               type: number
               description: Total capacity of the virtual event.
               format: int32
+              nullable: true
+            isManualApprovalEnabled:
+              type: boolean
+              description: Indicates whether registrations require organizer approval before a participant is confirmed.
+              nullable: true
+            isWaitlistEnabled:
+              type: boolean
+              description: Indicates whether more registrants are automatically placed on a waitlist when capacity is reached.
               nullable: true
             registrationWebUrl:
               type: string
@@ -180547,7 +198102,7 @@ components:
         maxLifetime:
           pattern: '^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$'
           type: string
-          description: 'String value that indicates the maximum lifetime for key expiration, defined as an ISO 8601 duration. For example, P4DT12H30M5S represents four days, 12 hours, 30 minutes, and five seconds. This property is required when restrictionType is set to keyLifetime.'
+          description: 'String value that indicates the maximum lifetime for key expiration, defined as an ISO 8601 duration. For example, P4DT12H30M5S represents four days, 12 hours, 30 minutes, and five seconds. This property is required when restrictionType is set to asymmetricKeyLifetime.'
           format: duration
           nullable: true
         restrictForAppsCreatedAfterDateTime:
@@ -180972,6 +198527,8 @@ components:
       properties:
         content:
           $ref: '#/components/schemas/microsoft.graph.contentBase'
+        contentCategory:
+          $ref: '#/components/schemas/microsoft.graph.contentCategory'
         correlationId:
           type: string
           description: 'An identifier used to group multiple related content entries (for example, different parts of the same file upload, messages in a conversation).'
@@ -181065,6 +198622,14 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.lockType:
+      title: lockType
+      enum:
+        - none
+        - exclusive
+        - shared
+        - unknownFutureValue
+      type: string
     microsoft.graph.mediaSourceContentCategory:
       title: mediaSourceContentCategory
       enum:
@@ -181601,6 +199166,15 @@ components:
         - deviceIntent
       type: string
       description: Authoring source of a policy
+    microsoft.graph.meetingEngagementType:
+      title: meetingEngagementType
+      enum:
+        - reaction
+        - hand
+        - camera
+        - microphone
+        - unknownFutureValue
+      type: string
     microsoft.graph.plannerApprovalStatus:
       title: plannerApprovalStatus
       enum:
@@ -181647,6 +199221,26 @@ components:
     microsoft.graph.Dictionary:
       title: Dictionary
       type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.plannerTaskChatMentionType:
+      title: plannerTaskChatMentionType
+      enum:
+        - user
+        - application
+        - unknownFutureValue
+      type: string
+    microsoft.graph.plannerTaskChatReactionEvent:
+      title: plannerTaskChatReactionEvent
+      type: object
+      properties:
+        createdBy:
+          $ref: '#/components/schemas/microsoft.graph.identitySet'
+        createdDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The date and time when the reaction was added. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
       additionalProperties:
         type: object
     microsoft.graph.storageQuotaBreakdown:
@@ -181893,7 +199487,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeExemption'
-          x-ms-navigationProperty: true
+          description: The collection of customSecurityAttributeExemption to exempt from the policy enforcement. Limit of 5.
       additionalProperties:
         type: object
     microsoft.graph.appKeyCredentialRestrictionType:
@@ -181954,7 +199548,7 @@ components:
           $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
         excludeAppsReceivingV2Tokens:
           type: boolean
-          description: 'If true, the restriction isn''t enforced for applications that are configured to receive V2 tokens in Microsoft Entra ID; else, the restriction isn''t enforced for those applications.'
+          description: 'If true, the restriction isn''t enforced for applications that are configured to receive V2 tokens in Microsoft Entra ID; else, the restriction is enforced for those applications.'
           nullable: true
         excludeSaml:
           type: boolean
@@ -182299,6 +199893,7 @@ components:
         - uploadFile
         - downloadText
         - downloadFile
+        - copyToClipboard
         - unknownFutureValue
       type: string
     microsoft.graph.contentBase:
@@ -182306,6 +199901,13 @@ components:
       type: object
       additionalProperties:
         type: object
+    microsoft.graph.contentCategory:
+      title: contentCategory
+      enum:
+        - none
+        - ai
+        - unknownFutureValue
+      type: string
     microsoft.graph.operatingSystemSpecifications:
       title: operatingSystemSpecifications
       type: object
@@ -182698,6 +200300,29 @@ components:
         - darkPink
         - darkYellow
         - unknownFutureValue
+        - darkRed
+        - cranberry
+        - darkOrange
+        - bronze
+        - peach
+        - gold
+        - lime
+        - forest
+        - lightGreen
+        - jade
+        - lightTeal
+        - darkTeal
+        - steel
+        - skyBlue
+        - blueGray
+        - lavender
+        - lilac
+        - plum
+        - magenta
+        - darkBrown
+        - beige
+        - charcoal
+        - silver
       type: string
     microsoft.graph.printTaskProcessingState:
       title: printTaskProcessingState
@@ -182714,6 +200339,8 @@ components:
         - title: customSecurityAttributeExemption
           type: object
           properties:
+            id:
+              type: string
             operator:
               $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeComparisonOperator'
           additionalProperties:
@@ -183566,6 +201193,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceUploadSessionCollectionResponse'
+    microsoft.graph.customDataProvidedResourceFileCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.customDataProvidedResourceFileCollectionResponse'
     microsoft.graph.accessPackageResourceCollectionResponse:
       description: Retrieved collection
       content:

--- a/openApiDocs/beta/Reports.yml
+++ b/openApiDocs/beta/Reports.yml
@@ -91,6 +91,342 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /admin/reportSettings/sharePoint:
+    get:
+      tags:
+        - admin.adminReportSettings
+      summary: Get sharePoint from admin
+      description: A container for SharePoint-specific report settings. Access the SharePoint API usage report metrics through the operations defined on the sharePointReportSettings resource type.
+      operationId: admin.reportSetting_GetSharePoint
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.sharePointReportSettings'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - admin.adminReportSettings
+      summary: Update the navigation property sharePoint in admin
+      operationId: admin.reportSetting_UpdateSharePoint
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.sharePointReportSettings'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.sharePointReportSettings'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - admin.adminReportSettings
+      summary: Delete navigation property sharePoint for admin
+      operationId: admin.reportSetting_DeleteSharePoint
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  /admin/reportSettings/sharePoint/apiUsageReportMetrics:
+    get:
+      tags:
+        - admin.adminReportSettings
+      summary: List apiUsageReportMetrics
+      description: 'Get the list of SharePoint API usage report metrics and their enablement status for the tenant. Currently, only the EgressReport metric is supported.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/sharepointreportsettings-list-apiusagereportmetrics?view=graph-rest-beta
+      operationId: admin.reportSetting.sharePoint_ListApiUsageReportMetric
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.apiUsageReportEnablementStatusCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - admin.adminReportSettings
+      summary: Create new navigation property to apiUsageReportMetrics for admin
+      operationId: admin.reportSetting.sharePoint_CreateApiUsageReportMetric
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.apiUsageReportEnablementStatus'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.apiUsageReportEnablementStatus'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/admin/reportSettings/sharePoint/apiUsageReportMetrics/{apiUsageReportEnablementStatus-metric}':
+    get:
+      tags:
+        - admin.adminReportSettings
+      summary: Get apiUsageReportMetrics from admin
+      description: The collection of API usage report metrics and the status of their enablement.
+      operationId: admin.reportSetting.sharePoint_GetApiUsageReportMetric
+      parameters:
+        - name: apiUsageReportEnablementStatus-metric
+          in: path
+          description: The unique identifier of apiUsageReportEnablementStatus
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: apiUsageReportEnablementStatus
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.apiUsageReportEnablementStatus'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - admin.adminReportSettings
+      summary: Update the navigation property apiUsageReportMetrics in admin
+      operationId: admin.reportSetting.sharePoint_UpdateApiUsageReportMetric
+      parameters:
+        - name: apiUsageReportEnablementStatus-metric
+          in: path
+          description: The unique identifier of apiUsageReportEnablementStatus
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: apiUsageReportEnablementStatus
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.apiUsageReportEnablementStatus'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.apiUsageReportEnablementStatus'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - admin.adminReportSettings
+      summary: Delete navigation property apiUsageReportMetrics for admin
+      operationId: admin.reportSetting.sharePoint_DeleteApiUsageReportMetric
+      parameters:
+        - name: apiUsageReportEnablementStatus-metric
+          in: path
+          description: The unique identifier of apiUsageReportEnablementStatus
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: apiUsageReportEnablementStatus
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  /admin/reportSettings/sharePoint/apiUsageReportMetrics/$count:
+    get:
+      tags:
+        - admin.adminReportSettings
+      summary: Get the number of the resource
+      operationId: admin.reportSetting.sharePoint.apiUsageReportMetric_GetCount
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  /admin/reportSettings/sharePoint/microsoft.graph.disableApiUsageReport:
+    post:
+      tags:
+        - admin.adminReportSettings
+      summary: Invoke action disableApiUsageReport
+      description: 'Disable a SharePoint API usage report metric for the tenant. After you disable a metric, SharePoint stops collecting and reporting data for that specific usage metric.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/sharepointreportsettings-disableapiusagereport?view=graph-rest-beta
+      operationId: admin.reportSetting.sharePoint_disableApiUsageReport
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                metric:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.apiUsageReportEnablementStatus'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  /admin/reportSettings/sharePoint/microsoft.graph.enableApiUsageReport:
+    post:
+      tags:
+        - admin.adminReportSettings
+      summary: Invoke action enableApiUsageReport
+      description: 'Enable a SharePoint API usage report metric for the tenant. After you enable a metric, SharePoint starts collecting and reporting data for that specific usage metric.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/sharepointreportsettings-enableapiusagereport?view=graph-rest-beta
+      operationId: admin.reportSetting.sharePoint_enableApiUsageReport
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                metric:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.apiUsageReportEnablementStatus'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   /auditLogs:
     get:
       tags:
@@ -150,6 +486,200 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  /auditLogs/auditActivityTypes:
+    get:
+      tags:
+        - auditLogs.auditActivityType
+      summary: List auditActivityType objects
+      description: Gets a list of all of the possible audit log types and which services they come from as defined in the auditActivityType object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/auditlogroot-list-auditactivitytypes?view=graph-rest-beta
+      operationId: auditLog_ListAuditActivityType
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.auditActivityTypeCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - auditLogs.auditActivityType
+      summary: Create new navigation property to auditActivityTypes for auditLogs
+      operationId: auditLog_CreateAuditActivityType
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.auditActivityType'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.auditActivityType'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/auditLogs/auditActivityTypes/{auditActivityType-id}':
+    get:
+      tags:
+        - auditLogs.auditActivityType
+      summary: Get auditActivityTypes from auditLogs
+      description: Represents an audit activity type which includes the associated service and category for a specific activity.
+      operationId: auditLog_GetAuditActivityType
+      parameters:
+        - name: auditActivityType-id
+          in: path
+          description: The unique identifier of auditActivityType
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: auditActivityType
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.auditActivityType'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - auditLogs.auditActivityType
+      summary: Update the navigation property auditActivityTypes in auditLogs
+      operationId: auditLog_UpdateAuditActivityType
+      parameters:
+        - name: auditActivityType-id
+          in: path
+          description: The unique identifier of auditActivityType
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: auditActivityType
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.auditActivityType'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.auditActivityType'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - auditLogs.auditActivityType
+      summary: Delete navigation property auditActivityTypes for auditLogs
+      operationId: auditLog_DeleteAuditActivityType
+      parameters:
+        - name: auditActivityType-id
+          in: path
+          description: The unique identifier of auditActivityType
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: auditActivityType
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  /auditLogs/auditActivityTypes/$count:
+    get:
+      tags:
+        - auditLogs.auditActivityType
+      summary: Get the number of the resource
+      operationId: auditLog.auditActivityType_GetCount
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /auditLogs/customSecurityAttributeAudits:
     get:
       tags:
@@ -730,6 +1260,237 @@ paths:
           $ref: '#/components/responses/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+  '/auditLogs/microsoft.graph.getSummarizedMSISignIns(aggregationWindow=''{aggregationWindow}'')':
+    get:
+      tags:
+        - auditLogs.auditLogRoot.Functions
+      summary: Invoke function getSummarizedMSISignIns
+      description: 'Returns aggregated MSI sign-in event counts grouped by user, application, IP address, and time window, with drill-down capability using individual requestIds via the /signIns endpoint.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/auditlogroot-getsummarizedmsisignins?view=graph-rest-beta
+      operationId: auditLog_getSummarizedMSISignIn
+      parameters:
+        - name: aggregationWindow
+          in: path
+          description: 'Usage: aggregationWindow=''{aggregationWindow}'''
+          required: true
+          style: simple
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.aggregationWindow'
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of summarizedSignIn
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.summarizedSignIn'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/auditLogs/microsoft.graph.getSummarizedNonInteractiveSignIns(aggregationWindow=''{aggregationWindow}'')':
+    get:
+      tags:
+        - auditLogs.auditLogRoot.Functions
+      summary: Invoke function getSummarizedNonInteractiveSignIns
+      description: 'Returns aggregated non-interactive sign-in event counts grouped by user, application, IP address, and time window, with drill-down capability using individual requestIds via the /signIns endpoint. This includes autonomous agent sign-in events.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/auditlogroot-getsummarizednoninteractivesignins?view=graph-rest-beta
+      operationId: auditLog_getSummarizedNonInteractiveSignIn
+      parameters:
+        - name: aggregationWindow
+          in: path
+          description: 'Usage: aggregationWindow=''{aggregationWindow}'''
+          required: true
+          style: simple
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.aggregationWindow'
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of summarizedSignIn
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.summarizedSignIn'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/auditLogs/microsoft.graph.getSummarizedServicePrincipalSignIns(aggregationWindow=''{aggregationWindow}'')':
+    get:
+      tags:
+        - auditLogs.auditLogRoot.Functions
+      summary: Invoke function getSummarizedServicePrincipalSignIns
+      description: 'Returns aggregated service principal sign-in event counts grouped by user, application, IP address, and time window, with drill-down capability using individual requestIds via the /signIns endpoint. This includes autonomous agent sign-in events.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/auditlogroot-getsummarizedserviceprincipalsignins?view=graph-rest-beta
+      operationId: auditLog_getSummarizedServicePrincipalSignIn
+      parameters:
+        - name: aggregationWindow
+          in: path
+          description: 'Usage: aggregationWindow=''{aggregationWindow}'''
+          required: true
+          style: simple
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.aggregationWindow'
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of summarizedSignIn
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.summarizedSignIn'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
   /auditLogs/provisioning:
     get:
       tags:
@@ -916,6 +1677,520 @@ paths:
         - auditLogs.provisioningObjectSummary
       summary: Get the number of the resource
       operationId: auditLog.provisioning_GetCount
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  /auditLogs/signInEventsAppSummary:
+    get:
+      tags:
+        - auditLogs.signInEventsAppActivity
+      summary: List signInEventsAppActivity objects
+      description: Get a list of applications and their number of sign-in events in the past 30 days as defined in the signInEventsAppActivity object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/auditlogroot-list-signineventsappsummary?view=graph-rest-beta
+      operationId: auditLog_ListSignInEventsAppSummary
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.signInEventsAppActivityCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - auditLogs.signInEventsAppActivity
+      summary: Create new navigation property to signInEventsAppSummary for auditLogs
+      operationId: auditLog_CreateSignInEventsAppSummary
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.signInEventsAppActivity'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.signInEventsAppActivity'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/auditLogs/signInEventsAppSummary/{signInEventsAppActivity-appId}':
+    get:
+      tags:
+        - auditLogs.signInEventsAppActivity
+      summary: Get signInEventsAppSummary from auditLogs
+      description: Represents the number of sign-in events for a specific application.
+      operationId: auditLog_GetSignInEventsAppSummary
+      parameters:
+        - name: signInEventsAppActivity-appId
+          in: path
+          description: The unique identifier of signInEventsAppActivity
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: signInEventsAppActivity
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.signInEventsAppActivity'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - auditLogs.signInEventsAppActivity
+      summary: Update the navigation property signInEventsAppSummary in auditLogs
+      operationId: auditLog_UpdateSignInEventsAppSummary
+      parameters:
+        - name: signInEventsAppActivity-appId
+          in: path
+          description: The unique identifier of signInEventsAppActivity
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: signInEventsAppActivity
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.signInEventsAppActivity'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.signInEventsAppActivity'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - auditLogs.signInEventsAppActivity
+      summary: Delete navigation property signInEventsAppSummary for auditLogs
+      operationId: auditLog_DeleteSignInEventsAppSummary
+      parameters:
+        - name: signInEventsAppActivity-appId
+          in: path
+          description: The unique identifier of signInEventsAppActivity
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: signInEventsAppActivity
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/auditLogs/signInEventsAppSummary/{signInEventsAppActivity-appId}/application':
+    get:
+      tags:
+        - auditLogs.signInEventsAppActivity
+      summary: Get application from auditLogs
+      description: Represents an application registered in Microsoft Entra ID.
+      operationId: auditLog.signInEventsAppSummary_GetApplication
+      parameters:
+        - name: signInEventsAppActivity-appId
+          in: path
+          description: The unique identifier of signInEventsAppActivity
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: signInEventsAppActivity
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.application'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/auditLogs/signInEventsAppSummary/{signInEventsAppActivity-appId}/application/logo':
+    get:
+      tags:
+        - auditLogs.signInEventsAppActivity
+      summary: Get logo for the navigation property application from auditLogs
+      description: The main logo for the application. Not nullable.
+      operationId: auditLog.signInEventsAppSummary_GetApplicationLogo
+      parameters:
+        - name: signInEventsAppActivity-appId
+          in: path
+          description: The unique identifier of signInEventsAppActivity
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: signInEventsAppActivity
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - auditLogs.signInEventsAppActivity
+      summary: Update logo for the navigation property application in auditLogs
+      description: The main logo for the application. Not nullable.
+      operationId: auditLog.signInEventsAppSummary_SetApplicationLogo
+      parameters:
+        - name: signInEventsAppActivity-appId
+          in: path
+          description: The unique identifier of signInEventsAppActivity
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: signInEventsAppActivity
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - auditLogs.signInEventsAppActivity
+      summary: Delete logo for the navigation property application in auditLogs
+      description: The main logo for the application. Not nullable.
+      operationId: auditLog.signInEventsAppSummary_DeleteApplicationLogo
+      parameters:
+        - name: signInEventsAppActivity-appId
+          in: path
+          description: The unique identifier of signInEventsAppActivity
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: signInEventsAppActivity
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  /auditLogs/signInEventsAppSummary/$count:
+    get:
+      tags:
+        - auditLogs.signInEventsAppActivity
+      summary: Get the number of the resource
+      operationId: auditLog.signInEventsAppSummary_GetCount
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  /auditLogs/signInEventsSummary:
+    get:
+      tags:
+        - auditLogs.signInEventsActivity
+      summary: List signInEventsActivity objects
+      description: Get a list of the number of signin events for a specific day as defined in the signInEventsActivity object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/auditlogroot-list-signineventssummary?view=graph-rest-beta
+      operationId: auditLog_ListSignInEventsSummary
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.signInEventsActivityCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - auditLogs.signInEventsActivity
+      summary: Create new navigation property to signInEventsSummary for auditLogs
+      operationId: auditLog_CreateSignInEventsSummary
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.signInEventsActivity'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.signInEventsActivity'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/auditLogs/signInEventsSummary/{signInEventsActivity-id}':
+    get:
+      tags:
+        - auditLogs.signInEventsActivity
+      summary: Get signInEventsSummary from auditLogs
+      description: Represents the total number of sign-in events for a specific day.
+      operationId: auditLog_GetSignInEventsSummary
+      parameters:
+        - name: signInEventsActivity-id
+          in: path
+          description: The unique identifier of signInEventsActivity
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: signInEventsActivity
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.signInEventsActivity'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - auditLogs.signInEventsActivity
+      summary: Update the navigation property signInEventsSummary in auditLogs
+      operationId: auditLog_UpdateSignInEventsSummary
+      parameters:
+        - name: signInEventsActivity-id
+          in: path
+          description: The unique identifier of signInEventsActivity
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: signInEventsActivity
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.signInEventsActivity'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.signInEventsActivity'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - auditLogs.signInEventsActivity
+      summary: Delete navigation property signInEventsSummary for auditLogs
+      operationId: auditLog_DeleteSignInEventsSummary
+      parameters:
+        - name: signInEventsActivity-id
+          in: path
+          description: The unique identifier of signInEventsActivity
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: signInEventsActivity
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  /auditLogs/signInEventsSummary/$count:
+    get:
+      tags:
+        - auditLogs.signInEventsActivity
+      summary: Get the number of the resource
+      operationId: auditLog.signInEventsSummary_GetCount
       parameters:
         - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/filter'
@@ -6736,76 +8011,6 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
-  /deviceManagement/reports/microsoft.graph.getZebraFotaDeploymentReport:
-    post:
-      tags:
-        - deviceManagement.deviceManagementReports
-      summary: Invoke action getZebraFotaDeploymentReport
-      operationId: deviceManagement.report_getZebraFotaDeploymentReport
-      requestBody:
-        description: Action parameters
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  nullable: true
-                select:
-                  type: array
-                  items:
-                    type: string
-                    nullable: true
-                search:
-                  type: string
-                  nullable: true
-                groupBy:
-                  type: array
-                  items:
-                    type: string
-                    nullable: true
-                orderBy:
-                  type: array
-                  items:
-                    type: string
-                    nullable: true
-                skip:
-                  maximum: 2147483647
-                  minimum: -2147483648
-                  type: number
-                  format: int32
-                top:
-                  maximum: 2147483647
-                  minimum: -2147483648
-                  type: number
-                  format: int32
-                sessionId:
-                  type: string
-                  nullable: true
-                filter:
-                  type: string
-                  nullable: true
-              additionalProperties:
-                type: object
-        required: true
-      responses:
-        2XX:
-          description: Success
-          content:
-            application/octet-stream:
-              schema:
-                type: object
-                properties:
-                  value:
-                    type: string
-                    format: base64url
-                    nullable: true
-                additionalProperties:
-                  type: object
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: action
   /deviceManagement/reports/microsoft.graph.retrieveAndroidWorkProfileDeviceMigrationStatuses:
     post:
       tags:
@@ -8979,6 +10184,87 @@ paths:
           $ref: '#/components/responses/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+  /reports/azureADPremiumLicenseInsight:
+    get:
+      tags:
+        - reports.azureADPremiumLicenseInsight
+      summary: Get azureADPremiumLicenseInsight
+      description: Get the premium license utilization insight for the tenant. This API returns data about how many premium licenses are entitled and how the associated P1 and P2 features are being used. The calling tenant must have at least one Microsoft Entra ID P1 or P2 license. Tenants without a premium license receive a 403 Forbidden response with the missingLicense error code.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/azureadpremiumlicenseinsight-get?view=graph-rest-beta
+      operationId: report_GetAzureADPremiumLicenseInsight
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.azureADPremiumLicenseInsight'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - reports.azureADPremiumLicenseInsight
+      summary: Update the navigation property azureADPremiumLicenseInsight in reports
+      operationId: report_UpdateAzureADPremiumLicenseInsight
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.azureADPremiumLicenseInsight'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.azureADPremiumLicenseInsight'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - reports.azureADPremiumLicenseInsight
+      summary: Delete navigation property azureADPremiumLicenseInsight for reports
+      operationId: report_DeleteAzureADPremiumLicenseInsight
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   /reports/credentialUserRegistrationDetails:
     get:
       tags:
@@ -19173,6 +20459,890 @@ paths:
       x-ms-pageable:
         nextLinkName: '@odata.nextLink'
         operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessInternetAppPolicyAllowedApps(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessInternetAppPolicyAllowedApps
+      description: Retrieve the number of internet applications allowed by web content filtering policies applied to specific FQDNs using Global Secure Access client.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessinternetapppolicyallowedapps?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessInternetAppPolicyAllowedApp
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessInternetAppPolicyAllowedUsers(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessInternetAppPolicyAllowedUsers
+      description: Retrieve the number of users allowed by web content filtering policies applied to specific FQDNs using Global Secure Access client.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessinternetapppolicyallowedusers?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessInternetAppPolicyAllowedUser
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessInternetAppPolicyBlockedApps(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessInternetAppPolicyBlockedApps
+      description: Retrieve the number of internet applications that were blocked due to web content filtering policies applied to specific FQDNs using Global Secure Access client. Microsoft Entra Internet Access traffic may be restricted when these policies are enforced.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessinternetapppolicyblockedapps?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessInternetAppPolicyBlockedApp
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessInternetAppPolicyBlockedUsers(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessInternetAppPolicyBlockedUsers
+      description: Retrieve the number of users' internet application access attempts blocked due to web content filtering policies applied to specific FQDNs using Global Secure Access client.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessinternetapppolicyblockedusers?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessInternetAppPolicyBlockedUser
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessPrivateAppsAllowedByConnector(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessPrivateAppsAllowedByConnector
+      description: Retrieve the number of private applications that were allowed using Global Secure Access client.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessprivateappsallowedbyconnector?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessPrivateAppsAllowedGraphBPreConnector
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessPrivateAppsBlockedByConnector(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessPrivateAppsBlockedByConnector
+      description: Retrieve the number of private applications that were blocked due to connector unavailability using Global Secure Access client. Microsoft Entra Private Access traffic could not reach the private application because the connector was either down or unreachable due to network connectivity issues.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessprivateappsblockedbyconnector?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessPrivateAppsBlockedGraphBPreConnector
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessPrivateAppUsersAllowedByConnector(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessPrivateAppUsersAllowedByConnector
+      description: Retrieve the number of users' private application access attempts that were allowed using Global Secure Access client.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessprivateappusersallowedbyconnector?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessPrivateAppUsersAllowedGraphBPreConnector
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessPrivateAppUsersBlockedByConnector(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessPrivateAppUsersBlockedByConnector
+      description: Retrieve the number of users' private application access attempts that were blocked due to connector unavailability using Global Secure Access client. Microsoft Entra Private Access traffic could not reach the private application because the connector was either down or unreachable due to network connectivity issues.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessprivateappusersblockedbyconnector?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessPrivateAppUsersBlockedGraphBPreConnector
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessRemoteNetworkBranchesAlive(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessRemoteNetworkBranchesAlive
+      description: Retrieve the number of remote networks which are connected. A remote network represents a location such as a branch office where customer premises equipment (CPE) is connected to the nearest deployment of Global Secure Access service through IPsec tunnels.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessremotenetworkbranchesalive?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessRemoteNetworkBranchesAlive
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessRemoteNetworkBranchesBGPConnected(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessRemoteNetworkBranchesBGPConnected
+      description: Retrieve the number of remote networks with connected BGP. A remote network represents a location such as a branch office where customer premises equipment (CPE) is connected to the nearest deployment of Global Secure Access service through IPsec tunnels.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessremotenetworkbranchesbgpconnected?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessRemoteNetworkBranchesBGPConnected
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessRemoteNetworkBranchesBGPDisconnected(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessRemoteNetworkBranchesBGPDisconnected
+      description: Retrieve the number of remote networks which are disconnected due to BGP being down. A remote network represents a location such as a branch office where customer premises equipment (CPE) is connected to the nearest deployment of Global Secure Access service through IPsec tunnels.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessremotenetworkbranchesbgpdisconnected?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessRemoteNetworkBranchesBGPDisconnected
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessRemoteNetworkBranchesTunnelConnected(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessRemoteNetworkBranchesTunnelConnected
+      description: Retrieve the number of remote network tunnels which are connected. A remote network represents a location such as a branch office where customer premises equipment (CPE) is connected to the nearest deployment of Global Secure Access service through IPsec tunnels.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessremotenetworkbranchestunnelconnected?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessRemoteNetworkBranchesTunnelConnected
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/reports/serviceActivity/microsoft.graph.getMetricsForNetworkAccessRemoteNetworkBranchesTunnelDisconnected(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
+    get:
+      tags:
+        - reports.serviceActivity
+      summary: Invoke function getMetricsForNetworkAccessRemoteNetworkBranchesTunnelDisconnected
+      description: Retrieve the number of remote networks which are disconnected due to the tunnel being down. A remote network represents a location such as a branch office where customer premises equipment (CPE) is connected to the nearest deployment of Global Secure Access service through IPsec tunnels.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/serviceactivity-getmetricsfornetworkaccessremotenetworkbranchestunneldisconnected?view=graph-rest-beta
+      operationId: report.serviceActivity_getMetricsGraphFPreNetworkAccessRemoteNetworkBranchesTunnelDisconnected
+      parameters:
+        - name: inclusiveIntervalStartDateTime
+          in: path
+          description: 'Usage: inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: exclusiveIntervalEndDateTime
+          in: path
+          description: 'Usage: exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime}'
+          required: true
+          style: simple
+          schema:
+            pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+            type: string
+            format: date-time
+        - name: aggregationIntervalInMinutes
+          in: query
+          description: 'Usage: aggregationIntervalInMinutes=@aggregationIntervalInMinutes'
+          style: form
+          explode: false
+          schema:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+            nullable: true
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.serviceActivityValueMetric'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
   '/reports/serviceActivity/microsoft.graph.getMetricsForSamlSignInSuccess(inclusiveIntervalStartDateTime={inclusiveIntervalStartDateTime},exclusiveIntervalEndDateTime={exclusiveIntervalEndDateTime},aggregationIntervalInMinutes=@aggregationIntervalInMinutes)':
     get:
       tags:
@@ -22439,12 +24609,45 @@ components:
             displayConcealedNames:
               type: boolean
               description: 'If set to true, all reports conceal user information such as usernames, groups, and sites. If false, all reports show identifiable information. This property represents a setting in the Microsoft 365 admin center. Required.'
+            sharePoint:
+              $ref: '#/components/schemas/microsoft.graph.sharePointReportSettings'
           additionalProperties:
             type: object
+    microsoft.graph.sharePointReportSettings:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: sharePointReportSettings
+          type: object
+          properties:
+            apiUsageReportMetrics:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.apiUsageReportEnablementStatus'
+              description: The collection of API usage report metrics and the status of their enablement.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.apiUsageReportEnablementStatus:
+      title: apiUsageReportEnablementStatus
+      type: object
+      properties:
+        metric:
+          type: string
+          description: 'The name of the API usage report metric. Currently, only EgressReport is supported.'
+        onboardingStatus:
+          $ref: '#/components/schemas/microsoft.graph.apiUsageReportOnboardingStatus'
+      additionalProperties:
+        type: object
     microsoft.graph.auditLogRoot:
       title: auditLogRoot
       type: object
       properties:
+        auditActivityTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.auditActivityType'
+          description: Represents an audit activity type which includes the associated service and category for a specific activity.
+          x-ms-navigationProperty: true
         customSecurityAttributeAudits:
           type: array
           items:
@@ -22467,6 +24670,18 @@ components:
             $ref: '#/components/schemas/microsoft.graph.provisioningObjectSummary'
           description: Represents an action performed by the Microsoft Entra provisioning service and its associated properties.
           x-ms-navigationProperty: true
+        signInEventsAppSummary:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.signInEventsAppActivity'
+          description: Represents the number of sign-in events for a specific application.
+          x-ms-navigationProperty: true
+        signInEventsSummary:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.signInEventsActivity'
+          description: Represents the total number of sign-in events for a specific day.
+          x-ms-navigationProperty: true
         signIns:
           type: array
           items:
@@ -22481,6 +24696,26 @@ components:
           x-ms-navigationProperty: true
       additionalProperties:
         type: object
+    microsoft.graph.auditActivityType:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: auditActivityType
+          type: object
+          properties:
+            activity:
+              type: string
+              description: 'Indicates the activity name or the operation name (for example ''Create User'', ''Add member to group''). For a list of activities logged, refer to Microsoft Entra audit log categories and activities. Supports $filter (eq).'
+              nullable: true
+            category:
+              type: string
+              description: 'Indicates which resource category that''s targeted by the activity. For example: UserManagement, GroupManagement, ApplicationManagement, RoleManagement. For a list of categories for activities logged, refer to Microsoft Entra audit log categories and activities. Supports $filter (eq).'
+              nullable: true
+            service:
+              type: string
+              description: 'Indicates information on which service initiated the activity. For example: Self-service Password Management, Core Directory, B2C, Invited Users, Microsoft Identity Manager, Privileged Identity Management. Supports $filter (eq).'
+              nullable: true
+          additionalProperties:
+            type: object
     microsoft.graph.customSecurityAttributeAudit:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -22560,6 +24795,8 @@ components:
               type: string
               description: 'Indicates the type of operation that was performed. The possible values include but aren''t limited to the following: Add, Assign, Update, Unassign, and Delete.'
               nullable: true
+            performedBy:
+              $ref: '#/components/schemas/microsoft.graph.auditActivityPerformer'
             result:
               $ref: '#/components/schemas/microsoft.graph.operationResult'
             resultReason:
@@ -22642,6 +24879,329 @@ components:
             tenantId:
               type: string
               description: 'Unique Microsoft Entra tenant ID. Supports $filter (eq, contains).'
+              nullable: true
+          additionalProperties:
+            type: object
+    microsoft.graph.aggregationWindow:
+      title: aggregationWindow
+      enum:
+        - h1
+        - h6
+        - d1
+        - unknownFutureValue
+      type: string
+    microsoft.graph.summarizedSignIn:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: summarizedSignIn
+          type: object
+          properties:
+            agent:
+              $ref: '#/components/schemas/microsoft.graph.agentic.agentSignIn'
+            aggregationDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The aggregated day for which the summary applies to. This property always represents the entire day. The DateTimeOffset type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            appDisplayName:
+              type: string
+              description: The application name displayed in the Microsoft Entra admin center. Supports $filter (eq).
+              nullable: true
+            appId:
+              type: string
+              description: The application identifier (client ID) in Microsoft Entra ID. Supports $filter (eq).
+              nullable: true
+            conditionalAccessStatus:
+              $ref: '#/components/schemas/microsoft.graph.conditionalAccessStatus'
+            firstSignInDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The earliest sign-in event included in this summary. This property always represents the entire day. The DateTimeOffset type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            ipAddress:
+              type: string
+              description: 'The IP address a user or autonomous agent used to reach a resource provider, used to determine Conditional Access compliance for some policies. For example, when a user interacts with Exchange Online, the IP address that Microsoft Exchange receives from the user can be recorded here. This value is often null. Supports $filter (eq, startswith).'
+              nullable: true
+            managedServiceIdentity:
+              $ref: '#/components/schemas/microsoft.graph.managedIdentity'
+            resourceDisplayName:
+              type: string
+              description: The name of the resource that the user signed in to. Supports $filter (eq).
+              nullable: true
+            resourceId:
+              type: string
+              description: The application identifier of the resource application that the user signed in to. Supports $filter (eq).
+              nullable: true
+            servicePrincipalId:
+              type: string
+              description: The application identifier of the specific service principal instance of the application identifier used for sign-in. This field is populated when you're signing in using an application and is different than the appId property. Supports $filter (eq).
+              nullable: true
+            servicePrincipalName:
+              type: string
+              description: 'The application name used for sign-in. This field is populated when you''re signing in using an application. Supports $filter (eq, startswith).'
+              nullable: true
+            signInCount:
+              type: number
+              description: The total number of sign-in events included in the summary.
+              format: int64
+              nullable: true
+            status:
+              $ref: '#/components/schemas/microsoft.graph.signInStatus'
+            tenantId:
+              type: string
+              description: The tenant identifier of the user initiating the sign-in. Supports $filter (eq).
+              nullable: true
+            tokenIssuerType:
+              $ref: '#/components/schemas/microsoft.graph.tokenIssuerType'
+            userPrincipalName:
+              type: string
+              description: 'User principal name of the user that initiated the sign-in. This value is always in lowercase. For guest users whose values in the user object typically contain #EXT# before the domain part, this property stores the value in both lowercase and the ''true'' format. For example, while the user object stores AdeleVance_fabrikam.com#EXT#@contoso.com, the sign-in logs store adelevance@fabrikam.com. Supports $filter (eq).'
+              nullable: true
+          additionalProperties:
+            type: object
+    microsoft.graph.signInEventsAppActivity:
+      title: signInEventsAppActivity
+      type: object
+      properties:
+        appId:
+          type: string
+          description: The application ID for the given summary. Supports $filter (eq).
+        signInCount:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: The total number of sign-in events for the given application. Supports $filter (gt).
+          format: int32
+        tenantId:
+          type: string
+          description: The tenant ID where sign-in events occurred.
+        application:
+          $ref: '#/components/schemas/microsoft.graph.application'
+      additionalProperties:
+        type: object
+    microsoft.graph.application:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.directoryObject'
+        - title: application
+          type: object
+          properties:
+            api:
+              $ref: '#/components/schemas/microsoft.graph.apiApplication'
+            appId:
+              type: string
+              description: The unique identifier for the application that is assigned by Microsoft Entra ID. Not nullable. Read-only. Alternate key. Supports $filter (eq).
+              nullable: true
+            appRoles:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.appRole'
+              description: 'The collection of roles defined for the application. With app role assignments, these roles can be assigned to users, groups, or service principals associated with other applications. Not nullable.'
+            authenticationBehaviors:
+              $ref: '#/components/schemas/microsoft.graph.authenticationBehaviors'
+            certification:
+              $ref: '#/components/schemas/microsoft.graph.certification'
+            createdByAppId:
+              type: string
+              description: The appId of the application that created this application. Set internally by Microsoft Entra ID. Read-only.
+              nullable: true
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time the application was registered. The DateTimeOffset type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.  Supports $filter (eq, ne, not, ge, le, in, and eq on null values) and $orderby.'
+              format: date-time
+              nullable: true
+            defaultRedirectUri:
+              type: string
+              description: 'The default redirect URI. If specified and there''s no explicit redirect URI in the sign-in request for SAML and OIDC flows, Microsoft Entra ID sends the token to this redirect URI. Microsoft Entra ID also sends the token to this default URI in SAML IdP-initiated single sign-on. The value must match one of the configured redirect URIs for the application.'
+              nullable: true
+            description:
+              type: string
+              description: 'Free text field to provide a description of the application object to end users. The maximum allowed size is 1,024 characters. Returned by default. Supports $filter (eq, ne, not, ge, le, startsWith) and $search.'
+              nullable: true
+            disabledByMicrosoftStatus:
+              type: string
+              description: 'Specifies whether Microsoft has disabled the registered application. The possible values are: null (default value), NotDisabled, and DisabledDueToViolationOfServicesAgreement (reasons may include suspicious, abusive, or malicious activity, or a violation of the Microsoft Services Agreement).  Supports $filter (eq, ne, not).'
+              nullable: true
+            displayName:
+              type: string
+              description: 'The display name for the application. Maximum length is 256 characters. Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values), $search, and $orderby.'
+              nullable: true
+            groupMembershipClaims:
+              type: string
+              description: 'Configures the groups claim issued in a user or OAuth 2.0 access token that the application expects. To set this attribute, use one of the following string values: None, SecurityGroup (for security groups and Microsoft Entra roles), All (this gets all security groups, distribution groups, and Microsoft Entra directory roles that the signed-in user is a member of).'
+              nullable: true
+            identifierUris:
+              type: array
+              items:
+                type: string
+              description: 'Also known as App ID URI, this value is set when an application is used as a resource app. The identifierUris acts as the prefix for the scopes you reference in your API''s code, and it must be globally unique across Microsoft Entra ID. For more information on valid identifierUris patterns and best practices, see Microsoft Entra application registration security best practices. Not nullable. Supports $filter (eq, ne, ge, le, startsWith).'
+            info:
+              $ref: '#/components/schemas/microsoft.graph.informationalUrl'
+            isDeviceOnlyAuthSupported:
+              type: boolean
+              description: Specifies whether this application supports device authentication without a user. The default is false.
+              nullable: true
+            isDisabled:
+              type: boolean
+              description: 'Deactivate an app without deleting it. This configuration specifies whether the service principal of the app in a tenant or across tenants for multi-tenant apps can obtain new access tokens or access protected resources. When set to true, existing tokens remain valid until they expire based on their configured lifetimes, and the app stays visible in the Enterprise apps list but users cannot sign in.true if the application is deactivated (disabled); otherwise false. Learn more in Deactivate an app registration.'
+              nullable: true
+            isFallbackPublicClient:
+              type: boolean
+              description: 'Specifies the fallback application type as public client, such as an installed application running on a mobile device. The default value is false, which means the fallback application type is confidential client such as a web app. There are certain scenarios where Microsoft Entra ID can''t determine the client application type. For example, the ROPC flow where the application is configured without specifying a redirect URI. In those cases Microsoft Entra ID interprets the application type based on the value of this property.'
+              nullable: true
+            keyCredentials:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.keyCredential'
+              description: 'The collection of key credentials associated with the application. Not nullable. Supports $filter (eq, not, ge, le).'
+            logo:
+              type: string
+              description: The main logo for the application. Not nullable.
+              format: base64url
+            managerApplications:
+              type: array
+              items:
+                pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+                type: string
+                format: uuid
+              description: 'A collection of application IDs for applications designated as managers of this application. Manager applications can create service principals for the applications they manage. Currently, only Microsoft first-party application IDs can be set as values. Maximum of 10 values. Not nullable. Read-only for third-party (3P) callers; writes by 3P callers are rejected with a 400 Bad Request error. Requires $select to retrieve.'
+            nativeAuthenticationApisEnabled:
+              $ref: '#/components/schemas/microsoft.graph.nativeAuthenticationApisEnabled'
+            notes:
+              type: string
+              description: Notes relevant for the management of the application.
+              nullable: true
+            onPremisesPublishing:
+              $ref: '#/components/schemas/microsoft.graph.onPremisesPublishing'
+            optionalClaims:
+              $ref: '#/components/schemas/microsoft.graph.optionalClaims'
+            parentalControlSettings:
+              $ref: '#/components/schemas/microsoft.graph.parentalControlSettings'
+            passwordCredentials:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.passwordCredential'
+              description: The collection of password credentials associated with the application. Not nullable.
+            publicClient:
+              $ref: '#/components/schemas/microsoft.graph.publicClientApplication'
+            publisherDomain:
+              type: string
+              description: 'The verified publisher domain for the application. Read-only. Supports $filter (eq, ne, ge, le, startsWith).'
+              nullable: true
+            requestSignatureVerification:
+              $ref: '#/components/schemas/microsoft.graph.requestSignatureVerification'
+            requiredResourceAccess:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.requiredResourceAccess'
+              description: 'Specifies the resources that the application needs to access. This property also specifies the set of delegated permissions and application roles that it needs for each of those resources. This configuration of access to the required resources drives the consent experience. No more than 50 resource services (APIs) can be configured. Beginning mid-October 2021, the total number of required permissions must not exceed 400. For more information, see Limits on requested permissions per app. Not nullable. Supports $filter (eq, not, ge, le).'
+            samlMetadataUrl:
+              type: string
+              description: The URL where the service exposes SAML metadata for federation. This property is valid only for single-tenant applications. Nullable.
+              nullable: true
+            serviceManagementReference:
+              type: string
+              description: References application or service contact information from a Service or Asset Management database. Nullable.
+              nullable: true
+            servicePrincipalLockConfiguration:
+              $ref: '#/components/schemas/microsoft.graph.servicePrincipalLockConfiguration'
+            signInAudience:
+              type: string
+              description: 'Specifies the Microsoft accounts that are supported for the current application. The possible values are: AzureADMyOrg (default), AzureADMultipleOrgs, AzureADandPersonalMicrosoftAccount, and PersonalMicrosoftAccount. See more in the table. The value of this object also limits the number of permissions an app can request. For more information, see Limits on requested permissions per app. The value for this property has implications on other app object properties. As a result, if you change this property, you may need to change other properties first. For more information, see Validation differences for signInAudience.Supports $filter (eq, ne, not).'
+              nullable: true
+            signInAudienceRestrictions:
+              $ref: '#/components/schemas/microsoft.graph.signInAudienceRestrictionsBase'
+            spa:
+              $ref: '#/components/schemas/microsoft.graph.spaApplication'
+            tags:
+              type: array
+              items:
+                type: string
+              description: 'Custom strings that can be used to categorize and identify the application. Not nullable. Strings added here also appear in the tags property of any associated service principals.Supports $filter (eq, not, ge, le, startsWith) and $search.'
+            tokenEncryptionKeyId:
+              pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+              type: string
+              description: 'Specifies the keyId of a public key from the keyCredentials collection. When configured, Microsoft Entra ID encrypts all the tokens it emits by using the key this property points to. The application code that receives the encrypted token must use the matching private key to decrypt the token before it can be used for the signed-in user.'
+              format: uuid
+              nullable: true
+            uniqueName:
+              type: string
+              description: The unique identifier that can be assigned to an application and used as an alternate key. Immutable. Read-only.
+              nullable: true
+            verifiedPublisher:
+              $ref: '#/components/schemas/microsoft.graph.verifiedPublisher'
+            web:
+              $ref: '#/components/schemas/microsoft.graph.webApplication'
+            windows:
+              $ref: '#/components/schemas/microsoft.graph.windowsApplication'
+            appManagementPolicies:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.appManagementPolicy'
+              description: The appManagementPolicy applied to this application.
+              x-ms-navigationProperty: true
+            connectorGroup:
+              $ref: '#/components/schemas/microsoft.graph.connectorGroup'
+            createdOnBehalfOf:
+              $ref: '#/components/schemas/microsoft.graph.directoryObject'
+            extensionProperties:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.extensionProperty'
+              description: 'Read-only. Nullable. Supports $expand and $filter (/$count eq 0, /$count ne 0).'
+              x-ms-navigationProperty: true
+            federatedIdentityCredentials:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.federatedIdentityCredential'
+              description: 'Federated identities for applications. Supports $expand and $filter (startsWith, /$count eq 0, /$count ne 0).'
+              x-ms-navigationProperty: true
+            homeRealmDiscoveryPolicies:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.homeRealmDiscoveryPolicy'
+              x-ms-navigationProperty: true
+            owners:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.directoryObject'
+              description: 'Directory objects that are owners of this application. The owners are a set of nonadmin users or service principals allowed to modify this object. Read-only. Nullable. Supports $expand, $filter (/$count eq 0, /$count ne 0, /$count eq 1, /$count ne 1), and $select nested in $expand.'
+              x-ms-navigationProperty: true
+            synchronization:
+              $ref: '#/components/schemas/microsoft.graph.synchronization'
+            tokenIssuancePolicies:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.tokenIssuancePolicy'
+              x-ms-navigationProperty: true
+            tokenLifetimePolicies:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.tokenLifetimePolicy'
+              description: The tokenLifetimePolicies assigned to this application. Supports $expand.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.signInEventsActivity:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: signInEventsActivity
+          type: object
+          properties:
+            activityDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The aggregated day for which the summary applies to. This property always represents the entire day. The DateTimeOffset type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Supports $filter (gt, lt).'
+              format: date-time
+              nullable: true
+            signInCount:
+              maximum: 2147483647
+              minimum: -2147483648
+              type: number
+              description: 'The number of sign-in events that occurred for this day. Supports $filter (gt, lt, eq).'
+              format: int32
               nullable: true
           additionalProperties:
             type: object
@@ -22733,6 +25293,9 @@ components:
               nullable: true
             clientCredentialType:
               $ref: '#/components/schemas/microsoft.graph.clientCredentialType'
+            clientSessionId:
+              type: string
+              nullable: true
             conditionalAccessAudiences:
               type: array
               items:
@@ -22885,7 +25448,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: 'Indicates the category of sign in that the event represents. For user sign ins, the category can be interactiveUser or nonInteractiveUser and corresponds to the value for the isInteractive property on the signin resource. For managed identity sign ins, the category is managedIdentity. For service principal sign-ins, the category is servicePrincipal. Possible values are: interactiveUser, nonInteractiveUser, servicePrincipal, managedIdentity, unknownFutureValue.  Supports $filter (eq, ne). NOTE: Only interactive sign-ins are returned unless you set an explicit filter. For example, the filter for getting non-interactive sign-ins is https://graph.microsoft.com/beta/auditLogs/signIns?&$filter=signInEventTypes/any(t: t eq ''nonInteractiveUser'').'
+              description: 'Indicates the category of sign in that the event represents. For user sign ins, the category can be interactiveUser or nonInteractiveUser and corresponds to the value for the isInteractive property on the signin resource. For managed identity sign ins, the category is managedIdentity. For service principal sign-ins, the category is servicePrincipal. The possible values are: interactiveUser, nonInteractiveUser, servicePrincipal, managedIdentity, unknownFutureValue.  Supports $filter (eq, ne). NOTE: Only interactive sign-ins are returned unless you set an explicit filter. For example, the filter for getting non-interactive sign-ins is https://graph.microsoft.com/beta/auditLogs/signIns?&$filter=signInEventTypes/any(t: t eq ''nonInteractiveUser''). You can also get both interactive and non-interactive sign-ins using the filter signInEventTypes/any(t: t eq ''interactiveUser'' or t eq ''noninteractiveUser''). However, the filter for getting both user and service principal sign-in even types is not supported.'
             signInIdentifier:
               type: string
               description: 'The identification that the user provided to sign in. It can be the userPrincipalName, but is also populated when a user signs in using other identifiers.'
@@ -22954,6 +25517,8 @@ components:
               type: string
               description: 'Date and time (UTC) the sign-up was initiated. Example: midnight on Jan 1, 2014 is reported as 2014-01-01T00:00:00Z.  Supports $orderby, $filter (eq, le, and ge).'
               format: date-time
+            fraudProtectionDetails:
+              $ref: '#/components/schemas/microsoft.graph.fraudProtectionDetails'
             signUpIdentity:
               $ref: '#/components/schemas/microsoft.graph.signUpIdentity'
             signUpIdentityProvider:
@@ -23104,6 +25669,8 @@ components:
               x-ms-navigationProperty: true
             authenticationMethods:
               $ref: '#/components/schemas/microsoft.graph.authenticationMethodsRoot'
+            azureADPremiumLicenseInsight:
+              $ref: '#/components/schemas/microsoft.graph.azureADPremiumLicenseInsight'
             credentialUserRegistrationDetails:
               type: array
               items:
@@ -23523,7 +26090,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: 'Collection of authentication methods that the system determined to be the most secure authentication methods among the registered methods for second factor authentication. Possible values are: push, oath, voiceMobile, voiceAlternateMobile, voiceOffice, sms, none, unknownFutureValue. Supports $filter (any with eq).'
+              description: 'Collection of authentication methods that the system determined to be the most secure authentication methods among the registered methods for second factor authentication. The possible values are: push, oath, voiceMobile, voiceAlternateMobile, voiceOffice, sms, none, unknownFutureValue. Supports $filter (any with eq).'
             userDisplayName:
               type: string
               description: 'The user display name, such as Adele Vance. Supports $filter (eq, startsWith) and $orderby.'
@@ -23536,6 +26103,34 @@ components:
               $ref: '#/components/schemas/microsoft.graph.signInUserType'
           additionalProperties:
             type: object
+    microsoft.graph.azureADPremiumLicenseInsight:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: azureADPremiumLicenseInsight
+          type: object
+          properties:
+            entitledP1LicenseCount:
+              type: number
+              description: The number of Microsoft Entra ID P1 licenses entitled to the tenant.
+              format: int64
+            entitledP2LicenseCount:
+              type: number
+              description: The number of Microsoft Entra ID P2 licenses entitled to the tenant.
+              format: int64
+            entitledTotalLicenseCount:
+              type: number
+              description: The total number of Microsoft Entra ID premium licenses (P1 + P2) entitled to the tenant.
+              format: int64
+            internetAccessFeatureUtilizations:
+              $ref: '#/components/schemas/microsoft.graph.internetAccessFeatureUtilizations'
+            p1FeatureUtilizations:
+              $ref: '#/components/schemas/microsoft.graph.azureADPremiumP1FeatureUtilizations'
+            p2FeatureUtilizations:
+              $ref: '#/components/schemas/microsoft.graph.azureADPremiumP2FeatureUtilizations'
+            privateAccessFeatureUtilizations:
+              $ref: '#/components/schemas/microsoft.graph.privateAccessFeatureUtilizations'
+          additionalProperties:
+            type: object
     microsoft.graph.credentialUserRegistrationDetails:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -23546,7 +26141,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.registrationAuthMethod'
-              description: 'Represents the authentication method that the user has registered. Possible values are: email, mobilePhone, officePhone,  securityQuestion (only used for self-service password reset), appNotification,  appCode, alternateMobilePhone (supported only in registration),  fido,  appPassword,  unknownFutureValue.'
+              description: 'Represents the authentication method that the user has registered. The possible values are: email, mobilePhone, officePhone,  securityQuestion (only used for self-service password reset), appNotification,  appCode, alternateMobilePhone (supported only in registration),  fido,  appPassword,  unknownFutureValue.'
             isCapable:
               type: boolean
               description: Indicates whether the user is ready to perform self-service password reset or MFA.
@@ -23708,7 +26303,7 @@ components:
       properties:
         content:
           type: string
-          description: The http content that has the data
+          description: Report content; details vary by report type.
           format: base64url
           nullable: true
       additionalProperties:
@@ -24200,7 +26795,7 @@ components:
               nullable: true
             groupType:
               type: string
-              description: 'The group type. Possible values are: Public or Private.'
+              description: 'The group type. The possible values are: Public or Private.'
               nullable: true
             isDeleted:
               type: boolean
@@ -25301,17 +27896,26 @@ components:
           description: The unique identifier for an entity. Read-only.
       additionalProperties:
         type: object
+    microsoft.graph.apiUsageReportOnboardingStatus:
+      title: apiUsageReportOnboardingStatus
+      enum:
+        - enabling
+        - enabled
+        - disabling
+        - disabled
+        - unknownFutureValue
+      type: string
     microsoft.graph.keyValue:
       title: keyValue
       type: object
       properties:
         key:
           type: string
-          description: Contains the name of the field that a value is associated with.
+          description: Key.
           nullable: true
         value:
           type: string
-          description: Contains the corresponding value for the specified key.
+          description: Value.
           nullable: true
       additionalProperties:
         type: object
@@ -25362,6 +27966,19 @@ components:
           type: string
           description: 'When type is set to User, this includes the user name that initiated the action; null for other types.'
           nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.auditActivityPerformer:
+      title: auditActivityPerformer
+      type: object
+      properties:
+        appId:
+          type: string
+        blueprintId:
+          type: string
+          nullable: true
+        identityType:
+          $ref: '#/components/schemas/microsoft.graph.auditIdentityType'
       additionalProperties:
         type: object
     microsoft.graph.initiator:
@@ -25476,14 +28093,770 @@ components:
       title: agentSignIn
       type: object
       properties:
+        agentSubjectParentId:
+          type: string
+          description: The subject's parent object ID. This is either the id of the agentIdentity or agentIdentityBlueprint.
+          nullable: true
+        agentSubjectType:
+          $ref: '#/components/schemas/microsoft.graph.agentic.agentType'
         agentType:
           $ref: '#/components/schemas/microsoft.graph.agentic.agentType'
         parentAppId:
           type: string
-          description: The ID of the parent application for agentic instances.
+          description: The appId of the parent agent where the agentType is agentic.
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.conditionalAccessStatus:
+      title: conditionalAccessStatus
+      enum:
+        - success
+        - failure
+        - notApplied
+        - unknownFutureValue
+      type: string
+    microsoft.graph.managedIdentity:
+      title: managedIdentity
+      type: object
+      properties:
+        associatedResourceId:
+          type: string
+          description: The ARM resource ID of the Azure resource associated with the managed identity used for sign in.
+          nullable: true
+        federatedTokenId:
+          type: string
+          description: The unique ID of the federated token.
+          nullable: true
+        federatedTokenIssuer:
+          type: string
+          description: The issuer of the federated token.
+          nullable: true
+        msiType:
+          $ref: '#/components/schemas/microsoft.graph.msiType'
+      additionalProperties:
+        type: object
+    microsoft.graph.signInStatus:
+      title: signInStatus
+      type: object
+      properties:
+        additionalDetails:
+          type: string
+          description: Provides additional details on the sign-in activity
+          nullable: true
+        errorCode:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: Provides the 5-6 digit error code that's generated during a sign-in failure. Check out the list of error codes and messages.
+          format: int32
+          nullable: true
+        failureReason:
+          type: string
+          description: Provides the error message or the reason for failure for the corresponding sign-in activity. Check out the list of error codes and messages.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.tokenIssuerType:
+      title: tokenIssuerType
+      enum:
+        - AzureAD
+        - ADFederationServices
+        - UnknownFutureValue
+        - AzureADBackupAuth
+        - ADFederationServicesMFAAdapter
+        - NPSExtension
+      type: string
+    microsoft.graph.directoryObject:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: directoryObject
+          type: object
+          properties:
+            deletedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Date and time when this object was deleted. Always null when the object hasn't been deleted.
+              format: date-time
+              nullable: true
+          additionalProperties:
+            type: object
+    microsoft.graph.apiApplication:
+      title: apiApplication
+      type: object
+      properties:
+        acceptMappedClaims:
+          type: boolean
+          description: 'When true, allows an application to use claims mapping without specifying a custom signing key.'
+          nullable: true
+        knownClientApplications:
+          type: array
+          items:
+            pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+            type: string
+            format: uuid
+            nullable: true
+          description: 'Used for bundling consent if you have a solution that contains two parts: a client app and a custom web API app. If you set the appID of the client app to this value, the user only consents once to the client app. Microsoft Entra ID knows that consenting to the client means implicitly consenting to the web API and automatically provisions service principals for both APIs at the same time. Both the client and the web API app must be registered in the same tenant.'
+        oauth2PermissionScopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.permissionScope'
+          description: 'The definition of the delegated permissions exposed by the web API represented by this application registration. These delegated permissions may be requested by a client application, and may be granted by users or administrators during consent. Delegated permissions are sometimes referred to as OAuth 2.0 scopes.'
+        preAuthorizedApplications:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.preAuthorizedApplication'
+          description: 'Lists the client applications that are preauthorized with the specified delegated permissions to access this application''s APIs. Users aren''t required to consent to any preauthorized application (for the permissions specified). However, any other permissions not listed in preAuthorizedApplications (requested through incremental consent for example) will require user consent.'
+        requestedAccessTokenVersion:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: 'Specifies the access token version expected by this resource. This changes the version and format of the JWT produced independent of the endpoint or client used to request the access token.  The endpoint used, v1.0 or v2.0, is chosen by the client and only impacts the version of id_tokens. Resources need to explicitly configure requestedAccessTokenVersion to indicate the supported access token format.  Possible values for requestedAccessTokenVersion are 1, 2, or null. If the value is null, this defaults to 1, which corresponds to the v1.0 endpoint.  If signInAudience on the application is configured as AzureADandPersonalMicrosoftAccount or PersonalMicrosoftAccount, the value for this property must be 2.'
+          format: int32
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.appRole:
+      title: appRole
+      type: object
+      properties:
+        allowedMemberTypes:
+          type: array
+          items:
+            type: string
+          description: 'Specifies whether this app role can be assigned to users and groups (by setting to [''User'']), to other application''s (by setting to [''Application''], or both (by setting to [''User'', ''Application'']). App roles supporting assignment to other applications'' service principals are also known as application permissions. The ''Application'' value is only supported for app roles defined on application entities.'
+        description:
+          type: string
+          description: 'The description for the app role. This is displayed when the app role is being assigned and, if the app role functions as an application permission, during  consent experiences.'
+          nullable: true
+        displayName:
+          type: string
+          description: Display name for the permission that appears in the app role assignment and consent experiences.
+          nullable: true
+        id:
+          pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+          type: string
+          description: Unique role identifier inside the appRoles collection. You must specify a new GUID identifier when you create a new app role.
+          format: uuid
+        isEnabled:
+          type: boolean
+          description: 'When you create or updating an app role, this value must be true. To delete a role, this must first be set to false. At that point, in a subsequent call, this role might be removed. Default value is true.'
+        origin:
+          type: string
+          description: Specifies if the app role is defined on the application object or on the servicePrincipal entity. Must not be included in any POST or PATCH requests. Read-only.
+          nullable: true
+        value:
+          type: string
+          description: 'Specifies the value to include in the roles claim in ID tokens and access tokens authenticating an assigned user or service principal. Must not exceed 120 characters in length. Allowed characters are : ! # $ % & '' ( ) * + , - . / : ;  =  ? @ [ ] ^ + _  {  } ~, and characters in the ranges 0-9, A-Z, and a-z. Any other character, including the space character, aren''t allowed. May not begin with ..'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.authenticationBehaviors:
+      title: authenticationBehaviors
+      type: object
+      properties:
+        blockAzureADGraphAccess:
+          type: boolean
+          description: 'If false, allows the app to have extended access to Azure AD Graph until August 31, 2025 when Azure AD Graph is fully retired. For more information on Azure AD retirement updates, see June 2024 update on Azure AD Graph API retirement.'
+          nullable: true
+        removeUnverifiedEmailClaim:
+          type: boolean
+          description: 'If true, removes the email claim from tokens sent to an application when the email address''s domain can''t be verified.'
+          nullable: true
+        requireClientServicePrincipal:
+          type: boolean
+          description: 'If true, requires multitenant applications to have a service principal in the resource tenant as part of authorization checks before they''re granted access tokens. This property is only modifiable for multitenant resource applications that rely on access from clients without a service principal and had this behavior as set to false by Microsoft. Tenant administrators should respond to security advisories sent through Azure Health Service events and the Microsoft 365 message center.'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.certification:
+      title: certification
+      type: object
+      properties:
+        certificationDetailsUrl:
+          type: string
+          description: URL that shows certification details for the application.
+          nullable: true
+          readOnly: true
+        certificationExpirationDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: The timestamp when the current certification for the application expires.
+          format: date-time
+          nullable: true
+        isCertifiedByMicrosoft:
+          type: boolean
+          description: Indicates whether the application is certified by Microsoft.
+          nullable: true
+          readOnly: true
+        isPublisherAttested:
+          type: boolean
+          description: Indicates whether the application developer or publisher completed Publisher Attestation.
+          nullable: true
+        lastCertificationDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: The timestamp when the certification for the application was most recently added or updated.
+          format: date-time
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.informationalUrl:
+      title: informationalUrl
+      type: object
+      properties:
+        logoUrl:
+          type: string
+          description: 'CDN URL to the application''s logo, Read-only.'
+          nullable: true
+        marketingUrl:
+          type: string
+          description: 'Link to the application''s marketing page. For example, https://www.contoso.com/app/marketing'
+          nullable: true
+        privacyStatementUrl:
+          type: string
+          description: 'Link to the application''s privacy statement. For example, https://www.contoso.com/app/privacy'
+          nullable: true
+        supportUrl:
+          type: string
+          description: 'Link to the application''s support page. For example, https://www.contoso.com/app/support'
+          nullable: true
+        termsOfServiceUrl:
+          type: string
+          description: 'Link to the application''s terms of service statement. For example, https://www.contoso.com/app/termsofservice'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.keyCredential:
+      title: keyCredential
+      type: object
+      properties:
+        customKeyIdentifier:
+          type: string
+          description: 'A 40-character binary type that can be used to identify the credential. Optional. When not provided in the payload, defaults to the thumbprint of the certificate.'
+          format: base64url
+          nullable: true
+        displayName:
+          type: string
+          description: 'The friendly name for the key, with a maximum length of 90 characters. Longer values are accepted but shortened. Optional.'
+          nullable: true
+        endDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The date and time at which the credential expires. The DateTimeOffset type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+          nullable: true
+        key:
+          type: string
+          description: 'Value for the key credential. Should be a Base64 encoded value. Requires $select to retrieve; only available for single object requests (GET /applications/{applicationId}?$select=keyCredentials or GET /servicePrincipals/{servicePrincipalId}?$select=keyCredentials); otherwise, it''s always null.  From a .cer certificate, you can read the key using the Convert.ToBase64String() method. For more information, see Get the certificate key.'
+          format: base64url
+          nullable: true
+        keyId:
+          pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+          type: string
+          description: The unique identifier for the key.
+          format: uuid
+          nullable: true
+        startDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The date and time at which the credential becomes valid.The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+          nullable: true
+        type:
+          type: string
+          description: 'The type of key credential; for example, Symmetric, AsymmetricX509Cert, or X509CertAndPassword.'
+          nullable: true
+        usage:
+          type: string
+          description: 'A string that describes the purpose for which the key can be used; for example, None​, Verify​, PairwiseIdentifier​, Delegation​, Decrypt​, Encrypt​, HashedIdentifier​, SelfSignedTls, or Sign. If usage is Sign​, the type should be X509CertAndPassword​, and the passwordCredentials​ for signing should be defined.'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.nativeAuthenticationApisEnabled:
+      title: nativeAuthenticationApisEnabled
+      enum:
+        - none
+        - all
+        - unknownFutureValue
+      type: string
+      x-ms-enum-flags:
+        isFlags: true
+    microsoft.graph.onPremisesPublishing:
+      title: onPremisesPublishing
+      type: object
+      properties:
+        alternateUrl:
+          type: string
+          description: 'If you''re configuring a traffic manager in front of multiple app proxy applications, this user-friendly URL points to the traffic manager.'
+          nullable: true
+        applicationServerTimeout:
+          type: string
+          description: 'The duration the connector waits for a response from the backend application before closing the connection. Possible values are default, long. When set to default, the backend application timeout has a length of 85 seconds. When set to long, the backend timeout is increased to 180 seconds. Use long if your server takes more than 85 seconds to respond to requests or if you are unable to access the application and the error status is ''Backend Timeout''. Default value is default.'
+          nullable: true
+        applicationType:
+          type: string
+          description: System-defined value that indicates whether this application is an application proxy configured application. The possible values are quickaccessapp and nonwebapp. Read-only.
+          nullable: true
+        externalAuthenticationType:
+          $ref: '#/components/schemas/microsoft.graph.externalAuthenticationType'
+        externalUrl:
+          type: string
+          description: 'The published external URL for the application. For example, https://intranet-contoso.msappproxy.net/.'
+          nullable: true
+        internalUrl:
+          type: string
+          description: 'The internal url of the application. For example, https://intranet/.'
+          nullable: true
+        isAccessibleViaZTNAClient:
+          type: boolean
+          description: Indicates whether the application is accessible via a Global Secure Access client on a managed device.
+          nullable: true
+        isBackendCertificateValidationEnabled:
+          type: boolean
+          description: 'Indicates whether backend SSL certificate validation is enabled for the application. For all new Application Proxy apps, the property is set to true by default. For all existing apps, the property is set to false.'
+          nullable: true
+        isContinuousAccessEvaluationEnabled:
+          type: boolean
+          description: 'Indicates whether continuous access evaluation is enabled for Application Proxy application. For all Application Proxy apps, the property is set to true by default.'
+          nullable: true
+        isDnsResolutionEnabled:
+          type: boolean
+          description: Indicates Microsoft Entra Private Access should handle DNS resolution. false by default.
+          nullable: true
+        isHttpOnlyCookieEnabled:
+          type: boolean
+          description: 'Indicates if the HTTPOnly cookie flag should be set in the HTTP response headers. Set this value to true to have Application Proxy cookies include the HTTPOnly flag in the HTTP response headers. If using Remote Desktop Services, set this value to False. Default value is false.'
+          nullable: true
+        isOnPremPublishingEnabled:
+          type: boolean
+          description: Indicates if the application is currently being published via Application Proxy or not. This is preset by the system. Read-only.
+          nullable: true
+        isPersistentCookieEnabled:
+          type: boolean
+          description: 'Indicates if the Persistent cookie flag should be set in the HTTP response headers. Keep this value set to false. Only use this setting for applications that can''t share cookies between processes. For more information about cookie settings, see Cookie settings for accessing on-premises applications in Microsoft Entra ID. Default value is false.'
+          nullable: true
+        isSecureCookieEnabled:
+          type: boolean
+          description: Indicates if the Secure cookie flag should be set in the HTTP response headers. Set this value to true to transmit cookies over a secure channel such as an encrypted HTTPS request. Default value is true.
+          nullable: true
+        isStateSessionEnabled:
+          type: boolean
+          description: Indicates whether validation of the state parameter when the client uses the OAuth 2.0 authorization code grant flow is enabled. This setting allows admins to specify whether they want to enable CSRF protection for their apps.
+          nullable: true
+        isTranslateHostHeaderEnabled:
+          type: boolean
+          description: Indicates if the application should translate urls in the response headers. Keep this value as true unless your application required the original host header in the authentication request. Default value is true.
+          nullable: true
+        isTranslateLinksInBodyEnabled:
+          type: boolean
+          description: 'Indicates if the application should translate urls in the application body. Keep this value as false unless you have hardcoded HTML links to other on-premises applications and don''t use custom domains. For more information, see Link translation with Application Proxy. Default value is false.'
+          nullable: true
+        onPremisesApplicationSegments:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.onPremisesApplicationSegment'
+          description: 'Represents the application segment collection for an on-premises wildcard application. This property is deprecated and will stop returning data on June 1, 2023. Use segmentsConfiguration instead.'
+        segmentsConfiguration:
+          $ref: '#/components/schemas/microsoft.graph.segmentConfiguration'
+        singleSignOnSettings:
+          $ref: '#/components/schemas/microsoft.graph.onPremisesPublishingSingleSignOn'
+        trafficRoutingMethod:
+          $ref: '#/components/schemas/microsoft.graph.trafficRoutingMethod'
+        useAlternateUrlForTranslationAndRedirect:
+          type: boolean
+          description: Indicates whether the application should use alternateUrl instead of externalUrl.
+          nullable: true
+        verifiedCustomDomainCertificatesMetadata:
+          $ref: '#/components/schemas/microsoft.graph.verifiedCustomDomainCertificatesMetadata'
+        verifiedCustomDomainKeyCredential:
+          $ref: '#/components/schemas/microsoft.graph.keyCredential'
+        verifiedCustomDomainPasswordCredential:
+          $ref: '#/components/schemas/microsoft.graph.passwordCredential'
+        wafAllowedHeaders:
+          $ref: '#/components/schemas/microsoft.graph.wafAllowedHeadersDictionary'
+        wafIpRanges:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.ipRange'
+        wafProvider:
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.optionalClaims:
+      title: optionalClaims
+      type: object
+      properties:
+        accessToken:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.optionalClaim'
+          description: The optional claims returned in the JWT access token.
+        idToken:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.optionalClaim'
+          description: The optional claims returned in the JWT ID token.
+        saml2Token:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.optionalClaim'
+          description: The optional claims returned in the SAML token.
+      additionalProperties:
+        type: object
+    microsoft.graph.parentalControlSettings:
+      title: parentalControlSettings
+      type: object
+      properties:
+        countriesBlockedForMinors:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: Specifies the two-letter ISO country codes. Access to the application will be blocked for minors from the countries specified in this list.
+        legalAgeGroupRule:
+          type: string
+          description: 'Specifies the legal age group rule that applies to users of the app. Can be set to one of the following values: ValueDescriptionAllowDefault. Enforces the legal minimum. This means parental consent is required for minors in the European Union and Korea.RequireConsentForPrivacyServicesEnforces the user to specify date of birth to comply with COPPA rules. RequireConsentForMinorsRequires parental consent for ages below 18, regardless of country/region minor rules.RequireConsentForKidsRequires parental consent for ages below 14, regardless of country/region minor rules.BlockMinorsBlocks minors from using the app.'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.passwordCredential:
+      title: passwordCredential
+      type: object
+      properties:
+        customKeyIdentifier:
+          type: string
+          description: Do not use.
+          format: base64url
+          nullable: true
+        displayName:
+          type: string
+          description: Friendly name for the password. Optional.
+          nullable: true
+        endDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The date and time at which the password expires represented using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Optional.'
+          format: date-time
+          nullable: true
+        hint:
+          type: string
+          description: Contains the first three characters of the password. Read-only.
+          nullable: true
+        keyId:
+          pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+          type: string
+          description: The unique identifier for the password.
+          format: uuid
+          nullable: true
+        secretText:
+          type: string
+          description: Read-only; Contains the strong passwords generated by Microsoft Entra ID that are 16-64 characters in length. The generated password value is only returned during the initial POST request to addPassword. There is no way to retrieve this password in the future.
+          nullable: true
+        startDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The date and time at which the password becomes valid. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Optional.'
+          format: date-time
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.publicClientApplication:
+      title: publicClientApplication
+      type: object
+      properties:
+        redirectUris:
+          type: array
+          items:
+            type: string
+          description: 'Specifies the URLs where user tokens are sent for sign-in, or the redirect URIs where OAuth 2.0 authorization codes and access tokens are sent. For iOS and macOS apps, specify the value following the syntax msauth.{BUNDLEID}://auth, replacing ''{BUNDLEID}''. For example, if the bundle ID is com.microsoft.identitysample.MSALiOS, the URI is msauth.com.microsoft.identitysample.MSALiOS://auth.'
+      additionalProperties:
+        type: object
+    microsoft.graph.requestSignatureVerification:
+      title: requestSignatureVerification
+      type: object
+      properties:
+        allowedWeakAlgorithms:
+          $ref: '#/components/schemas/microsoft.graph.weakAlgorithms'
+        isSignedRequestRequired:
+          type: boolean
+          description: Specifies whether signed authentication requests for this application should be required.
+      additionalProperties:
+        type: object
+    microsoft.graph.requiredResourceAccess:
+      title: requiredResourceAccess
+      type: object
+      properties:
+        resourceAccess:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.resourceAccess'
+          description: The list of OAuth2.0 permission scopes and app roles that the application requires from the specified resource.
+        resourceAppId:
+          type: string
+          description: The unique identifier for the resource that the application requires access to. This should be equal to the appId declared on the target resource application.
+      additionalProperties:
+        type: object
+    microsoft.graph.servicePrincipalLockConfiguration:
+      title: servicePrincipalLockConfiguration
+      type: object
+      properties:
+        allProperties:
+          type: boolean
+          description: 'Enables locking all sensitive properties. The sensitive properties are keyCredentials, passwordCredentials, and tokenEncryptionKeyId.'
+          nullable: true
+        credentialsWithUsageSign:
+          type: boolean
+          description: Locks the keyCredentials and passwordCredentials properties for modification where credential usage type is Sign.
+          nullable: true
+        credentialsWithUsageVerify:
+          type: boolean
+          description: Locks the keyCredentials and passwordCredentials properties for modification where credential usage type is Verify. This locks OAuth service principals.
+          nullable: true
+        isEnabled:
+          type: boolean
+          description: 'Enables or disables service principal lock configuration. To allow the sensitive properties to be updated, update this property to false to disable the lock on the service principal.'
+        tokenEncryptionKeyId:
+          type: boolean
+          description: Locks the tokenEncryptionKeyId property for modification on the service principal.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.signInAudienceRestrictionsBase:
+      title: signInAudienceRestrictionsBase
+      type: object
+      properties:
+        kind:
+          $ref: '#/components/schemas/microsoft.graph.kind'
+      additionalProperties:
+        type: object
+    microsoft.graph.spaApplication:
+      title: spaApplication
+      type: object
+      properties:
+        redirectUris:
+          type: array
+          items:
+            type: string
+          description: 'Specifies the URLs where user tokens are sent for sign-in, or the redirect URIs where OAuth 2.0 authorization codes and access tokens are sent.'
+      additionalProperties:
+        type: object
+    microsoft.graph.verifiedPublisher:
+      title: verifiedPublisher
+      type: object
+      properties:
+        addedDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: The timestamp when the verified publisher was first added or most recently updated.
+          format: date-time
+          nullable: true
+        displayName:
+          type: string
+          description: The verified publisher name from the app publisher's Microsoft Partner Network (MPN) account.
+          nullable: true
+        verifiedPublisherId:
+          type: string
+          description: The ID of the verified publisher from the app publisher's Partner Center account.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.webApplication:
+      title: webApplication
+      type: object
+      properties:
+        homePageUrl:
+          type: string
+          description: Home page or landing page of the application.
+          nullable: true
+        implicitGrantSettings:
+          $ref: '#/components/schemas/microsoft.graph.implicitGrantSettings'
+        logoutUrl:
+          type: string
+          description: 'Specifies the URL that will be used by Microsoft''s authorization service to logout a user using front-channel, back-channel or SAML logout protocols.'
+          nullable: true
+        oauth2AllowImplicitFlow:
+          type: boolean
+          nullable: true
+        redirectUris:
+          type: array
+          items:
+            type: string
+          description: 'Specifies the URLs where user tokens are sent for sign-in, or the redirect URIs where OAuth 2.0 authorization codes and access tokens are sent.'
+        redirectUriSettings:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.redirectUriSettings'
+          description: Specifies the index of the URLs where user tokens are sent for sign-in. This is only valid for applications using SAML.
+      additionalProperties:
+        type: object
+    microsoft.graph.windowsApplication:
+      title: windowsApplication
+      type: object
+      properties:
+        packageSid:
+          type: string
+          description: The package security identifier that Microsoft has assigned the application. Optional. Read-only.
+          nullable: true
+        redirectUris:
+          type: array
+          items:
+            type: string
+          description: Specifies the URLs where user tokens are sent for sign-in or the redirect URIs where OAuth 2.0 authorization codes and access tokens are sent. Only available for applications that support the PersonalMicrosoftAccount signInAudience.
+      additionalProperties:
+        type: object
+    microsoft.graph.appManagementPolicy:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.policyBase'
+        - title: appManagementPolicy
+          type: object
+          properties:
+            isEnabled:
+              type: boolean
+              description: Denotes whether the policy is enabled.
+            restrictions:
+              $ref: '#/components/schemas/microsoft.graph.customAppManagementConfiguration'
+            appliesTo:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.directoryObject'
+              description: Collection of application and service principals to which a policy is applied.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.connectorGroup:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: connectorGroup
+          type: object
+          properties:
+            connectorGroupType:
+              $ref: '#/components/schemas/microsoft.graph.connectorGroupType'
+            isDefault:
+              type: boolean
+              description: Indicates if the connectorGroup is the default connectorGroup. Only a single connector group can be the default connectorGroup and this is pre-set by the system. Read-only.
+            name:
+              type: string
+              description: The name associated with the connectorGroup.
+            region:
+              $ref: '#/components/schemas/microsoft.graph.connectorGroupRegion'
+            applications:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.application'
+              x-ms-navigationProperty: true
+            members:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.connector'
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.extensionProperty:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.directoryObject'
+        - title: extensionProperty
+          type: object
+          properties:
+            appDisplayName:
+              type: string
+              description: Display name of the application object on which this extension property is defined. Read-only.
+              nullable: true
+            dataType:
+              type: string
+              description: 'Specifies the data type of the value the extension property can hold. Following values are supported. Binary - 256 bytes maximumBooleanDateTime - Must be specified in ISO 8601 format. Will be stored in UTC.Integer - 32-bit value.LargeInteger - 64-bit value.String - 256 characters maximumNot nullable. For multivalued directory extensions, these limits apply per value in the collection.'
+            isMultiValued:
+              type: boolean
+              description: 'Defines the directory extension as a multi-valued property. When true, the directory extension property can store a collection of objects of the dataType; for example, a collection of string types such as ''extensionb7b1c57b532f40b8b5ed4b7a7ba67401jobGroupTracker'': [''String 1'', ''String 2'']. The default value is false. Supports $filter (eq).'
+            isSyncedFromOnPremises:
+              type: boolean
+              description: Indicates if this extension property was synced from on-premises active directory using Microsoft Entra Connect. Read-only.
+              nullable: true
+            name:
+              type: string
+              description: Name of the extension property. Not nullable. Supports $filter (eq).
+            targetObjects:
+              type: array
+              items:
+                type: string
+              description: Following values are supported. Not nullable. UserGroupAdministrativeUnitApplicationDeviceOrganization
+          additionalProperties:
+            type: object
+    microsoft.graph.federatedIdentityCredential:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: federatedIdentityCredential
+          type: object
+          properties:
+            audiences:
+              type: array
+              items:
+                type: string
+              description: The audience that can appear in the external token. This field is mandatory and should be set to api://AzureADTokenExchange for Microsoft Entra ID. It says what Microsoft identity platform should accept in the aud claim in the incoming token. This value represents Microsoft Entra ID in your external identity provider and has no fixed value across identity providers - you may need to create a new application registration in your identity provider to serve as the audience of this token. This field can only accept a single value and has a limit of 600 characters. Required.
+            claimsMatchingExpression:
+              $ref: '#/components/schemas/microsoft.graph.federatedIdentityExpression'
+            description:
+              type: string
+              description: 'The un-validated, user-provided description of the federated identity credential. It has a limit of 600 characters. Optional.'
+              nullable: true
+            issuer:
+              type: string
+              description: The URL of the external identity provider and must match the issuer claim of the external token being exchanged. The combination of the values of issuer and subject must be unique on the app. It has a limit of 600 characters. Required.
+            name:
+              type: string
+              description: 'The unique identifier for the federated identity credential, which has a limit of 120 characters and must be URL friendly. It is immutable once created. Alternate key. Required. Not nullable. Supports $filter (eq).'
+            subject:
+              type: string
+              description: 'Nullable.  Defaults to null if not set. The identifier of the external software workload within the external identity provider. Like the audience value, it has no fixed format, as each identity provider uses their own - sometimes a GUID, sometimes a colon delimited identifier, sometimes arbitrary strings. The value here must match the sub claim within the token presented to Microsoft Entra ID. The combination of issuer and subject must be unique on the app. It has a limit of 600 characters. If subject is defined, claimsMatchingExpression must be null. Supports $filter (eq).'
+              nullable: true
+          additionalProperties:
+            type: object
+    microsoft.graph.homeRealmDiscoveryPolicy:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.stsPolicy'
+        - title: homeRealmDiscoveryPolicy
+          type: object
+          additionalProperties:
+            type: object
+    microsoft.graph.synchronization:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: synchronization
+          type: object
+          properties:
+            secrets:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.synchronizationSecretKeyStringValuePair'
+              description: Represents a collection of credentials to access provisioned cloud applications.
+            jobs:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.synchronizationJob'
+              description: 'Performs synchronization by periodically running in the background, polling for changes in one directory, and pushing them to another directory.'
+              x-ms-navigationProperty: true
+            templates:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.synchronizationTemplate'
+              description: Pre-configured synchronization settings for a particular application.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.tokenIssuancePolicy:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.stsPolicy'
+        - title: tokenIssuancePolicy
+          type: object
+          additionalProperties:
+            type: object
+    microsoft.graph.tokenLifetimePolicy:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.stsPolicy'
+        - title: tokenLifetimePolicy
+          type: object
+          additionalProperties:
+            type: object
     microsoft.graph.appliedConditionalAccessPolicy:
       title: appliedConditionalAccessPolicy
       type: object
@@ -25667,6 +29040,8 @@ components:
         - prtNonBrokerBased
         - onBehalfOf
         - samlOnBehalfOf
+        - officeS2S
+        - wsTrust
       type: string
       x-ms-enum-flags:
         isFlags: true
@@ -25691,14 +29066,6 @@ components:
         - federatedIdentityCredential
         - managedIdentity
         - certificate
-        - unknownFutureValue
-      type: string
-    microsoft.graph.conditionalAccessStatus:
-      title: conditionalAccessStatus
-      enum:
-        - success
-        - failure
-        - notApplied
         - unknownFutureValue
       type: string
     microsoft.graph.signInAccessType:
@@ -25784,26 +29151,6 @@ components:
           nullable: true
       additionalProperties:
         type: object
-    microsoft.graph.managedIdentity:
-      title: managedIdentity
-      type: object
-      properties:
-        associatedResourceId:
-          type: string
-          description: The ARM resource ID of the Azure resource associated with the managed identity used for sign in.
-          nullable: true
-        federatedTokenId:
-          type: string
-          description: The unique ID of the federated token.
-          nullable: true
-        federatedTokenIssuer:
-          type: string
-          description: The issuer of the federated token.
-          nullable: true
-        msiType:
-          $ref: '#/components/schemas/microsoft.graph.msiType'
-      additionalProperties:
-        type: object
     microsoft.graph.mfaDetail:
       title: mfaDetail
       type: object
@@ -25883,6 +29230,10 @@ components:
         - userChangedPasswordOnPremises
         - adminDismissedRiskForSignIn
         - adminConfirmedAccountSafe
+        - adminConfirmedAgentSafe
+        - adminConfirmedAgentCompromised
+        - adminDismissedRiskForAgent
+        - microsoftRevokedSessions
       type: string
     microsoft.graph.riskLevel:
       title: riskLevel
@@ -25927,37 +29278,6 @@ components:
         - onPremisesUserPrincipalName
         - unknownFutureValue
       type: string
-    microsoft.graph.signInStatus:
-      title: signInStatus
-      type: object
-      properties:
-        additionalDetails:
-          type: string
-          description: Provides additional details on the sign-in activity
-          nullable: true
-        errorCode:
-          maximum: 2147483647
-          minimum: -2147483648
-          type: number
-          description: Provides the 5-6 digit error code that's generated during a sign-in failure. Check out the list of error codes and messages.
-          format: int32
-          nullable: true
-        failureReason:
-          type: string
-          description: Provides the error message or the reason for failure for the corresponding sign-in activity. Check out the list of error codes and messages.
-          nullable: true
-      additionalProperties:
-        type: object
-    microsoft.graph.tokenIssuerType:
-      title: tokenIssuerType
-      enum:
-        - AzureAD
-        - ADFederationServices
-        - UnknownFutureValue
-        - AzureADBackupAuth
-        - ADFederationServicesMFAAdapter
-        - NPSExtension
-      type: string
     microsoft.graph.tokenProtectionStatusDetails:
       title: tokenProtectionStatusDetails
       type: object
@@ -25968,6 +29288,7 @@ components:
           maximum: 2147483647
           minimum: -2147483648
           type: number
+          description: Additional information about the status.
           format: int32
           nullable: true
       additionalProperties:
@@ -25979,6 +29300,42 @@ components:
         - guest
         - unknownFutureValue
       type: string
+    microsoft.graph.fraudProtectionDetails:
+      title: fraudProtectionDetails
+      type: object
+      properties:
+        providerErrorMessages:
+          type: array
+          items:
+            type: string
+        providerHttpStatusCodes:
+          type: array
+          items:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+        providerName:
+          type: string
+          nullable: true
+        providerResponseTimes:
+          type: array
+          items:
+            maximum: 2147483647
+            minimum: -2147483648
+            type: number
+            format: int32
+        providerSessionId:
+          type: string
+          nullable: true
+        reason:
+          type: string
+          nullable: true
+        verdict:
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.signUpIdentity:
       title: signUpIdentity
       type: object
@@ -26182,6 +29539,7 @@ components:
         - fido2SecurityKey
         - oneTimePasscode
         - passKeySynced
+        - qrCode
       type: string
     microsoft.graph.featureType:
       title: featureType
@@ -26238,6 +29596,44 @@ components:
         - none
         - unknownFutureValue
       type: string
+    microsoft.graph.internetAccessFeatureUtilizations:
+      title: internetAccessFeatureUtilizations
+      type: object
+      properties:
+        internetAccess:
+          $ref: '#/components/schemas/microsoft.graph.azureADPremiumFeatureUtilization'
+        internetAccessM365:
+          $ref: '#/components/schemas/microsoft.graph.azureADPremiumFeatureUtilization'
+      additionalProperties:
+        type: object
+    microsoft.graph.azureADPremiumP1FeatureUtilizations:
+      title: azureADPremiumP1FeatureUtilizations
+      type: object
+      properties:
+        conditionalAccess:
+          $ref: '#/components/schemas/microsoft.graph.azureADPremiumFeatureUtilization'
+        conditionalAccessGuestUsers:
+          $ref: '#/components/schemas/microsoft.graph.azureADPremiumFeatureUtilization'
+      additionalProperties:
+        type: object
+    microsoft.graph.azureADPremiumP2FeatureUtilizations:
+      title: azureADPremiumP2FeatureUtilizations
+      type: object
+      properties:
+        riskBasedConditionalAccess:
+          $ref: '#/components/schemas/microsoft.graph.azureADPremiumFeatureUtilization'
+        riskBasedConditionalAccessGuestUsers:
+          $ref: '#/components/schemas/microsoft.graph.azureADPremiumFeatureUtilization'
+      additionalProperties:
+        type: object
+    microsoft.graph.privateAccessFeatureUtilizations:
+      title: privateAccessFeatureUtilizations
+      type: object
+      properties:
+        privateAccess:
+          $ref: '#/components/schemas/microsoft.graph.azureADPremiumFeatureUtilization'
+      additionalProperties:
+        type: object
     microsoft.graph.registrationAuthMethod:
       title: registrationAuthMethod
       enum:
@@ -26601,6 +29997,35 @@ components:
           $ref: '#/components/schemas/microsoft.graph.ODataErrors.MainError'
       additionalProperties:
         type: object
+    microsoft.graph.apiUsageReportEnablementStatusCollectionResponse:
+      title: Collection of apiUsageReportEnablementStatus
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.apiUsageReportEnablementStatus'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    ODataCountResponse:
+      type: integer
+      format: int32
+    microsoft.graph.auditActivityTypeCollectionResponse:
+      title: Collection of auditActivityType
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.auditActivityType'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.customSecurityAttributeAuditCollectionResponse:
       title: Collection of customSecurityAttributeAudit
       type: object
@@ -26614,9 +30039,6 @@ components:
           nullable: true
       additionalProperties:
         type: object
-    ODataCountResponse:
-      type: integer
-      format: int32
     microsoft.graph.directoryAuditCollectionResponse:
       title: Collection of directoryAudit
       type: object
@@ -26638,6 +30060,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.provisioningObjectSummary'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.signInEventsAppActivityCollectionResponse:
+      title: Collection of signInEventsAppActivity
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.signInEventsAppActivity'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.signInEventsActivityCollectionResponse:
+      title: Collection of signInEventsActivity
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.signInEventsActivity'
         '@odata.nextLink':
           type: string
           nullable: true
@@ -27133,17 +30581,24 @@ components:
         - azureAD
         - unknownFutureValue
       type: string
+    microsoft.graph.auditIdentityType:
+      title: auditIdentityType
+      enum:
+        - agent
+        - servicePrincipal
+        - unknownFutureValue
+      type: string
     microsoft.graph.identity:
       title: identity
       type: object
       properties:
         displayName:
           type: string
-          description: The display name of the identity. This property is read-only.
+          description: 'The display name of the identity. For drive items, the display name might not always be available or up to date. For example, if a user changes their display name the API might show the new value in a future response, but the items associated with the user don''t show up as changed when using delta.'
           nullable: true
         id:
           type: string
-          description: The identifier of the identity. This property is read-only.
+          description: 'Unique identifier for the identity or actor. For example, in the access reviews decisions API, this property might record the id of the principal, that is, the group, user, or application that''s subject to review.'
           nullable: true
       additionalProperties:
         type: object
@@ -27208,11 +30663,427 @@ components:
       title: agentType
       enum:
         - notAgentic
-        - agenticAppBuilder
         - agenticApp
         - agenticAppInstance
+        - agentIdentityBlueprintPrincipal
+        - agentIDuser
         - unknownFutureValue
       type: string
+    microsoft.graph.msiType:
+      title: msiType
+      enum:
+        - none
+        - userAssigned
+        - systemAssigned
+        - unknownFutureValue
+      type: string
+    microsoft.graph.permissionScope:
+      title: permissionScope
+      type: object
+      properties:
+        adminConsentDescription:
+          type: string
+          description: 'A description of the delegated permissions, intended to be read by an administrator granting the permission on behalf of all users. This text appears in tenant-wide admin consent experiences.'
+          nullable: true
+        adminConsentDisplayName:
+          type: string
+          description: 'The permission''s title, intended to be read by an administrator granting the permission on behalf of all users.'
+          nullable: true
+        id:
+          pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+          type: string
+          description: Unique delegated permission identifier inside the collection of delegated permissions defined for a resource application.
+          format: uuid
+        isEnabled:
+          type: boolean
+          description: 'When you create or update a permission, this property must be set to true (which is the default). To delete a permission, this property must first be set to false.  At that point, in a subsequent call, the permission may be removed.'
+        origin:
+          type: string
+          nullable: true
+        type:
+          type: string
+          description: 'The possible values are: User and Admin. Specifies whether this delegated permission should be considered safe for non-admin users to consent to on behalf of themselves, or whether an administrator consent should always be required. While Microsoft Graph defines the default consent requirement for each permission, the tenant administrator may override the behavior in their organization (by allowing, restricting, or limiting user consent to this delegated permission). For more information, see Configure how users consent to applications.'
+          nullable: true
+        userConsentDescription:
+          type: string
+          description: 'A description of the delegated permissions, intended to be read by a user granting the permission on their own behalf. This text appears in consent experiences where the user is consenting only on behalf of themselves.'
+          nullable: true
+        userConsentDisplayName:
+          type: string
+          description: 'A title for the permission, intended to be read by a user granting the permission on their own behalf. This text appears in consent experiences where the user is consenting only on behalf of themselves.'
+          nullable: true
+        value:
+          type: string
+          description: 'Specifies the value to include in the scp (scope) claim in access tokens. Must not exceed 120 characters in length. Allowed characters are : ! # $ % & '' ( ) * + , - . / : ;  =  ? @ [ ] ^ + _  {  } ~, and characters in the ranges 0-9, A-Z and a-z. Any other character, including the space character, aren''t allowed. May not begin with ..'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.preAuthorizedApplication:
+      title: preAuthorizedApplication
+      type: object
+      properties:
+        appId:
+          type: string
+          description: The unique identifier for the client application.
+        permissionIds:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: The unique identifier for the scopes the client application is granted.
+      additionalProperties:
+        type: object
+    microsoft.graph.externalAuthenticationType:
+      title: externalAuthenticationType
+      enum:
+        - passthru
+        - aadPreAuthentication
+      type: string
+    microsoft.graph.onPremisesApplicationSegment:
+      title: onPremisesApplicationSegment
+      type: object
+      properties:
+        alternateUrl:
+          type: string
+          description: 'If you''re configuring a traffic manager in front of multiple App Proxy application segments, contains the user-friendly URL that will point to the traffic manager.'
+          nullable: true
+        corsConfigurations:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.corsConfiguration'
+          description: CORS Rule definition for a particular application segment.
+        externalUrl:
+          type: string
+          description: 'The published external URL for the application segment; for example, https://intranet.contoso.com./'
+          nullable: true
+        internalUrl:
+          type: string
+          description: 'The internal URL of the application segment; for example, https://intranet/.'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.segmentConfiguration:
+      title: segmentConfiguration
+      type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.onPremisesPublishingSingleSignOn:
+      title: onPremisesPublishingSingleSignOn
+      type: object
+      properties:
+        kerberosSignOnSettings:
+          $ref: '#/components/schemas/microsoft.graph.kerberosSignOnSettings'
+        singleSignOnMode:
+          $ref: '#/components/schemas/microsoft.graph.singleSignOnMode'
+      additionalProperties:
+        type: object
+    microsoft.graph.trafficRoutingMethod:
+      title: trafficRoutingMethod
+      enum:
+        - none
+        - random
+        - sessionPersistence
+        - performance
+        - unknownFutureValue
+      type: string
+    microsoft.graph.verifiedCustomDomainCertificatesMetadata:
+      title: verifiedCustomDomainCertificatesMetadata
+      type: object
+      properties:
+        expiryDate:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The expiry date of the custom domain certificate. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+          nullable: true
+        issueDate:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The issue date of the custom domain. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+          nullable: true
+        issuerName:
+          type: string
+          description: The issuer name of the custom domain certificate.
+          nullable: true
+        subjectName:
+          type: string
+          description: The subject name of the custom domain certificate.
+          nullable: true
+        thumbprint:
+          type: string
+          description: The thumbprint associated with the custom domain certificate.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.wafAllowedHeadersDictionary:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.Dictionary'
+        - title: wafAllowedHeadersDictionary
+          type: object
+          additionalProperties:
+            type: object
+    microsoft.graph.ipRange:
+      title: ipRange
+      type: object
+      additionalProperties:
+        type: object
+      description: 'IP range base class for representing IPV4, IPV6 address ranges'
+    microsoft.graph.optionalClaim:
+      title: optionalClaim
+      type: object
+      properties:
+        additionalProperties:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: 'Additional properties of the claim. If a property exists in this collection, it modifies the behavior of the optional claim specified in the name property.'
+        essential:
+          type: boolean
+          description: 'If the value is true, the claim specified by the client is necessary to ensure a smooth authorization experience for the specific task requested by the end user. The default value is false.'
+        name:
+          type: string
+          description: The name of the optional claim.
+        source:
+          type: string
+          description: 'The source (directory object) of the claim. There are predefined claims and user-defined claims from extension properties. If the source value is null, the claim is a predefined optional claim. If the source value is user, the value in the name property is the extension property from the user object.'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.weakAlgorithms:
+      title: weakAlgorithms
+      enum:
+        - rsaSha1
+        - unknownFutureValue
+      type: string
+      x-ms-enum-flags:
+        isFlags: true
+    microsoft.graph.resourceAccess:
+      title: resourceAccess
+      type: object
+      properties:
+        id:
+          pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+          type: string
+          description: 'The unique identifier of an app role or delegated permission exposed by the resource application. For delegated permissions, this should match the id property of one of the delegated permissions in the oauth2PermissionScopes collection of the resource application''s service principal. For app roles (application permissions), this should match the id property of an app role in the appRoles collection of the resource application''s service principal.'
+          format: uuid
+        type:
+          type: string
+          description: 'Specifies whether the id property references a delegated permission or an app role (application permission). The possible values are: Scope (for delegated permissions) or Role (for app roles).'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.kind:
+      title: kind
+      enum:
+        - unrestricted
+        - allowedTenants
+        - unknownFutureValue
+      type: string
+    microsoft.graph.implicitGrantSettings:
+      title: implicitGrantSettings
+      type: object
+      properties:
+        enableAccessTokenIssuance:
+          type: boolean
+          description: Specifies whether this web application can request an access token using the OAuth 2.0 implicit flow.
+          nullable: true
+        enableIdTokenIssuance:
+          type: boolean
+          description: Specifies whether this web application can request an ID token using the OAuth 2.0 implicit flow.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriSettings:
+      title: redirectUriSettings
+      type: object
+      properties:
+        index:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: Identifies the specific URI within the redirectURIs collection in SAML SSO flows. Defaults to null. The index is unique across all the redirectUris for the application.
+          format: int32
+          nullable: true
+        uri:
+          type: string
+          description: Specifies the URI that tokens are sent to.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.policyBase:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.directoryObject'
+        - title: policyBase
+          type: object
+          properties:
+            description:
+              type: string
+              description: Description for this policy. Required.
+            displayName:
+              type: string
+              description: Display name for this policy. Required.
+          additionalProperties:
+            type: object
+    microsoft.graph.customAppManagementConfiguration:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.appManagementConfiguration'
+        - title: customAppManagementConfiguration
+          type: object
+          properties:
+            applicationRestrictions:
+              $ref: '#/components/schemas/microsoft.graph.customAppManagementApplicationConfiguration'
+          additionalProperties:
+            type: object
+    microsoft.graph.connectorGroupType:
+      title: connectorGroupType
+      enum:
+        - applicationProxy
+      type: string
+    microsoft.graph.connectorGroupRegion:
+      title: connectorGroupRegion
+      enum:
+        - nam
+        - eur
+        - aus
+        - asia
+        - ind
+        - unknownFutureValue
+      type: string
+    microsoft.graph.connector:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: connector
+          type: object
+          properties:
+            externalIp:
+              type: string
+              description: The external IP address as detected by the connector server. Read-only.
+            machineName:
+              type: string
+              description: The name of the computer on which the connector is installed and runs on.
+            status:
+              $ref: '#/components/schemas/microsoft.graph.connectorStatus'
+            version:
+              type: string
+              description: The version of the connector. Read-only.
+            memberOf:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.connectorGroup'
+              description: The connectorGroup that the connector is a member of. Read-only.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.federatedIdentityExpression:
+      title: federatedIdentityExpression
+      type: object
+      properties:
+        languageVersion:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: Indicated the language version to be used. Should always be set to 1. Required.
+          format: int32
+        value:
+          type: string
+          description: Indicates the configured expression. Required.
+      additionalProperties:
+        type: object
+    microsoft.graph.stsPolicy:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.policyBase'
+        - title: stsPolicy
+          type: object
+          properties:
+            definition:
+              type: array
+              items:
+                type: string
+              description: A string collection containing a JSON string that defines the rules and settings for a policy. The syntax for the definition differs for each derived policy type. Required.
+            isOrganizationDefault:
+              type: boolean
+              description: 'If set to true, activates this policy. There can be many policies for the same policy type, but only one can be activated as the organization default. Optional, default value is false.'
+              nullable: true
+            appliesTo:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.directoryObject'
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.synchronizationSecretKeyStringValuePair:
+      title: synchronizationSecretKeyStringValuePair
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationSecret'
+        value:
+          type: string
+          description: The value of the secret.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.synchronizationJob:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: synchronizationJob
+          type: object
+          properties:
+            schedule:
+              $ref: '#/components/schemas/microsoft.graph.synchronizationSchedule'
+            status:
+              $ref: '#/components/schemas/microsoft.graph.synchronizationStatus'
+            synchronizationJobSettings:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.keyValuePair'
+              description: Settings associated with the job. Some settings are inherited from the template.
+            templateId:
+              type: string
+              description: Identifier of the synchronization template this job is based on.
+              nullable: true
+            bulkUpload:
+              $ref: '#/components/schemas/microsoft.graph.bulkUpload'
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.synchronizationSchema'
+          additionalProperties:
+            type: object
+    microsoft.graph.synchronizationTemplate:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: synchronizationTemplate
+          type: object
+          properties:
+            applicationId:
+              pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+              type: string
+              description: Identifier of the application this template belongs to.
+              format: uuid
+            default:
+              type: boolean
+              description: true if this template is recommended to be the default for the application.
+            description:
+              type: string
+              description: Description of the template.
+              nullable: true
+            discoverable:
+              type: boolean
+              description: true if this template should appear in the collection of templates available for the application instance (service principal).
+            factoryTag:
+              type: string
+              description: One of the well-known factory tags supported by the synchronization engine. The factoryTag tells the synchronization engine which implementation to use when processing jobs based on this template.
+              nullable: true
+            metadata:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.synchronizationMetadataEntry'
+              description: 'Additional extension properties. Unless mentioned explicitly, metadata values shouldn''t be changed.'
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.synchronizationSchema'
+          additionalProperties:
+            type: object
     microsoft.graph.authenticationStrength:
       title: authenticationStrength
       type: object
@@ -27385,14 +31256,6 @@ components:
           nullable: true
       additionalProperties:
         type: object
-    microsoft.graph.msiType:
-      title: msiType
-      enum:
-        - none
-        - userAssigned
-        - systemAssigned
-        - unknownFutureValue
-      type: string
     microsoft.graph.networkType:
       title: networkType
       enum:
@@ -27419,6 +31282,7 @@ components:
       enum:
         - emailAddress
         - unknownFutureValue
+        - federation
       type: string
     microsoft.graph.authenticationMethodFeature:
       title: authenticationMethodFeature
@@ -27430,6 +31294,16 @@ components:
         - mfaCapable
         - unknownFutureValue
       type: string
+    microsoft.graph.azureADPremiumFeatureUtilization:
+      title: azureADPremiumFeatureUtilization
+      type: object
+      properties:
+        userCount:
+          type: number
+          description: The number of users who have used this premium feature.
+          format: int64
+      additionalProperties:
+        type: object
     microsoft.graph.healthMonitoring.healthMonitoringDictionary:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.healthMonitoring.Dictionary'
@@ -27554,6 +31428,260 @@ components:
         - success
         - unknownFutureValue
       type: string
+    microsoft.graph.corsConfiguration:
+      title: corsConfiguration
+      type: object
+      properties:
+        allowedHeaders:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: The request headers that the origin domain may specify on the CORS request. The wildcard character * indicates that any header beginning with the specified prefix is allowed.
+        allowedMethods:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: The HTTP request methods that the origin domain may use for a CORS request.
+        allowedOrigins:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: The origin domains that are permitted to make a request against the service via CORS. The origin domain is the domain from which the request originates. The origin must be an exact case-sensitive match with the origin that the user age sends to the service.
+        maxAgeInSeconds:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: The maximum amount of time that a browser should cache the response to the preflight OPTIONS request.
+          format: int32
+          nullable: true
+        resource:
+          type: string
+          description: Resource within the application segment for which CORS permissions are granted. / grants permission for whole app segment.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.kerberosSignOnSettings:
+      title: kerberosSignOnSettings
+      type: object
+      properties:
+        kerberosServicePrincipalName:
+          type: string
+          description: The Internal Application SPN of the application server. This SPN needs to be in the list of services to which the connector can present delegated credentials.
+          nullable: true
+        kerberosSignOnMappingAttributeType:
+          $ref: '#/components/schemas/microsoft.graph.kerberosSignOnMappingAttributeType'
+      additionalProperties:
+        type: object
+    microsoft.graph.singleSignOnMode:
+      title: singleSignOnMode
+      enum:
+        - none
+        - onPremisesKerberos
+        - saml
+        - pingHeaderBased
+        - aadHeaderBased
+        - oAuthToken
+        - unknownFutureValue
+      type: string
+    microsoft.graph.Dictionary:
+      title: Dictionary
+      type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.appManagementConfiguration:
+      title: appManagementConfiguration
+      type: object
+      properties:
+        keyCredentials:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.keyCredentialConfiguration'
+          description: Collection of certificate restrictions settings to be applied to an application or service principal.
+        passwordCredentials:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.passwordCredentialConfiguration'
+          description: Collection of password restrictions settings to be applied to an application or service principal.
+      additionalProperties:
+        type: object
+    microsoft.graph.customAppManagementApplicationConfiguration:
+      title: customAppManagementApplicationConfiguration
+      type: object
+      properties:
+        audiences:
+          $ref: '#/components/schemas/microsoft.graph.audiencesConfiguration'
+        identifierUris:
+          $ref: '#/components/schemas/microsoft.graph.identifierUriConfiguration'
+        redirectUris:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriConfiguration'
+      additionalProperties:
+        type: object
+    microsoft.graph.connectorStatus:
+      title: connectorStatus
+      enum:
+        - active
+        - inactive
+      type: string
+    microsoft.graph.synchronizationSecret:
+      title: synchronizationSecret
+      enum:
+        - None
+        - UserName
+        - Password
+        - SecretToken
+        - AppKey
+        - BaseAddress
+        - ClientIdentifier
+        - ClientSecret
+        - SingleSignOnType
+        - Sandbox
+        - Url
+        - Domain
+        - ConsumerKey
+        - ConsumerSecret
+        - TokenKey
+        - TokenExpiration
+        - Oauth2AccessToken
+        - Oauth2AccessTokenCreationTime
+        - Oauth2RefreshToken
+        - SyncAll
+        - InstanceName
+        - Oauth2ClientId
+        - Oauth2ClientSecret
+        - CompanyId
+        - UpdateKeyOnSoftDelete
+        - SynchronizationSchedule
+        - SystemOfRecord
+        - SandboxName
+        - EnforceDomain
+        - SyncNotificationSettings
+        - SkipOutOfScopeDeletions
+        - Oauth2AuthorizationCode
+        - Oauth2RedirectUri
+        - ApplicationTemplateIdentifier
+        - Oauth2TokenExchangeUri
+        - Oauth2AuthorizationUri
+        - AuthenticationType
+        - Server
+        - PerformInboundEntitlementGrants
+        - HardDeletesEnabled
+        - SyncAgentCompatibilityKey
+        - SyncAgentADContainer
+        - ValidateDomain
+        - TestReferences
+        - ConnectionString
+      type: string
+    microsoft.graph.synchronizationSchedule:
+      title: synchronizationSchedule
+      type: object
+      properties:
+        expiration:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Date and time when this job will expire. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+          nullable: true
+        interval:
+          pattern: '^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$'
+          type: string
+          description: 'The interval between synchronization iterations. The value is represented in ISO 8601  format for durations. For example, P1M represents a period of one month and PT1M represents a period of one minute.'
+          format: duration
+        state:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationScheduleState'
+      additionalProperties:
+        type: object
+    microsoft.graph.synchronizationStatus:
+      title: synchronizationStatus
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationStatusCode'
+        countSuccessiveCompleteFailures:
+          type: number
+          description: Number of consecutive times this job failed.
+          format: int64
+        escrowsPruned:
+          type: boolean
+          description: 'true if the job''s escrows (object-level errors) were pruned during initial synchronization. Escrows can be pruned if during the initial synchronization, you reach the threshold of errors that would normally put the job in quarantine. Instead of going into quarantine, the synchronization process clears the job''s errors and continues until the initial synchronization is completed. When the initial synchronization is completed, the job will pause and wait for the customer to clean up the errors.'
+        lastExecution:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationTaskExecution'
+        lastSuccessfulExecution:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationTaskExecution'
+        lastSuccessfulExecutionWithExports:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationTaskExecution'
+        progress:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.synchronizationProgress'
+          description: Details of the progress of a job toward completion.
+        quarantine:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationQuarantine'
+        steadyStateFirstAchievedTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The time when steady state (no more changes to the process) was first achieved. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+        steadyStateLastAchievedTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The time when steady state (no more changes to the process) was last achieved. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+        synchronizedEntryCountByType:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.stringKeyLongValuePair'
+          description: 'Count of synchronized objects, listed by object type.'
+        troubleshootingUrl:
+          type: string
+          description: 'In the event of an error, the URL with the troubleshooting steps for the issue.'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.bulkUpload:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: bulkUpload
+          type: object
+          additionalProperties:
+            type: object
+    microsoft.graph.synchronizationSchema:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: synchronizationSchema
+          type: object
+          properties:
+            synchronizationRules:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.synchronizationRule'
+              description: A collection of synchronization rules configured for the synchronizationJob or synchronizationTemplate.
+            version:
+              type: string
+              description: 'The version of the schema, updated automatically with every schema change.'
+              nullable: true
+            directories:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.directoryDefinition'
+              description: Contains the collection of directories and all of their objects.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.synchronizationMetadataEntry:
+      title: synchronizationMetadataEntry
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationMetadata'
+        value:
+          type: string
+          description: Value of the metadata property.
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.authenticationStrengthResult:
       title: authenticationStrengthResult
       enum:
@@ -27634,6 +31762,1091 @@ components:
       additionalProperties:
         type: object
       description: The structure of this object is service-specific
+    microsoft.graph.kerberosSignOnMappingAttributeType:
+      title: kerberosSignOnMappingAttributeType
+      enum:
+        - userPrincipalName
+        - onPremisesUserPrincipalName
+        - userPrincipalUsername
+        - onPremisesUserPrincipalUsername
+        - onPremisesSAMAccountName
+      type: string
+    microsoft.graph.keyCredentialConfiguration:
+      title: keyCredentialConfiguration
+      type: object
+      properties:
+        certificateBasedApplicationConfigurationIds:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: Collection of GUIDs that represent certificateBasedApplicationConfiguration that is allowed as root and intermediate certificate authorities.
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        maxLifetime:
+          pattern: '^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$'
+          type: string
+          description: 'String value that indicates the maximum lifetime for key expiration, defined as an ISO 8601 duration. For example, P4DT12H30M5S represents four days, 12 hours, 30 minutes, and five seconds. This property is required when restrictionType is set to asymmetricKeyLifetime.'
+          format: duration
+          nullable: true
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Specifies the date from which the policy restriction applies to newly created applications. For existing applications, the enforcement date can be retroactively applied.'
+          format: date-time
+          nullable: true
+        restrictionType:
+          $ref: '#/components/schemas/microsoft.graph.appKeyCredentialRestrictionType'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+      additionalProperties:
+        type: object
+    microsoft.graph.passwordCredentialConfiguration:
+      title: passwordCredentialConfiguration
+      type: object
+      properties:
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        maxLifetime:
+          pattern: '^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$'
+          type: string
+          description: 'String value that indicates the maximum lifetime for password expiration, defined as an ISO 8601 duration. For example, P4DT12H30M5S represents four days, 12 hours, 30 minutes, and five seconds. This property is required when restrictionType is set to passwordLifetime.'
+          format: duration
+          nullable: true
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Specifies the date from which the policy restriction applies to newly created applications. For existing applications, the enforcement date can be retroactively applied.'
+          format: date-time
+          nullable: true
+        restrictionType:
+          $ref: '#/components/schemas/microsoft.graph.appCredentialRestrictionType'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+      additionalProperties:
+        type: object
+    microsoft.graph.audiencesConfiguration:
+      title: audiencesConfiguration
+      type: object
+      properties:
+        azureAdMultipleOrgs:
+          $ref: '#/components/schemas/microsoft.graph.azureAdMultipleOrgsAudienceRestriction'
+        personalMicrosoftAccount:
+          $ref: '#/components/schemas/microsoft.graph.audienceRestriction'
+      additionalProperties:
+        type: object
+    microsoft.graph.identifierUriConfiguration:
+      title: identifierUriConfiguration
+      type: object
+      properties:
+        nonDefaultUriAddition:
+          $ref: '#/components/schemas/microsoft.graph.identifierUriRestriction'
+        uriAdditionWithoutUniqueTenantIdentifier:
+          $ref: '#/components/schemas/microsoft.graph.identifierUriRestriction'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriConfiguration:
+      title: redirectUriConfiguration
+      type: object
+      properties:
+        uriWithBlockedDomain:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriBlockedDomainConfiguration'
+        uriWithBlockedScheme:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriBlockedSchemeConfiguration'
+        uriWithoutAllowedDomain:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriAllowedDomainConfiguration'
+        uriWithoutAllowedScheme:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriAllowedSchemeConfiguration'
+        uriWithWildcard:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriWildcardConfiguration'
+      additionalProperties:
+        type: object
+    microsoft.graph.synchronizationScheduleState:
+      title: synchronizationScheduleState
+      enum:
+        - Active
+        - Disabled
+        - Paused
+      type: string
+    microsoft.graph.synchronizationStatusCode:
+      title: synchronizationStatusCode
+      enum:
+        - NotConfigured
+        - NotRun
+        - Active
+        - Paused
+        - Quarantine
+      type: string
+    microsoft.graph.synchronizationTaskExecution:
+      title: synchronizationTaskExecution
+      type: object
+      properties:
+        activityIdentifier:
+          type: string
+          description: Identifier of the job run.
+          nullable: true
+        countEntitled:
+          type: number
+          description: Count of processed entries that were assigned for this application.
+          format: int64
+        countEntitledForProvisioning:
+          type: number
+          description: Count of processed entries that were assigned for provisioning.
+          format: int64
+        countEscrowed:
+          type: number
+          description: Count of entries that were escrowed (errors).
+          format: int64
+        countEscrowedRaw:
+          type: number
+          description: 'Count of entries that were escrowed, including system-generated escrows.'
+          format: int64
+        countExported:
+          type: number
+          description: Count of exported entries.
+          format: int64
+        countExports:
+          type: number
+          description: Count of entries that were expected to be exported.
+          format: int64
+        countImported:
+          type: number
+          description: Count of imported entries.
+          format: int64
+        countImportedDeltas:
+          type: number
+          description: Count of imported delta-changes.
+          format: int64
+        countImportedReferenceDeltas:
+          type: number
+          description: Count of imported delta-changes pertaining to reference changes.
+          format: int64
+        error:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationError'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationTaskExecutionResult'
+        timeBegan:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Time when this job run began. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+        timeEnded:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Time when this job run ended. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+      additionalProperties:
+        type: object
+    microsoft.graph.synchronizationProgress:
+      title: synchronizationProgress
+      type: object
+      properties:
+        completedUnits:
+          type: number
+          description: The numerator of a progress ratio; the number of units of changes already processed.
+          format: int64
+        progressObservationDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: The time of a progress observation as an offset in minutes from UTC.
+          format: date-time
+        totalUnits:
+          type: number
+          description: The denominator of a progress ratio; a number of units of changes to be processed to accomplish synchronization.
+          format: int64
+        units:
+          type: string
+          description: An optional description of the units.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.synchronizationQuarantine:
+      title: synchronizationQuarantine
+      type: object
+      properties:
+        currentBegan:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Date and time when the quarantine was last evaluated and imposed. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+        error:
+          $ref: '#/components/schemas/microsoft.graph.synchronizationError'
+        nextAttempt:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Date and time when the next attempt to re-evaluate the quarantine will be made. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+        reason:
+          $ref: '#/components/schemas/microsoft.graph.quarantineReason'
+        seriesBegan:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Date and time when the quarantine was first imposed in this series (a series starts when a quarantine is first imposed, and is reset as soon as the quarantine is lifted). The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+        seriesCount:
+          type: number
+          description: 'Number of times in this series the quarantine was re-evaluated and left in effect (a series starts when quarantine is first imposed, and is reset as soon as quarantine is lifted).'
+          format: int64
+      additionalProperties:
+        type: object
+    microsoft.graph.stringKeyLongValuePair:
+      title: stringKeyLongValuePair
+      type: object
+      properties:
+        key:
+          type: string
+          description: The mapping of the user type from the source system to the target system. For example:User to User - For Microsoft Entra ID to Microsoft Entra synchronization worker to user - For Workday to Microsoft Entra synchronization.
+          nullable: true
+        value:
+          type: number
+          description: Total number of synchronized objects.
+          format: int64
+      additionalProperties:
+        type: object
+    microsoft.graph.synchronizationRule:
+      title: synchronizationRule
+      type: object
+      properties:
+        containerFilter:
+          $ref: '#/components/schemas/microsoft.graph.containerFilter'
+        editable:
+          type: boolean
+          description: true if the synchronization rule can be customized; false if this rule is read-only and shouldn't be changed.
+        groupFilter:
+          $ref: '#/components/schemas/microsoft.graph.groupFilter'
+        id:
+          type: string
+          description: Synchronization rule identifier. Must be one of the identifiers recognized by the synchronization engine. Supported rule identifiers can be found in the synchronization template returned by the API.
+          nullable: true
+        metadata:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.stringKeyStringValuePair'
+          description: 'Additional extension properties. Unless instructed explicitly by the support team, metadata values shouldn''t be changed.'
+        name:
+          type: string
+          description: Human-readable name of the synchronization rule. Not nullable.
+          nullable: true
+        objectMappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.objectMapping'
+          description: Collection of object mappings supported by the rule. Tells the synchronization engine which objects should be synchronized.
+        priority:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: Priority relative to other rules in the synchronizationSchema. Rules with the lowest priority number will be processed first.
+          format: int32
+        sourceDirectoryName:
+          type: string
+          description: Name of the source directory. Must match one of the directory definitions in synchronizationSchema.
+          nullable: true
+        targetDirectoryName:
+          type: string
+          description: Name of the target directory. Must match one of the directory definitions in synchronizationSchema.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.directoryDefinition:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: directoryDefinition
+          type: object
+          properties:
+            discoverabilities:
+              $ref: '#/components/schemas/microsoft.graph.directoryDefinitionDiscoverabilities'
+            discoveryDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Represents the discovery date and time using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            name:
+              type: string
+              description: Name of the directory. Must be unique within the synchronization schema. Not nullable.
+              nullable: true
+            objects:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.objectDefinition'
+              description: Collection of objects supported by the directory.
+            readOnly:
+              type: boolean
+              description: Whether this object is read-only.
+            version:
+              type: string
+              description: Read only value that indicates version discovered. null if discovery hasn't yet occurred.
+              nullable: true
+          additionalProperties:
+            type: object
+    microsoft.graph.synchronizationMetadata:
+      title: synchronizationMetadata
+      enum:
+        - galleryApplicationIdentifier
+        - galleryApplicationKey
+        - isOAuthEnabled
+        - IsSynchronizationAgentAssignmentRequired
+        - isSynchronizationAgentRequired
+        - isSynchronizationInPreview
+        - oAuthSettings
+        - synchronizationLearnMoreIbizaFwLink
+        - configurationFields
+      type: string
+    microsoft.graph.appManagementPolicyActorExemptions:
+      title: appManagementPolicyActorExemptions
+      type: object
+      properties:
+        customSecurityAttributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeExemption'
+          description: The collection of customSecurityAttributeExemption to exempt from the policy enforcement. Limit of 5.
+      additionalProperties:
+        type: object
+    microsoft.graph.appKeyCredentialRestrictionType:
+      title: appKeyCredentialRestrictionType
+      enum:
+        - asymmetricKeyLifetime
+        - trustedCertificateAuthority
+        - unknownFutureValue
+      type: string
+    microsoft.graph.appManagementRestrictionState:
+      title: appManagementRestrictionState
+      enum:
+        - enabled
+        - disabled
+        - unknownFutureValue
+      type: string
+    microsoft.graph.appCredentialRestrictionType:
+      title: appCredentialRestrictionType
+      enum:
+        - passwordAddition
+        - passwordLifetime
+        - symmetricKeyAddition
+        - symmetricKeyLifetime
+        - customPasswordAddition
+        - unknownFutureValue
+      type: string
+    microsoft.graph.azureAdMultipleOrgsAudienceRestriction:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.audienceRestriction'
+        - title: azureAdMultipleOrgsAudienceRestriction
+          type: object
+          additionalProperties:
+            type: object
+    microsoft.graph.audienceRestriction:
+      title: audienceRestriction
+      type: object
+      properties:
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Specifies the date from which the policy restriction applies to newly created applications. For existing applications, the enforcement date can be retroactively applied.'
+          format: date-time
+          nullable: true
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+      additionalProperties:
+        type: object
+    microsoft.graph.identifierUriRestriction:
+      title: identifierUriRestriction
+      type: object
+      properties:
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        excludeAppsReceivingV2Tokens:
+          type: boolean
+          description: 'If true, the restriction isn''t enforced for applications that are configured to receive V2 tokens in Microsoft Entra ID; else, the restriction is enforced for those applications.'
+          nullable: true
+        excludeSaml:
+          type: boolean
+          description: 'If true, the restriction isn''t enforced for SAML applications in Microsoft Entra ID; else, the restriction is enforced for those applications.'
+          nullable: true
+        isStateSetByMicrosoft:
+          type: boolean
+          description: 'If true, Microsoft sets the identifierUriRestriction state. If false, the tenant modifies the identifierUriRestriction state. Read-only.'
+          readOnly: true
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Specifies the date from which the policy restriction applies to newly created applications. For existing applications, the enforcement date can be retroactively applied.'
+          format: date-time
+          nullable: true
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriBlockedDomainConfiguration:
+      title: redirectUriBlockedDomainConfiguration
+      type: object
+      properties:
+        blockedDomains:
+          type: array
+          items:
+            type: string
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        publicClient:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedDomainConfiguration'
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        spa:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedDomainConfiguration'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+        web:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedDomainConfiguration'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriBlockedSchemeConfiguration:
+      title: redirectUriBlockedSchemeConfiguration
+      type: object
+      properties:
+        blockedSchemes:
+          type: array
+          items:
+            type: string
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        exemptFormats:
+          type: array
+          items:
+            type: string
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        publicClient:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedSchemeConfiguration'
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        spa:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedSchemeConfiguration'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+        web:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedSchemeConfiguration'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriAllowedDomainConfiguration:
+      title: redirectUriAllowedDomainConfiguration
+      type: object
+      properties:
+        allowedDomains:
+          type: array
+          items:
+            type: string
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        publicClient:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedDomainConfiguration'
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        spa:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedDomainConfiguration'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+        web:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedDomainConfiguration'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriAllowedSchemeConfiguration:
+      title: redirectUriAllowedSchemeConfiguration
+      type: object
+      properties:
+        allowedSchemes:
+          type: array
+          items:
+            type: string
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        publicClient:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedSchemeConfiguration'
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        spa:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedSchemeConfiguration'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+        web:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedSchemeConfiguration'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriWildcardConfiguration:
+      title: redirectUriWildcardConfiguration
+      type: object
+      properties:
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        excludeFormats:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriWildcardExcludeFormats'
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+      additionalProperties:
+        type: object
+    microsoft.graph.synchronizationError:
+      title: synchronizationError
+      type: object
+      properties:
+        code:
+          type: string
+          description: 'The error code. For example, AzureDirectoryB2BManagementPolicyCheckFailure.'
+          nullable: true
+        message:
+          type: string
+          description: 'The error message. For example, Policy permitting auto-redemption of invitations not configured.'
+          nullable: true
+        tenantActionable:
+          type: boolean
+          description: 'The action to take to resolve the error. For example, false.'
+      additionalProperties:
+        type: object
+    microsoft.graph.synchronizationTaskExecutionResult:
+      title: synchronizationTaskExecutionResult
+      enum:
+        - Succeeded
+        - Failed
+        - EntryLevelErrors
+      type: string
+    microsoft.graph.quarantineReason:
+      title: quarantineReason
+      enum:
+        - EncounteredBaseEscrowThreshold
+        - EncounteredTotalEscrowThreshold
+        - EncounteredEscrowProportionThreshold
+        - EncounteredQuarantineException
+        - Unknown
+        - QuarantinedOnDemand
+        - TooManyDeletes
+        - IngestionInterrupted
+      type: string
+    microsoft.graph.containerFilter:
+      title: containerFilter
+      type: object
+      properties:
+        includedContainers:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: 'The identifiers of containers, such as organizational units, that are in scope for a synchronization rule. For Active Directory organizational units, use the distinguished names. An empty list means no container filtering is configured.'
+      additionalProperties:
+        type: object
+    microsoft.graph.groupFilter:
+      title: groupFilter
+      type: object
+      properties:
+        includedGroups:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: 'Identifiers of groups that are in scope for a synchronization rule. For Active Directory groups, use the distinguished names. An empty list means no group filtering is configured.'
+      additionalProperties:
+        type: object
+    microsoft.graph.stringKeyStringValuePair:
+      title: stringKeyStringValuePair
+      type: object
+      properties:
+        key:
+          type: string
+          description: Key.
+          nullable: true
+        value:
+          type: string
+          description: Value.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.objectMapping:
+      title: objectMapping
+      type: object
+      properties:
+        attributeMappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.attributeMapping'
+          description: Attribute mappings define which attributes to map from the source object into the target object and how they should flow. A number of functions are available to support the transformation of the original source values.
+        enabled:
+          type: boolean
+          description: 'When true, this object mapping will be processed during synchronization. When false, this object mapping will be skipped.'
+        flowTypes:
+          $ref: '#/components/schemas/microsoft.graph.objectFlowTypes'
+        metadata:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.objectMappingMetadataEntry'
+          description: 'Additional extension properties. Unless mentioned explicitly, metadata values should not be changed.'
+        name:
+          type: string
+          description: Human-friendly name of the object mapping.
+          nullable: true
+        scope:
+          $ref: '#/components/schemas/microsoft.graph.filter'
+        sourceObjectName:
+          type: string
+          description: Name of the object in the source directory. Must match the object name from the source directory definition.
+          nullable: true
+        targetObjectName:
+          type: string
+          description: Name of the object in target directory. Must match the object name from the target directory definition.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.directoryDefinitionDiscoverabilities:
+      title: directoryDefinitionDiscoverabilities
+      enum:
+        - None
+        - AttributeNames
+        - AttributeDataTypes
+        - AttributeReadOnly
+        - ReferenceAttributes
+        - UnknownFutureValue
+      type: string
+      x-ms-enum-flags:
+        isFlags: true
+    microsoft.graph.objectDefinition:
+      title: objectDefinition
+      type: object
+      properties:
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.attributeDefinition'
+          description: Defines attributes of the object.
+        metadata:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.objectDefinitionMetadataEntry'
+          description: Metadata for the given object.
+        name:
+          type: string
+          description: Name of the object. Must be unique within a directory definition. Not nullable.
+          nullable: true
+        supportedApis:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: The API that the provisioning service queries to retrieve data for synchronization.
+      additionalProperties:
+        type: object
+    microsoft.graph.customSecurityAttributeExemption:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: customSecurityAttributeExemption
+          type: object
+          properties:
+            id:
+              type: string
+            operator:
+              $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeComparisonOperator'
+          additionalProperties:
+            type: object
+    microsoft.graph.redirectUriPlatformBlockedDomainConfiguration:
+      title: redirectUriPlatformBlockedDomainConfiguration
+      type: object
+      properties:
+        blockedDomains:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriPlatformBlockedSchemeConfiguration:
+      title: redirectUriPlatformBlockedSchemeConfiguration
+      type: object
+      properties:
+        blockedSchemes:
+          type: array
+          items:
+            type: string
+        exemptFormats:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriPlatformAllowedDomainConfiguration:
+      title: redirectUriPlatformAllowedDomainConfiguration
+      type: object
+      properties:
+        allowedDomains:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriPlatformAllowedSchemeConfiguration:
+      title: redirectUriPlatformAllowedSchemeConfiguration
+      type: object
+      properties:
+        allowedSchemes:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriWildcardExcludeFormats:
+      title: redirectUriWildcardExcludeFormats
+      type: object
+      properties:
+        excludeWildcardsInPath:
+          type: boolean
+        excludeWildcardsInPathWithDomains:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: object
+    microsoft.graph.attributeMapping:
+      title: attributeMapping
+      type: object
+      properties:
+        defaultValue:
+          type: string
+          description: Default value to be used in case the source property was evaluated to null. Optional.
+          nullable: true
+        exportMissingReferences:
+          type: boolean
+          description: For internal use only.
+        flowBehavior:
+          $ref: '#/components/schemas/microsoft.graph.attributeFlowBehavior'
+        flowType:
+          $ref: '#/components/schemas/microsoft.graph.attributeFlowType'
+        matchingPriority:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: 'If higher than 0, this attribute will be used to perform an initial match of the objects between source and target directories. The synchronization engine will try to find the matching object using attribute with lowest value of matching priority first. If not found, the attribute with the next matching priority will be used, and so on a until match is found or no more matching attributes are left. Only attributes that are expected to have unique values, such as email, should be used as matching attributes.'
+          format: int32
+        source:
+          $ref: '#/components/schemas/microsoft.graph.attributeMappingSource'
+        targetAttributeName:
+          type: string
+          description: Name of the attribute on the target object.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.objectFlowTypes:
+      title: objectFlowTypes
+      enum:
+        - None
+        - Add
+        - Update
+        - Delete
+      type: string
+      x-ms-enum-flags:
+        isFlags: true
+    microsoft.graph.objectMappingMetadataEntry:
+      title: objectMappingMetadataEntry
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/microsoft.graph.objectMappingMetadata'
+        value:
+          type: string
+          description: Value of the metadata property.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.filter:
+      title: filter
+      type: object
+      properties:
+        categoryFilterGroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.filterGroup'
+          description: '*Experimental* Filter group set used to decide whether given object belongs and should be processed as part of this object mapping. An object is considered in scope if ANY of the groups in the collection is evaluated to true.'
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.filterGroup'
+          description: 'Filter group set used to decide whether given object is in scope for provisioning. This is the filter which should be used in most cases. If an object used to satisfy this filter at a given moment, and then the object or the filter was changed so that filter isn''t satisfied any longer, such object will get de-provisioned''. An object is considered in scope if ANY of the groups in the collection is evaluated to true.'
+        inputFilterGroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.filterGroup'
+          description: '*Experimental* Filter group set used to filter out objects at the early stage of reading them from the directory. If an object doesn''t satisfy this filter, it will not be processed further. Important to understand is that if an object used to satisfy this filter at a given moment, and then the object or the filter was changed so that filter is no longer satisfied, such object will NOT get de-provisioned. An object is considered in scope if ANY of the groups in the collection is evaluated to true.'
+      additionalProperties:
+        type: object
+    microsoft.graph.attributeDefinition:
+      title: attributeDefinition
+      type: object
+      properties:
+        anchor:
+          type: boolean
+          description: 'true if the attribute should be used as the anchor for the object. Anchor attributes must have a unique value identifying an object, and must be immutable. Default is false. One, and only one, of the object''s attributes must be designated as the anchor to support synchronization.'
+        apiExpressions:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.stringKeyStringValuePair'
+        caseExact:
+          type: boolean
+          description: true if value of this attribute should be treated as case-sensitive. This setting affects how the synchronization engine detects changes for the attribute.
+        defaultValue:
+          type: string
+          description: The default value of the attribute.
+          nullable: true
+        flowNullValues:
+          type: boolean
+          description: '''true'' to allow null values for attributes.'
+        metadata:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.attributeDefinitionMetadataEntry'
+          description: Metadata for the given object.
+        multivalued:
+          type: boolean
+          description: true if an attribute can have multiple values. Default is false.
+        mutability:
+          $ref: '#/components/schemas/microsoft.graph.mutability'
+        name:
+          type: string
+          description: Name of the attribute. Must be unique within the object definition. Not nullable.
+          nullable: true
+        referencedObjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.referencedObject'
+          description: 'For attributes with reference type, lists referenced objects (for example, the manager attribute would list User as the referenced object).'
+        required:
+          type: boolean
+          description: 'true if attribute is required. Object can not be created if any of the required attributes are missing. If during synchronization, the required attribute has no value, the default value will be used. If default the value was not set, synchronization will record an error.'
+        type:
+          $ref: '#/components/schemas/microsoft.graph.attributeType'
+      additionalProperties:
+        type: object
+    microsoft.graph.objectDefinitionMetadataEntry:
+      title: objectDefinitionMetadataEntry
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/microsoft.graph.objectDefinitionMetadata'
+        value:
+          type: string
+          description: Value of the metadata property.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.customSecurityAttributeComparisonOperator:
+      title: customSecurityAttributeComparisonOperator
+      enum:
+        - equals
+        - unknownFutureValue
+      type: string
+    microsoft.graph.attributeFlowBehavior:
+      title: attributeFlowBehavior
+      enum:
+        - FlowWhenChanged
+        - FlowAlways
+      type: string
+    microsoft.graph.attributeFlowType:
+      title: attributeFlowType
+      enum:
+        - Always
+        - ObjectAddOnly
+        - MultiValueAddOnly
+        - ValueAddOnly
+        - AttributeAddOnly
+      type: string
+    microsoft.graph.attributeMappingSource:
+      title: attributeMappingSource
+      type: object
+      properties:
+        expression:
+          type: string
+          description: Equivalent expression representation of this attributeMappingSource object.
+          nullable: true
+        name:
+          type: string
+          description: 'Name parameter of the mapping source. Depending on the type property value, this can be the name of the function, the name of the source attribute, or a constant value to be used.'
+          nullable: true
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.stringKeyAttributeMappingSourceValuePair'
+          description: 'If this object represents a function, lists function parameters. Parameters consist of attributeMappingSource objects themselves, allowing for complex expressions. If type isn''t Function, this property is null/empty array.'
+        type:
+          $ref: '#/components/schemas/microsoft.graph.attributeMappingSourceType'
+      additionalProperties:
+        type: object
+    microsoft.graph.objectMappingMetadata:
+      title: objectMappingMetadata
+      enum:
+        - EscrowBehavior
+        - DisableMonitoringForChanges
+        - OriginalJoiningProperty
+        - Disposition
+        - IsCustomerDefined
+        - ExcludeFromReporting
+        - Unsynchronized
+      type: string
+    microsoft.graph.filterGroup:
+      title: filterGroup
+      type: object
+      properties:
+        clauses:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.filterClause'
+          description: Filter clauses (conditions) of this group. All clauses in a group must be satisfied in order for the filter group to evaluate to true.
+        name:
+          type: string
+          description: Human-readable name of the filter group.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.attributeDefinitionMetadataEntry:
+      title: attributeDefinitionMetadataEntry
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/microsoft.graph.attributeDefinitionMetadata'
+        value:
+          type: string
+          description: Value of the metadata property.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.mutability:
+      title: mutability
+      enum:
+        - ReadWrite
+        - ReadOnly
+        - Immutable
+        - WriteOnly
+      type: string
+    microsoft.graph.referencedObject:
+      title: referencedObject
+      type: object
+      properties:
+        referencedObjectName:
+          type: string
+          description: Name of the referenced object. Must match one of the objects in the directory definition.
+          nullable: true
+        referencedProperty:
+          type: string
+          description: 'Currently not supported. Name of the property in the referenced object, the value for which is used as the reference.'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.attributeType:
+      title: attributeType
+      enum:
+        - String
+        - Integer
+        - Reference
+        - Binary
+        - Boolean
+        - DateTime
+      type: string
+    microsoft.graph.objectDefinitionMetadata:
+      title: objectDefinitionMetadata
+      enum:
+        - PropertyNameAccountEnabled
+        - PropertyNameSoftDeleted
+        - IsSoftDeletionSupported
+        - IsSynchronizeAllSupported
+        - ConnectorDataStorageRequired
+        - Extensions
+        - BaseObjectName
+      type: string
+    microsoft.graph.stringKeyAttributeMappingSourceValuePair:
+      title: stringKeyAttributeMappingSourceValuePair
+      type: object
+      properties:
+        key:
+          type: string
+          description: The name of the parameter.
+          nullable: true
+        value:
+          $ref: '#/components/schemas/microsoft.graph.attributeMappingSource'
+      additionalProperties:
+        type: object
+    microsoft.graph.attributeMappingSourceType:
+      title: attributeMappingSourceType
+      enum:
+        - Attribute
+        - Constant
+        - Function
+      type: string
+    microsoft.graph.filterClause:
+      title: filterClause
+      type: object
+      properties:
+        operatorName:
+          type: string
+          description: Name of the operator to be applied to the source and target operands. Must be one of the supported operators. Supported operators can be discovered.
+          nullable: true
+        sourceOperandName:
+          type: string
+          description: Name of source operand (the operand being tested). The source operand name must match one of the attribute names on the source object.
+          nullable: true
+        targetOperand:
+          $ref: '#/components/schemas/microsoft.graph.filterOperand'
+      additionalProperties:
+        type: object
+    microsoft.graph.attributeDefinitionMetadata:
+      title: attributeDefinitionMetadata
+      enum:
+        - BaseAttributeName
+        - ComplexObjectDefinition
+        - IsContainer
+        - IsCustomerDefined
+        - IsDomainQualified
+        - LinkPropertyNames
+        - LinkTypeName
+        - MaximumLength
+        - ReferencedProperty
+      type: string
+    microsoft.graph.filterOperand:
+      title: filterOperand
+      type: object
+      properties:
+        values:
+          type: array
+          items:
+            type: string
+            nullable: true
+          description: Collection of values.
+      additionalProperties:
+        type: object
   responses:
     error:
       description: error
@@ -27641,18 +32854,30 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/microsoft.graph.ODataErrors.ODataError'
-    microsoft.graph.customSecurityAttributeAuditCollectionResponse:
+    microsoft.graph.apiUsageReportEnablementStatusCollectionResponse:
       description: Retrieved collection
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeAuditCollectionResponse'
+            $ref: '#/components/schemas/microsoft.graph.apiUsageReportEnablementStatusCollectionResponse'
     ODataCountResponse:
       description: The count of the resource
       content:
         text/plain:
           schema:
             $ref: '#/components/schemas/ODataCountResponse'
+    microsoft.graph.auditActivityTypeCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.auditActivityTypeCollectionResponse'
+    microsoft.graph.customSecurityAttributeAuditCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeAuditCollectionResponse'
     microsoft.graph.directoryAuditCollectionResponse:
       description: Retrieved collection
       content:
@@ -27665,6 +32890,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/microsoft.graph.provisioningObjectSummaryCollectionResponse'
+    microsoft.graph.signInEventsAppActivityCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.signInEventsAppActivityCollectionResponse'
+    microsoft.graph.signInEventsActivityCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.signInEventsActivityCollectionResponse'
     microsoft.graph.signInCollectionResponse:
       description: Retrieved collection
       content:

--- a/openApiDocs/beta/Security.yml
+++ b/openApiDocs/beta/Security.yml
@@ -69,7 +69,7 @@ paths:
     get:
       tags:
         - security.alert
-      summary: List alerts
+      summary: List alerts (deprecated)
       description: Retrieve a list of alert objects.
       externalDocs:
         description: Find more info here
@@ -422,11 +422,54 @@ paths:
           $ref: '#/components/responses/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+  /security/alerts_v2/microsoft.graph.security.moveAlerts:
+    post:
+      tags:
+        - security.alert
+      summary: Invoke action moveAlerts
+      description: Move one or more alert resources to a new or existing incident.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-alert-movealerts?view=graph-rest-beta
+      operationId: security.alerts_v2_moveAlert
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                alertIds:
+                  type: array
+                  items:
+                    type: string
+                    nullable: true
+                incidentId:
+                  type: string
+                  nullable: true
+                alertComment:
+                  type: string
+                  nullable: true
+                newCorrelationReasons:
+                  $ref: '#/components/schemas/microsoft.graph.security.correlationReason'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.mergeResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   '/security/alerts/{alert-id}':
     get:
       tags:
         - security.alert
-      summary: Get alert
+      summary: Get alert (deprecated)
       description: Retrieve the properties and relationships of an alert object.
       externalDocs:
         description: Find more info here
@@ -480,7 +523,7 @@ paths:
     patch:
       tags:
         - security.alert
-      summary: Update alert
+      summary: Update alert (deprecated)
       description: Update an editable alert property within any integrated solution to keep alert status and assignments in sync across solutions. This method updates any solution that has a record of the referenced alert ID.
       externalDocs:
         description: Find more info here
@@ -3556,6 +3599,7 @@ paths:
       tags:
         - security.auditCoreRoot
       summary: Get auditLog from security
+      description: The entry point for Microsoft Purview audit log queries and operations.
       operationId: security_GetAuditLog
       parameters:
         - name: $select
@@ -3758,37 +3802,6 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
-      tags:
-        - security.auditCoreRoot
-      summary: Update the navigation property queries in security
-      operationId: security.auditLog_UpdateQuery
-      parameters:
-        - name: auditLogQuery-id
-          in: path
-          description: The unique identifier of auditLogQuery
-          required: true
-          style: simple
-          schema:
-            type: string
-          x-ms-docs-key-type: auditLogQuery
-      requestBody:
-        description: New navigation property values
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/microsoft.graph.security.auditLogQuery'
-        required: true
-      responses:
-        2XX:
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/microsoft.graph.security.auditLogQuery'
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
     delete:
       tags:
         - security.auditCoreRoot
@@ -3878,37 +3891,6 @@ paths:
         nextLinkName: '@odata.nextLink'
         operationName: listMore
       x-ms-docs-operation-type: operation
-    post:
-      tags:
-        - security.auditCoreRoot
-      summary: Create new navigation property to records for security
-      operationId: security.auditLog.query_CreateRecord
-      parameters:
-        - name: auditLogQuery-id
-          in: path
-          description: The unique identifier of auditLogQuery
-          required: true
-          style: simple
-          schema:
-            type: string
-          x-ms-docs-key-type: auditLogQuery
-      requestBody:
-        description: New navigation property
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/microsoft.graph.security.auditLogRecord'
-        required: true
-      responses:
-        2XX:
-          description: Created navigation property.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/microsoft.graph.security.auditLogRecord'
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
   '/security/auditLog/queries/{auditLogQuery-id}/records/{auditLogRecord-id}':
     get:
       tags:
@@ -3960,79 +3942,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/microsoft.graph.security.auditLogRecord'
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    patch:
-      tags:
-        - security.auditCoreRoot
-      summary: Update the navigation property records in security
-      operationId: security.auditLog.query_UpdateRecord
-      parameters:
-        - name: auditLogQuery-id
-          in: path
-          description: The unique identifier of auditLogQuery
-          required: true
-          style: simple
-          schema:
-            type: string
-          x-ms-docs-key-type: auditLogQuery
-        - name: auditLogRecord-id
-          in: path
-          description: The unique identifier of auditLogRecord
-          required: true
-          style: simple
-          schema:
-            type: string
-          x-ms-docs-key-type: auditLogRecord
-      requestBody:
-        description: New navigation property values
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/microsoft.graph.security.auditLogRecord'
-        required: true
-      responses:
-        2XX:
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/microsoft.graph.security.auditLogRecord'
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - security.auditCoreRoot
-      summary: Delete navigation property records for security
-      operationId: security.auditLog.query_DeleteRecord
-      parameters:
-        - name: auditLogQuery-id
-          in: path
-          description: The unique identifier of auditLogQuery
-          required: true
-          style: simple
-          schema:
-            type: string
-          x-ms-docs-key-type: auditLogQuery
-        - name: auditLogRecord-id
-          in: path
-          description: The unique identifier of auditLogRecord
-          required: true
-          style: simple
-          schema:
-            type: string
-          x-ms-docs-key-type: auditLogRecord
-        - name: If-Match
-          in: header
-          description: ETag
-          style: simple
-          schema:
-            type: string
-      responses:
-        2XX:
-          description: Success
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -4662,7 +4571,7 @@ paths:
       tags:
         - security.casesRoot
       summary: Create custodians
-      description: "Create a new ediscoveryCustodian object.\nAfter the custodian object is created, you will need to create the custodian's userSource to reference their mailbox and OneDrive for Business site."
+      description: "Create a new ediscoveryCustodian object.\r\nAfter the custodian object is created, you will need to create the custodian's userSource to reference their mailbox and OneDrive for Business site."
       externalDocs:
         description: Find more info here
         url: https://learn.microsoft.com/graph/api/security-ediscoverycase-post-custodians?view=graph-rest-beta
@@ -6543,6 +6452,39 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/security/cases/ediscoveryCases/{ediscoveryCase-id}/legalHolds/{ediscoveryHoldPolicy-id}/microsoft.graph.security.retryPolicy':
+    post:
+      tags:
+        - security.casesRoot
+      summary: Invoke action retryPolicy
+      description: Trigger a retry of an eDiscovery hold policy.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-ediscoveryholdpolicy-retrypolicy?view=graph-rest-beta
+      operationId: security.case.ediscoveryCase.legalHold_retryPolicy
+      parameters:
+        - name: ediscoveryCase-id
+          in: path
+          description: The unique identifier of ediscoveryCase
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: ediscoveryCase
+        - name: ediscoveryHoldPolicy-id
+          in: path
+          description: The unique identifier of ediscoveryHoldPolicy
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: ediscoveryHoldPolicy
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   '/security/cases/ediscoveryCases/{ediscoveryCase-id}/legalHolds/{ediscoveryHoldPolicy-id}/siteSources':
     get:
       tags:
@@ -10835,7 +10777,7 @@ paths:
       tags:
         - security.casesRoot
       summary: Invoke action purgeData
-      description: "Delete Exchange mailbox items or Microsoft Teams messages contained in an eDiscovery search. You can collect and purge the following categories of Teams content:\n- Teams 1:1 chats - Chat messages, posts, and attachments shared in a Teams conversation between two people. Teams 1:1 chats are also called *conversations*.\n- Teams group chats - Chat messages, posts, and attachments shared in a Teams conversation between three or more people. Also called *1:N* chats or *group conversations*.\n- Teams channels - Chat messages, posts, replies, and attachments shared in a standard Teams channel.\n- Private channels - Message posts, replies, and attachments shared in a private Teams channel.\n- Shared channels - Message posts, replies, and attachments shared in a shared Teams channel. For more information about purging Teams messages, see:\n- eDiscovery solution series: Data spillage scenario - Search and purge\n- eDiscovery (Premium) workflow for content in Microsoft Teams "
+      description: "Delete Exchange mailbox items or Microsoft Teams messages contained in an eDiscovery search. You can collect and purge the following categories of Teams content:\r\n- Teams 1:1 chats - Chat messages, posts, and attachments shared in a Teams conversation between two people. Teams 1:1 chats are also called *conversations*.\r\n- Teams group chats - Chat messages, posts, and attachments shared in a Teams conversation between three or more people. Also called *1:N* chats or *group conversations*.\r\n- Teams channels - Chat messages, posts, replies, and attachments shared in a standard Teams channel.\r\n- Private channels - Message posts, replies, and attachments shared in a private Teams channel.\r\n- Shared channels - Message posts, replies, and attachments shared in a shared Teams channel. For more information about purging Teams messages, see:\r\n- eDiscovery solution series: Data spillage scenario - Search and purge\r\n- eDiscovery (Premium) workflow for content in Microsoft Teams "
       externalDocs:
         description: Find more info here
         url: https://learn.microsoft.com/graph/api/security-ediscoverysearch-purgedata?view=graph-rest-beta
@@ -14940,7 +14882,11 @@ paths:
     get:
       tags:
         - security.identityContainer
-      summary: Get identityAccounts from security
+      summary: List identityAccounts objects
+      description: Get a list of the identityAccounts objects and their properties.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-identitycontainer-list-identityaccounts?view=graph-rest-beta
       operationId: security.identity_ListIdentityAccount
       parameters:
         - $ref: '#/components/parameters/top'
@@ -15013,7 +14959,11 @@ paths:
     get:
       tags:
         - security.identityContainer
-      summary: Get identityAccounts from security
+      summary: Get identityAccounts
+      description: Read the properties and relationships of a single identity security account object. This allows retrieving information about available identity accounts.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-identityaccounts-get?view=graph-rest-beta
       operationId: security.identity_GetIdentityAccount
       parameters:
         - name: identityAccounts-id
@@ -15116,6 +15066,10 @@ paths:
       tags:
         - security.identityContainer
       summary: Invoke action invokeAction
+      description: Perform actions such as revoking accounts and forcing password reset for identity accounts that are observed in Microsoft Defender for Identity. This action allows reading and performing identity security actions on behalf of the signed-in identity.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-identityaccounts-invokeaction?view=graph-rest-beta
       operationId: security.identity.identityAccount_invokeAction
       parameters:
         - name: identityAccounts-id
@@ -15166,6 +15120,531 @@ paths:
           $ref: '#/components/responses/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+  /security/identities/sensorCandidateActivationConfiguration:
+    get:
+      tags:
+        - security.identityContainer
+      summary: Get sensorCandidateActivationConfiguration
+      description: Read the properties and relationships of microsoft.graph.security.sensorCandidateActivationConfiguration object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-sensorcandidateactivationconfiguration-get?view=graph-rest-beta
+      operationId: security.identity_GetSensorCandidateActivationConfiguration
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.sensorCandidateActivationConfiguration'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.identityContainer
+      summary: Update the navigation property sensorCandidateActivationConfiguration in security
+      operationId: security.identity_UpdateSensorCandidateActivationConfiguration
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.sensorCandidateActivationConfiguration'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.sensorCandidateActivationConfiguration'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.identityContainer
+      summary: Delete navigation property sensorCandidateActivationConfiguration for security
+      operationId: security.identity_DeleteSensorCandidateActivationConfiguration
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  /security/identities/sensorCandidates:
+    get:
+      tags:
+        - security.identityContainer
+      summary: List sensorCandidate objects
+      description: Get a list of the sensorCandidate objects and their properties.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-identitycontainer-list-sensorcandidates?view=graph-rest-beta
+      operationId: security.identity_ListSensorCandidate
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.security.sensorCandidateCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - security.identityContainer
+      summary: Create new navigation property to sensorCandidates for security
+      operationId: security.identity_CreateSensorCandidate
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.sensorCandidate'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.sensorCandidate'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/identities/sensorCandidates/{sensorCandidate-id}':
+    get:
+      tags:
+        - security.identityContainer
+      summary: Get sensorCandidates from security
+      operationId: security.identity_GetSensorCandidate
+      parameters:
+        - name: sensorCandidate-id
+          in: path
+          description: The unique identifier of sensorCandidate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: sensorCandidate
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.sensorCandidate'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.identityContainer
+      summary: Update the navigation property sensorCandidates in security
+      operationId: security.identity_UpdateSensorCandidate
+      parameters:
+        - name: sensorCandidate-id
+          in: path
+          description: The unique identifier of sensorCandidate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: sensorCandidate
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.sensorCandidate'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.sensorCandidate'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.identityContainer
+      summary: Delete navigation property sensorCandidates for security
+      operationId: security.identity_DeleteSensorCandidate
+      parameters:
+        - name: sensorCandidate-id
+          in: path
+          description: The unique identifier of sensorCandidate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: sensorCandidate
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  /security/identities/sensorCandidates/$count:
+    get:
+      tags:
+        - security.identityContainer
+      summary: Get the number of the resource
+      operationId: security.identity.sensorCandidate_GetCount
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  /security/identities/sensorCandidates/microsoft.graph.security.activate:
+    post:
+      tags:
+        - security.identityContainer
+      summary: Invoke action activate
+      description: Activate Microsoft Defender for Identity sensors.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-sensorcandidate-activate?view=graph-rest-beta
+      operationId: security.identity.sensorCandidate_activate
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                serverIds:
+                  type: array
+                  items:
+                    type: string
+                    nullable: true
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  /security/identities/sensorMigration:
+    get:
+      tags:
+        - security.identityContainer
+      summary: Get sensorMigration from security
+      operationId: security.identity_ListSensorMigration
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.security.sensorMigrationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - security.identityContainer
+      summary: Create new navigation property to sensorMigration for security
+      operationId: security.identity_CreateSensorMigration
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.sensorMigration'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.sensorMigration'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/identities/sensorMigration/{sensorMigration-id}':
+    get:
+      tags:
+        - security.identityContainer
+      summary: Get sensorMigration from security
+      operationId: security.identity_GetSensorMigration
+      parameters:
+        - name: sensorMigration-id
+          in: path
+          description: The unique identifier of sensorMigration
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: sensorMigration
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.sensorMigration'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.identityContainer
+      summary: Update the navigation property sensorMigration in security
+      operationId: security.identity_UpdateSensorMigration
+      parameters:
+        - name: sensorMigration-id
+          in: path
+          description: The unique identifier of sensorMigration
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: sensorMigration
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.sensorMigration'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.sensorMigration'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.identityContainer
+      summary: Delete navigation property sensorMigration for security
+      operationId: security.identity_DeleteSensorMigration
+      parameters:
+        - name: sensorMigration-id
+          in: path
+          description: The unique identifier of sensorMigration
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: sensorMigration
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  /security/identities/sensorMigration/$count:
+    get:
+      tags:
+        - security.identityContainer
+      summary: Get the number of the resource
+      operationId: security.identity.sensorMigration_GetCount
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  /security/identities/sensorMigration/microsoft.graph.security.migrate:
+    post:
+      tags:
+        - security.identityContainer
+      summary: Invoke action migrate
+      operationId: security.identity.sensorMigration_migrate
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sensorIds:
+                  type: array
+                  items:
+                    type: string
+                    nullable: true
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.migrateSensorsResult'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   /security/identities/sensors:
     get:
       tags:
@@ -15567,6 +16046,165 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  /security/identities/settings:
+    get:
+      tags:
+        - security.identityContainer
+      summary: Get settings from security
+      description: Represents a container for security identities settings APIs.
+      operationId: security.identity_GetSetting
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.settingsContainer'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.identityContainer
+      summary: Update the navigation property settings in security
+      operationId: security.identity_UpdateSetting
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.settingsContainer'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.settingsContainer'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.identityContainer
+      summary: Delete navigation property settings for security
+      operationId: security.identity_DeleteSetting
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  /security/identities/settings/autoAuditingConfiguration:
+    get:
+      tags:
+        - security.identityContainer
+      summary: Get autoAuditingConfiguration
+      description: Get the properties and relationships of an microsoft.graph.security.autoAuditingConfiguration object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-autoauditingconfiguration-get?view=graph-rest-beta
+      operationId: security.identity.setting_GetAutoAuditingConfiguration
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.autoAuditingConfiguration'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.identityContainer
+      summary: Update the navigation property autoAuditingConfiguration in security
+      operationId: security.identity.setting_UpdateAutoAuditingConfiguration
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.autoAuditingConfiguration'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.autoAuditingConfiguration'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.identityContainer
+      summary: Delete navigation property autoAuditingConfiguration for security
+      operationId: security.identity.setting_DeleteAutoAuditingConfiguration
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   /security/incidents:
     get:
       tags:
@@ -15983,6 +16621,46 @@ paths:
           $ref: '#/components/responses/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+  /security/incidents/microsoft.graph.security.mergeIncidents:
+    post:
+      tags:
+        - security.incident
+      summary: Invoke action mergeIncidents
+      description: Merge multiple incident resources into a single incident.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-incident-mergeincidents?view=graph-rest-beta
+      operationId: security.incident_mergeIncident
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                incidentIds:
+                  type: array
+                  items:
+                    type: string
+                    nullable: true
+                incidentComment:
+                  type: string
+                  nullable: true
+                mergeReasons:
+                  $ref: '#/components/schemas/microsoft.graph.security.correlationReason'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.mergeResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
   /security/incidentTasks:
     get:
       tags:
@@ -19253,6 +19931,22 @@ paths:
           $ref: '#/components/responses/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+  /security/microsoft.graph.security.getHuntingSchema():
+    get:
+      tags:
+        - security.security.Functions
+      summary: Invoke function getHuntingSchema
+      operationId: security_getHuntingSchema
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.huntingSchemaResult'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
   /security/microsoft.graph.security.runHuntingQuery:
     post:
       tags:
@@ -19291,7 +19985,7 @@ paths:
       tags:
         - security.partnerSecurity
       summary: Get partner from security
-      description: 'A container that safeguards the Microsoft Azure resources of Microsoft Cloud Solution Provider (CSP) partners’ customers, including alerts, scores, and all aspects of security.'
+      description: 'A container that safeguards the Microsoft Azure resources of Microsoft Cloud Solution Provider (CSP) partners'' customers, including alerts, scores, and all aspects of security.'
       operationId: security_GetPartner
       parameters:
         - name: $select
@@ -20541,7 +21235,7 @@ paths:
       tags:
         - security.rulesRoot
       summary: List detectionRules
-      description: "Get a list of custom detection rules.\nWith custom detections, you can proactively monitor for and respond to various events and system states, including suspected breach activity and misconfigured assets in their organization network.\nCustom detection rules, which are written in Kusto query language (KQL), automatically trigger alerts and response actions once there are events matching their KQL queries."
+      description: "Get a list of custom detection rules.\r\nWith custom detections, you can proactively monitor for and respond to various events and system states, including suspected breach activity and misconfigured assets in their organization network.\r\nCustom detection rules, which are written in Kusto query language (KQL), automatically trigger alerts and response actions once there are events matching their KQL queries."
       externalDocs:
         description: Find more info here
         url: https://learn.microsoft.com/graph/api/security-detectionrule-list?view=graph-rest-beta
@@ -21008,7 +21702,7 @@ paths:
       tags:
         - security.secureScore
       summary: Get secureScores from security
-      description: Measurements of tenants’ security posture to help protect them from threats.
+      description: Measurements of tenants' security posture to help protect them from threats.
       operationId: security_GetSecureScore
       parameters:
         - name: secureScore-id
@@ -21388,6 +22082,1382 @@ paths:
         date: '2024-04-10'
         version: 2024-01/Deprecation
         description: 'The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API.'
+  /security/securityCopilot:
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get securityCopilot from security
+      description: Represents the resources related to Microsoft Security Copilot.
+      operationId: security_GetSecurityCopilot
+      parameters:
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.securityCopilot'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.securityCopilot
+      summary: Update the navigation property securityCopilot in security
+      operationId: security_UpdateSecurityCopilot
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.securityCopilot'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.securityCopilot'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.securityCopilot
+      summary: Delete navigation property securityCopilot for security
+      operationId: security_DeleteSecurityCopilot
+      parameters:
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  /security/securityCopilot/workspaces:
+    get:
+      tags:
+        - security.securityCopilot
+      summary: List workspace objects
+      description: Get a list of the workspace objects and their properties.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/securitycopilot-list-workspaces?view=graph-rest-beta
+      operationId: security.securityCopilot_ListWorkspace
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.security.securityCopilot.workspaceCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - security.securityCopilot
+      summary: Create new navigation property to workspaces for security
+      operationId: security.securityCopilot_CreateWorkspace
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.workspace'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.workspace'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/securityCopilot/workspaces/{workspace-id}':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get workspaces from security
+      description: References a workspace in Security Copilot.
+      operationId: security.securityCopilot_GetWorkspace
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.workspace'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.securityCopilot
+      summary: Update the navigation property workspaces in security
+      operationId: security.securityCopilot_UpdateWorkspace
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.workspace'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.workspace'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.securityCopilot
+      summary: Delete navigation property workspaces for security
+      operationId: security.securityCopilot_DeleteWorkspace
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/securityCopilot/workspaces/{workspace-id}/plugins':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get plugins from security
+      description: Represents plugins in Security Copilot.
+      operationId: security.securityCopilot.workspace_ListPlugin
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.security.securityCopilot.pluginCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - security.securityCopilot
+      summary: Create new navigation property to plugins for security
+      operationId: security.securityCopilot.workspace_CreatePlugin
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.plugin'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.plugin'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/securityCopilot/workspaces/{workspace-id}/plugins/{plugin-name}':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get plugins from security
+      description: Represents plugins in Security Copilot.
+      operationId: security.securityCopilot.workspace_GetPlugin
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: plugin-name
+          in: path
+          description: The unique identifier of plugin
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plugin
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.plugin'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.securityCopilot
+      summary: Update the navigation property plugins in security
+      operationId: security.securityCopilot.workspace_UpdatePlugin
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: plugin-name
+          in: path
+          description: The unique identifier of plugin
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plugin
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.plugin'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.plugin'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.securityCopilot
+      summary: Delete navigation property plugins for security
+      operationId: security.securityCopilot.workspace_DeletePlugin
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: plugin-name
+          in: path
+          description: The unique identifier of plugin
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plugin
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/securityCopilot/workspaces/{workspace-id}/plugins/$count':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get the number of the resource
+      operationId: security.securityCopilot.workspace.plugin_GetCount
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/security/securityCopilot/workspaces/{workspace-id}/sessions':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get sessions from security
+      description: Represents sessions in Security Copilot.
+      operationId: security.securityCopilot.workspace_ListSession
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.security.securityCopilot.sessionCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - security.securityCopilot
+      summary: Create new navigation property to sessions for security
+      operationId: security.securityCopilot.workspace_CreateSession
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.session'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.session'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/securityCopilot/workspaces/{workspace-id}/sessions/{session-id}':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get sessions from security
+      description: Represents sessions in Security Copilot.
+      operationId: security.securityCopilot.workspace_GetSession
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.session'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.securityCopilot
+      summary: Update the navigation property sessions in security
+      operationId: security.securityCopilot.workspace_UpdateSession
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.session'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.session'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.securityCopilot
+      summary: Delete navigation property sessions for security
+      operationId: security.securityCopilot.workspace_DeleteSession
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/securityCopilot/workspaces/{workspace-id}/sessions/{session-id}/prompts':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get prompts from security
+      description: The collection of prompts in the session.
+      operationId: security.securityCopilot.workspace.session_ListPrompt
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.security.securityCopilot.promptCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - security.securityCopilot
+      summary: Create new navigation property to prompts for security
+      operationId: security.securityCopilot.workspace.session_CreatePrompt
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.prompt'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.prompt'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/securityCopilot/workspaces/{workspace-id}/sessions/{session-id}/prompts/{prompt-id}':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get prompts from security
+      description: The collection of prompts in the session.
+      operationId: security.securityCopilot.workspace.session_GetPrompt
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: prompt-id
+          in: path
+          description: The unique identifier of prompt
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: prompt
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.prompt'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.securityCopilot
+      summary: Update the navigation property prompts in security
+      operationId: security.securityCopilot.workspace.session_UpdatePrompt
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: prompt-id
+          in: path
+          description: The unique identifier of prompt
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: prompt
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.prompt'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.prompt'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.securityCopilot
+      summary: Delete navigation property prompts for security
+      operationId: security.securityCopilot.workspace.session_DeletePrompt
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: prompt-id
+          in: path
+          description: The unique identifier of prompt
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: prompt
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/securityCopilot/workspaces/{workspace-id}/sessions/{session-id}/prompts/{prompt-id}/evaluations':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get evaluations from security
+      description: Collection of evaluations
+      operationId: security.securityCopilot.workspace.session.prompt_ListEvaluation
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: prompt-id
+          in: path
+          description: The unique identifier of prompt
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: prompt
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.security.securityCopilot.evaluationCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - security.securityCopilot
+      summary: Create new navigation property to evaluations for security
+      operationId: security.securityCopilot.workspace.session.prompt_CreateEvaluation
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: prompt-id
+          in: path
+          description: The unique identifier of prompt
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: prompt
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluation'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluation'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/securityCopilot/workspaces/{workspace-id}/sessions/{session-id}/prompts/{prompt-id}/evaluations/{evaluation-id}':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get evaluations from security
+      description: Collection of evaluations
+      operationId: security.securityCopilot.workspace.session.prompt_GetEvaluation
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: prompt-id
+          in: path
+          description: The unique identifier of prompt
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: prompt
+        - name: evaluation-id
+          in: path
+          description: The unique identifier of evaluation
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: evaluation
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluation'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.securityCopilot
+      summary: Update the navigation property evaluations in security
+      operationId: security.securityCopilot.workspace.session.prompt_UpdateEvaluation
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: prompt-id
+          in: path
+          description: The unique identifier of prompt
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: prompt
+        - name: evaluation-id
+          in: path
+          description: The unique identifier of evaluation
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: evaluation
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluation'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluation'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.securityCopilot
+      summary: Delete navigation property evaluations for security
+      operationId: security.securityCopilot.workspace.session.prompt_DeleteEvaluation
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: prompt-id
+          in: path
+          description: The unique identifier of prompt
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: prompt
+        - name: evaluation-id
+          in: path
+          description: The unique identifier of evaluation
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: evaluation
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/securityCopilot/workspaces/{workspace-id}/sessions/{session-id}/prompts/{prompt-id}/evaluations/$count':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get the number of the resource
+      operationId: security.securityCopilot.workspace.session.prompt.evaluation_GetCount
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - name: prompt-id
+          in: path
+          description: The unique identifier of prompt
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: prompt
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/security/securityCopilot/workspaces/{workspace-id}/sessions/{session-id}/prompts/$count':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get the number of the resource
+      operationId: security.securityCopilot.workspace.session.prompt_GetCount
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - name: session-id
+          in: path
+          description: The unique identifier of session
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: session
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/security/securityCopilot/workspaces/{workspace-id}/sessions/$count':
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get the number of the resource
+      operationId: security.securityCopilot.workspace.session_GetCount
+      parameters:
+        - name: workspace-id
+          in: path
+          description: The unique identifier of workspace
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: workspace
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  /security/securityCopilot/workspaces/$count:
+    get:
+      tags:
+        - security.securityCopilot
+      summary: Get the number of the resource
+      operationId: security.securityCopilot.workspace_GetCount
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /security/subjectRightsRequests:
     get:
       tags:
@@ -21680,7 +23750,7 @@ paths:
       tags:
         - security.subjectRightsRequest
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: security.subjectRightsRequest.approver_GetMailboxSetting
       parameters:
         - name: subjectRightsRequest-id
@@ -22055,7 +24125,7 @@ paths:
       tags:
         - security.subjectRightsRequest
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: security.subjectRightsRequest.collaborator_GetMailboxSetting
       parameters:
         - name: subjectRightsRequest-id
@@ -26210,7 +28280,7 @@ paths:
       tags:
         - security.threatIntelligence
       summary: Get whoisRecord
-      description: "Get the specified whoisRecord resource.  Specify the desired whoisRecord in one of the following two ways:\n- Identify a host and get its current whoisRecord. \n- Specify an id value to get the corresponding whoisRecord."
+      description: "Get the specified whoisRecord resource.  Specify the desired whoisRecord in one of the following two ways:\r\n- Identify a host and get its current whoisRecord. \r\n- Specify an id value to get the corresponding whoisRecord."
       externalDocs:
         description: Find more info here
         url: https://learn.microsoft.com/graph/api/security-whoisrecord-get?view=graph-rest-beta
@@ -29127,7 +31197,7 @@ paths:
       tags:
         - security.threatIntelligence
       summary: Get whoisRecord
-      description: "Get the specified whoisRecord resource.  Specify the desired whoisRecord in one of the following two ways:\n- Identify a host and get its current whoisRecord. \n- Specify an id value to get the corresponding whoisRecord."
+      description: "Get the specified whoisRecord resource.  Specify the desired whoisRecord in one of the following two ways:\r\n- Identify a host and get its current whoisRecord. \r\n- Specify an id value to get the corresponding whoisRecord."
       externalDocs:
         description: Find more info here
         url: https://learn.microsoft.com/graph/api/security-whoisrecord-get?view=graph-rest-beta
@@ -30306,7 +32376,7 @@ paths:
     get:
       tags:
         - security.tiIndicator
-      summary: List threat intelligence indicators
+      summary: List threat intelligence indicators (deprecated)
       description: Retrieve a list of tiIndicator objects.
       externalDocs:
         description: Find more info here
@@ -30366,7 +32436,7 @@ paths:
     post:
       tags:
         - security.tiIndicator
-      summary: Create threat intelligence indicator
+      summary: Create threat intelligence indicator (deprecated)
       description: Create a new tiIndicator object.
       externalDocs:
         description: Find more info here
@@ -30399,7 +32469,7 @@ paths:
     get:
       tags:
         - security.tiIndicator
-      summary: Get threat intelligence indicator
+      summary: Get threat intelligence indicator (deprecated)
       description: Retrieve the properties and relationships of a tiIndicator object.
       externalDocs:
         description: Find more info here
@@ -30453,7 +32523,7 @@ paths:
     patch:
       tags:
         - security.tiIndicator
-      summary: Update tiIndicator
+      summary: Update tiIndicator (deprecated)
       description: Update the properties of a tiIndicator object.
       externalDocs:
         description: Find more info here
@@ -30494,7 +32564,7 @@ paths:
     delete:
       tags:
         - security.tiIndicator
-      summary: Delete threat intelligence indicator
+      summary: Delete threat intelligence indicator (deprecated)
       description: Delete a tiIndicator object.
       externalDocs:
         description: Find more info here
@@ -31598,6 +33668,503 @@ paths:
         date: '2024-04-10'
         version: 2024-01/Deprecation
         description: 'The legacy Graph Security API is deprecated and will stop returning data on January 31, 2025. Please use the new Graph Security API.'
+  /security/zones:
+    get:
+      tags:
+        - security.zone
+      summary: List zones
+      description: Get a list of the zone objects and their properties.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-security-list-zones?view=graph-rest-beta
+      operationId: security_ListZone
+      parameters:
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.security.zoneCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - security.zone
+      summary: Create zone
+      description: 'Create a new zone object. You can create up to 1,000 zones per tenant.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-security-post-zones?view=graph-rest-beta
+      operationId: security_CreateZone
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.zone'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.zone'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/zones/{zone-id}':
+    get:
+      tags:
+        - security.zone
+      summary: Get zone
+      description: Get a zone object by a specific zoneId.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-zone-get?view=graph-rest-beta
+      operationId: security_GetZone
+      parameters:
+        - name: zone-id
+          in: path
+          description: The unique identifier of zone
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: zone
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.zone'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - security.zone
+      summary: Update zone
+      description: Update the properties of a zone object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-zone-update?view=graph-rest-beta
+      operationId: security_UpdateZone
+      parameters:
+        - name: zone-id
+          in: path
+          description: The unique identifier of zone
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: zone
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.zone'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.zone'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.zone
+      summary: Delete zone
+      description: Delete a zone object by providing the zoneId.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-zone-delete?view=graph-rest-beta
+      operationId: security_DeleteZone
+      parameters:
+        - name: zone-id
+          in: path
+          description: The unique identifier of zone
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: zone
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/zones/{zone-id}/aggregations/{aggregatedEnvironment-kind}':
+    get:
+      tags:
+        - security.zone
+      summary: Get aggregations from security
+      description: 'Environment count summaries by type. Read-only. Supports $filter (eq) on the kind property. For example, $filter=aggregations/any(a: a/kind eq ''azureSubscription'').'
+      operationId: security.zone_GetAggregation
+      parameters:
+        - name: zone-id
+          in: path
+          description: The unique identifier of zone
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: zone
+        - name: aggregatedEnvironment-kind
+          in: path
+          description: The unique identifier of aggregatedEnvironment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: aggregatedEnvironment
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.aggregatedEnvironment'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/zones/{zone-id}/aggregations/$count':
+    get:
+      tags:
+        - security.zone
+      summary: Get the number of the resource
+      operationId: security.zone.aggregation_GetCount
+      parameters:
+        - name: zone-id
+          in: path
+          description: The unique identifier of zone
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: zone
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/security/zones/{zone-id}/environments':
+    get:
+      tags:
+        - security.zone
+      summary: List environments
+      description: Get all environment objects associated with a zone object.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-zone-list-environments?view=graph-rest-beta
+      operationId: security.zone_ListEnvironment
+      parameters:
+        - name: zone-id
+          in: path
+          description: The unique identifier of zone
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: zone
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.security.environmentCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - security.zone
+      summary: Create environment
+      description: 'Create an environment object to attach it to a zone. You can create up to 1,000 environments per zone.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-zone-post-environments?view=graph-rest-beta
+      operationId: security.zone_CreateEnvironment
+      parameters:
+        - name: zone-id
+          in: path
+          description: The unique identifier of zone
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: zone
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.security.environment'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.environment'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/zones/{zone-id}/environments/{environment-id}':
+    get:
+      tags:
+        - security.zone
+      summary: Get environments from security
+      description: Collection of attached environments. Supports $expand.
+      operationId: security.zone_GetEnvironment
+      parameters:
+        - name: zone-id
+          in: path
+          description: The unique identifier of zone
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: zone
+        - name: environment-id
+          in: path
+          description: The unique identifier of environment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: environment
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.security.environment'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - security.zone
+      summary: Delete environment
+      description: Delete an environment object from a zone object by providing the environment ID. The environment ID should be URL-encoded.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/security-environment-delete?view=graph-rest-beta
+      operationId: security.zone_DeleteEnvironment
+      parameters:
+        - name: zone-id
+          in: path
+          description: The unique identifier of zone
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: zone
+        - name: environment-id
+          in: path
+          description: The unique identifier of environment
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: environment
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/security/zones/{zone-id}/environments/$count':
+    get:
+      tags:
+        - security.zone
+      summary: Get the number of the resource
+      operationId: security.zone.environment_GetCount
+      parameters:
+        - name: zone-id
+          in: path
+          description: The unique identifier of zone
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: zone
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  /security/zones/$count:
+    get:
+      tags:
+        - security.zone
+      summary: Get the number of the resource
+      operationId: security.zone_GetCount
+      parameters:
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/users/{user-id}/security':
     get:
       tags:
@@ -32498,7 +35065,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.alert'
-          description: Notifications for suspicious or potential security issues in a customer’s tenant.
+          description: Notifications for suspicious or potential security issues in a customer's tenant.
           x-ms-navigationProperty: true
         alerts_v2:
           type: array
@@ -32579,13 +35146,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.secureScore'
-          description: Measurements of tenants’ security posture to help protect them from threats.
+          description: Measurements of tenants' security posture to help protect them from threats.
           x-ms-navigationProperty: true
         securityActions:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.securityAction'
           x-ms-navigationProperty: true
+        securityCopilot:
+          $ref: '#/components/schemas/microsoft.graph.securityCopilot'
         subjectRightsRequests:
           type: array
           items:
@@ -32599,6 +35168,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.tiIndicator'
+          description: Deprecated. The tiIndicator entity is deprecated and will be removed by April 2026.
           x-ms-navigationProperty: true
         triggers:
           $ref: '#/components/schemas/microsoft.graph.security.triggersRoot'
@@ -32609,8 +35179,15 @@ components:
           items:
             $ref: '#/components/schemas/microsoft.graph.userSecurityProfile'
           x-ms-navigationProperty: true
+        zones:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.zone'
+          description: A collection of cloud zones in Microsoft Defender for Cloud that group and manage cloud environments across multiple cloud providers.
+          x-ms-navigationProperty: true
       additionalProperties:
         type: object
+      description: Security singleton providing access to audit log resources.
     microsoft.graph.alert:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -32667,7 +35244,7 @@ components:
             createdDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'Time at which the alert was created by the alert provider. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Required.'
+              description: 'Time at which the alert provider created the alert. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Required.'
               format: date-time
               nullable: true
             description:
@@ -32692,7 +35269,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.fileSecurityState'
-              description: Security-related stateful information generated by the provider about the file(s) related to this alert.
+              description: Security-related stateful information generated by the provider about the files related to this alert.
             historyStates:
               type: array
               items:
@@ -32702,7 +35279,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.hostSecurityState'
-              description: Security-related stateful information generated by the provider about the host(s) related to this alert.
+              description: Security-related stateful information generated by the provider about the hosts related to this alert.
             incidentIds:
               type: array
               items:
@@ -32737,7 +35314,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.networkConnection'
-              description: Security-related stateful information generated by the provider about the network connection(s) related to this alert.
+              description: Security-related stateful information generated by the provider about the network connections related to this alert.
             processes:
               type: array
               items:
@@ -32748,7 +35325,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: 'Vendor/provider recommended action(s) to take as a result of the alert (for example, isolate machine, enforce2FA, reimage host).'
+              description: 'Vendor/provider recommended actions to take as a result of the alert (for example, isolate machine, enforce2FA, reimage host).'
             registryKeyStates:
               type: array
               items:
@@ -32758,7 +35335,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.securityResource'
-              description: 'Resources related to current alert. For example, for some alerts this can have the Azure Resource value.'
+              description: 'Resources related to current alert. For example, some alerts have the Azure Resource value.'
             severity:
               $ref: '#/components/schemas/microsoft.graph.alertSeverity'
             sourceMaterials:
@@ -32774,7 +35351,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: 'User-definable labels that can be applied to an alert and can serve as filter conditions (for example ''HVA'', ''SAW'') (supports update).'
+              description: 'User-definable labels that can be applied to an alert and can serve as filter conditions (for example, ''HVA'', ''SAW''). Updatable.'
             title:
               type: string
               description: Alert title. Required.
@@ -32826,9 +35403,15 @@ components:
               type: string
               description: 'Owner of the alert, or null if no owner is assigned.'
               nullable: true
+            categories:
+              type: array
+              items:
+                type: string
+                nullable: true
+              description: The attack kill-chain categories that the alert belongs to. Aligned with the MITRE ATT&CK framework.
             category:
               type: string
-              description: The attack kill-chain category that the alert belongs to. Aligned with the MITRE ATT&CK framework.
+              description: The attack kill-chain category that the alert belongs to. Aligned with the MITRE ATT&CK framework. This property is in the process of being deprecated. Use the categories property instead.
               nullable: true
             classification:
               $ref: '#/components/schemas/microsoft.graph.security.alertClassification'
@@ -32876,6 +35459,8 @@ components:
               type: string
               description: URL for the incident page in the Microsoft 365 Defender portal.
               nullable: true
+            investigationState:
+              $ref: '#/components/schemas/microsoft.graph.security.investigationState'
             lastActivityDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
@@ -32959,6 +35544,39 @@ components:
           type: string
           description: The time when the comment was submitted.
           format: date-time
+      additionalProperties:
+        type: object
+    microsoft.graph.security.correlationReason:
+      title: correlationReason
+      enum:
+        - repeatedAlertOccurrence
+        - sameGeography
+        - similarArtifacts
+        - sameTargetedAsset
+        - sameNetworkSegment
+        - eventSequence
+        - timeFrame
+        - sameThreatSource
+        - similarTTPsOrBehavior
+        - sameActor
+        - sameCampaign
+        - sharedIndicators
+        - sameAsset
+        - networkProximity
+        - eventCasualSequence
+        - temporalProximity
+        - lateralMovementPath
+        - unknownFutureValue
+      type: string
+      x-ms-enum-flags:
+        isFlags: true
+    microsoft.graph.security.mergeResponse:
+      title: mergeResponse
+      type: object
+      properties:
+        targetIncidentId:
+          type: string
+          description: The ID of the target incident after the operation completes.
       additionalProperties:
         type: object
     microsoft.graph.attackSimulationRoot:
@@ -33652,6 +36270,7 @@ components:
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
+          description: Root entity for the audit log API.
     microsoft.graph.security.auditLogQuery:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -33706,7 +36325,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.auditLogRecordType'
-              description: 'The type of operation indicated by the record. The possible values are: exchangeAdmin, exchangeItem, exchangeItemGroup, sharePoint, syntheticProbe, sharePointFileOperation, oneDrive, azureActiveDirectory, azureActiveDirectoryAccountLogon, dataCenterSecurityCmdlet, complianceDLPSharePoint, sway, complianceDLPExchange, sharePointSharingOperation, azureActiveDirectoryStsLogon, skypeForBusinessPSTNUsage, skypeForBusinessUsersBlocked, securityComplianceCenterEOPCmdlet, exchangeAggregatedOperation, powerBIAudit, crm, yammer, skypeForBusinessCmdlets, discovery, microsoftTeams, threatIntelligence, mailSubmission, microsoftFlow, aeD, microsoftStream, complianceDLPSharePointClassification, threatFinder, project, sharePointListOperation, sharePointCommentOperation, dataGovernance, kaizala, securityComplianceAlerts, threatIntelligenceUrl, securityComplianceInsights, mipLabel, workplaceAnalytics, powerAppsApp, powerAppsPlan, threatIntelligenceAtpContent, labelContentExplorer, teamsHealthcare, exchangeItemAggregated, hygieneEvent, dataInsightsRestApiAudit, informationBarrierPolicyApplication, sharePointListItemOperation, sharePointContentTypeOperation, sharePointFieldOperation, microsoftTeamsAdmin, hrSignal, microsoftTeamsDevice, microsoftTeamsAnalytics, informationWorkerProtection, campaign, dlpEndpoint, airInvestigation, quarantine, microsoftForms, applicationAudit, complianceSupervisionExchange, customerKeyServiceEncryption, officeNative, mipAutoLabelSharePointItem, mipAutoLabelSharePointPolicyLocation, microsoftTeamsShifts, secureScore, mipAutoLabelExchangeItem, cortanaBriefing, search, wdatpAlerts, powerPlatformAdminDlp, powerPlatformAdminEnvironment, mdatpAudit, sensitivityLabelPolicyMatch, sensitivityLabelAction, sensitivityLabeledFileAction, attackSim, airManualInvestigation, securityComplianceRBAC, userTraining, airAdminActionInvestigation, mstic, physicalBadgingSignal, teamsEasyApprovals, aipDiscover, aipSensitivityLabelAction, aipProtectionAction, aipFileDeleted, aipHeartBeat, mcasAlerts, onPremisesFileShareScannerDlp, onPremisesSharePointScannerDlp, exchangeSearch, sharePointSearch, privacyDataMinimization, labelAnalyticsAggregate, myAnalyticsSettings, securityComplianceUserChange, complianceDLPExchangeClassification, complianceDLPEndpoint, mipExactDataMatch, msdeResponseActions, msdeGeneralSettings, msdeIndicatorsSettings, ms365DCustomDetection, msdeRolesSettings, mapgAlerts, mapgPolicy, mapgRemediation, privacyRemediationAction, privacyDigestEmail, mipAutoLabelSimulationProgress, mipAutoLabelSimulationCompletion, mipAutoLabelProgressFeedback, dlpSensitiveInformationType, mipAutoLabelSimulationStatistics, largeContentMetadata, microsoft365Group, cdpMlInferencingResult, filteringMailMetadata, cdpClassificationMailItem, cdpClassificationDocument, officeScriptsRunAction, filteringPostMailDeliveryAction, cdpUnifiedFeedback, tenantAllowBlockList, consumptionResource, healthcareSignal, dlpImportResult, cdpCompliancePolicyExecution, multiStageDisposition, privacyDataMatch, filteringDocMetadata, filteringEmailFeatures, powerBIDlp, filteringUrlInfo, filteringAttachmentInfo, coreReportingSettings, complianceConnector, powerPlatformLockboxResourceAccessRequest, powerPlatformLockboxResourceCommand, cdpPredictiveCodingLabel, cdpCompliancePolicyUserFeedback, webpageActivityEndpoint, omePortal, cmImprovementActionChange, filteringUrlClick, mipLabelAnalyticsAuditRecord, filteringEntityEvent, filteringRuleHits, filteringMailSubmission, labelExplorer, microsoftManagedServicePlatform, powerPlatformServiceActivity, scorePlatformGenericAuditRecord, filteringTimeTravelDocMetadata, alert, alertStatus, alertIncident, incidentStatus, case, caseInvestigation, recordsManagement, privacyRemediation, dataShareOperation, cdpDlpSensitive, ehrConnector, filteringMailGradingResult, publicFolder, privacyTenantAuditHistoryRecord, aipScannerDiscoverEvent, eduDataLakeDownloadOperation, m365ComplianceConnector, microsoftGraphDataConnectOperation, microsoftPurview, filteringEmailContentFeatures, powerPagesSite, powerAppsResource, plannerPlan, plannerCopyPlan, plannerTask, plannerRoster, plannerPlanList, plannerTaskList, plannerTenantSettings, projectForTheWebProject, projectForTheWebTask, projectForTheWebRoadmap, projectForTheWebRoadmapItem, projectForTheWebProjectSettings, projectForTheWebRoadmapSettings, quarantineMetadata, microsoftTodoAudit, timeTravelFilteringDocMetadata, teamsQuarantineMetadata, sharePointAppPermissionOperation, microsoftTeamsSensitivityLabelAction, filteringTeamsMetadata, filteringTeamsUrlInfo, filteringTeamsPostDeliveryAction, mdcAssessments, mdcRegulatoryComplianceStandards, mdcRegulatoryComplianceControls, mdcRegulatoryComplianceAssessments, mdcSecurityConnectors, mdaDataSecuritySignal, vivaGoals, filteringRuntimeInfo, attackSimAdmin, microsoftGraphDataConnectConsent, filteringAtpDetonationInfo, privacyPortal, managedTenants, unifiedSimulationMatchedItem, unifiedSimulationSummary, updateQuarantineMetadata, ms365DSuppressionRule, purviewDataMapOperation, filteringUrlPostClickAction, irmUserDefinedDetectionSignal, teamsUpdates, plannerRosterSensitivityLabel, ms365DIncident, filteringDelistingMetadata, complianceDLPSharePointClassificationExtended, microsoftDefenderForIdentityAudit, supervisoryReviewDayXInsight, defenderExpertsforXDRAdmin, cdpEdgeBlockedMessage, hostedRpa, cdpContentExplorerAggregateRecord, cdpHygieneAttachmentInfo, cdpHygieneSummary, cdpPostMailDeliveryAction, cdpEmailFeatures, cdpHygieneUrlInfo, cdpUrlClick, cdpPackageManagerHygieneEvent, filteringDocScan, timeTravelFilteringDocScan, mapgOnboard, unknownFutureValue.'
+              description: 'The type of operation indicated by the record. For the list of member values, see auditLogRecordType.'
             serviceFilters:
               type: array
               items:
@@ -33728,6 +36347,7 @@ components:
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
+          description: Represents a query against the unified audit log.
     microsoft.graph.security.auditLogRecord:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -33782,6 +36402,7 @@ components:
               $ref: '#/components/schemas/microsoft.graph.security.auditLogUserType'
           additionalProperties:
             type: object
+          description: Represents an individual audit log record.
     microsoft.graph.security.casesRoot:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -33953,14 +36574,28 @@ components:
             isPersonalSite:
               type: boolean
               nullable: true
+            locale:
+              type: string
+              description: The language settings of the site.
+              nullable: true
+            lockState:
+              $ref: '#/components/schemas/microsoft.graph.siteLockState'
+            ownerIdentityToResolve:
+              $ref: '#/components/schemas/microsoft.graph.identityInput'
             root:
               $ref: '#/components/schemas/microsoft.graph.root'
             settings:
               $ref: '#/components/schemas/microsoft.graph.siteSettings'
+            shareByEmailEnabled:
+              type: boolean
+              description: Determines whether the site and its content can be shared via email.
+              nullable: true
             sharepointIds:
               $ref: '#/components/schemas/microsoft.graph.sharepointIds'
             siteCollection:
               $ref: '#/components/schemas/microsoft.graph.siteCollection'
+            template:
+              $ref: '#/components/schemas/microsoft.graph.siteTemplateType'
             analytics:
               $ref: '#/components/schemas/microsoft.graph.itemAnalytics'
             columns:
@@ -34081,21 +36716,21 @@ components:
               $ref: '#/components/schemas/microsoft.graph.groupAccessType'
             allowExternalSenders:
               type: boolean
-              description: 'Indicates if people external to the organization can send messages to the group. The default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates if people external to the organization can send messages to the group. The default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             assignedLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignedLabel'
-              description: 'The list of sensitivity label pairs (label ID, label name) associated with a Microsoft 365 group. Returned only on $select. This property can be updated only in delegated scenarios where the caller requires both the Microsoft Graph permission and a supported administrator role.'
+              description: 'The list of sensitivity label pairs (label ID, label name) associated with a Microsoft 365 group. Requires $select to retrieve. This property can be updated only in delegated scenarios where the caller requires both the Microsoft Graph permission and a supported administrator role.'
             assignedLicenses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignedLicense'
-              description: The licenses that are assigned to the group. Returned only on $select. Supports $filter (eq). Read-only.
+              description: The licenses that are assigned to the group. Requires $select to retrieve. Supports $filter (eq). Read-only.
             autoSubscribeNewMembers:
               type: boolean
-              description: 'Indicates if new members added to the group are auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; don''t set it in the initial POST request that creates the group. Default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates if new members added to the group are auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; don''t set it in the initial POST request that creates the group. Default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             classification:
               type: string
@@ -34138,11 +36773,11 @@ components:
               nullable: true
             hideFromAddressLists:
               type: boolean
-              description: 'true if the group isn''t displayed in certain parts of the Outlook user interface: in the Address Book, in address lists for selecting message recipients, and in the Browse Groups dialog for searching groups; false otherwise. The default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'true if the group isn''t displayed in certain parts of the Outlook user interface: in the Address Book, in address lists for selecting message recipients, and in the Browse Groups dialog for searching groups; false otherwise. The default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             hideFromOutlookClients:
               type: boolean
-              description: 'true if the group isn''t displayed in Outlook clients, such as Outlook for Windows and Outlook on the web, false otherwise. The default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'true if the group isn''t displayed in Outlook clients, such as Outlook for Windows and Outlook on the web, false otherwise. The default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             infoCatalogs:
               type: array
@@ -34167,7 +36802,7 @@ components:
               nullable: true
             isSubscribedByMail:
               type: boolean
-              description: 'Indicates whether the signed-in user is subscribed to receive email conversations. The default value is true. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates whether the signed-in user is subscribed to receive email conversations. The default value is true. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             licenseProcessingState:
               $ref: '#/components/schemas/microsoft.graph.licenseProcessingState'
@@ -34197,6 +36832,8 @@ components:
               type: string
               description: 'Contains the on-premises domain FQDN, also called dnsDomainName synchronized from the on-premises directory. The property is only populated for customers synchronizing their on-premises directory to Microsoft Entra ID via Microsoft Entra Connect.Returned by default. Read-only.'
               nullable: true
+            onPremisesExtensionAttributes:
+              $ref: '#/components/schemas/microsoft.graph.onPremisesExtensionAttributes'
             onPremisesLastSyncDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
@@ -34255,7 +36892,7 @@ components:
               type: array
               items:
                 type: string
-              description: 'Specifies the group resources that are associated with the Microsoft 365 group. The possible value is Team. For more information, see Microsoft 365 group behaviors and provisioning options. Returned by default. Supports $filter (eq, not, startsWith.'
+              description: 'Specifies the group resources that are associated with the Microsoft 365 group. The possible value is Team. For more information, see Microsoft 365 group behaviors and provisioning options. Returned by default. Supports $filter (eq, not, startsWith).'
             securityEnabled:
               type: boolean
               description: 'Specifies whether the group is a security group. Required.Returned by default. Supports $filter (eq, ne, not, in).'
@@ -34281,26 +36918,30 @@ components:
               maximum: 2147483647
               minimum: -2147483648
               type: number
-              description: Count of conversations delivered one or more new posts since the signed-in user's last visit to the group. This property is the same as unseenCount. Returned only on $select.
+              description: Count of conversations delivered one or more new posts since the signed-in user's last visit to the group. This property is the same as unseenCount. Requires $select to retrieve.
               format: int32
               nullable: true
             unseenCount:
               maximum: 2147483647
               minimum: -2147483648
               type: number
-              description: 'Count of conversations that have received new posts since the signed-in user last visited the group. This property is the same as unseenConversationsCount.Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Count of conversations that have received new posts since the signed-in user last visited the group. This property is the same as unseenConversationsCount.Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               format: int32
               nullable: true
             unseenMessagesCount:
               maximum: 2147483647
               minimum: -2147483648
               type: number
-              description: Count of new posts that have been delivered to the group's conversations since the signed-in user's last visit to the group. Returned only on $select.
+              description: Count of new posts that have been delivered to the group's conversations since the signed-in user's last visit to the group. Requires $select to retrieve.
               format: int32
               nullable: true
             visibility:
               type: string
-              description: 'Specifies the group join policy and group content visibility for groups. Possible values are: Private, Public, or HiddenMembership. HiddenMembership can be set only for Microsoft 365 groups when the groups are created. It can''t be updated later. Other values of visibility can be updated after group creation. If visibility value isn''t specified during group creation on Microsoft Graph, a security group is created as Private by default, and Microsoft 365 group is Public. Groups assignable to roles are always Private. To learn more, see group visibility options. Returned by default. Nullable.'
+              description: 'Specifies the group join policy and group content visibility for groups. The possible values are: Private, Public, or HiddenMembership. HiddenMembership can be set only for Microsoft 365 groups when the groups are created. It can''t be updated later. Other values of visibility can be updated after group creation. If visibility value isn''t specified during group creation on Microsoft Graph, a security group is created as Private by default, and Microsoft 365 group is Public. Groups assignable to roles are always Private. To learn more, see group visibility options. Returned by default. Nullable.'
+              nullable: true
+            welcomeMessageEnabled:
+              type: boolean
+              description: 'Indicates whether a welcome message is sent to new members when they are added to the group. The default value is true. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             writebackConfiguration:
               $ref: '#/components/schemas/microsoft.graph.groupWritebackConfiguration'
@@ -34710,7 +37351,6 @@ components:
         - includeFolderAndPath
         - friendlyName
         - condensePaths
-        - optimizedPartitionSize
       type: string
       x-ms-enum-flags:
         isFlags: true
@@ -34744,6 +37384,11 @@ components:
               $ref: '#/components/schemas/microsoft.graph.security.documentVersion'
             itemsToInclude:
               $ref: '#/components/schemas/microsoft.graph.security.itemsToInclude'
+            reportFileMetadata:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.reportFileMetadata'
+              description: 'Contains the properties for report file metadata, including downloadUrl, fileName, and size.'
             reviewSet:
               $ref: '#/components/schemas/microsoft.graph.security.ediscoveryReviewSet'
             search:
@@ -34773,6 +37418,11 @@ components:
               description: The number of mailboxes that had search hits.
               format: int32
               nullable: true
+            reportFileMetadata:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.reportFileMetadata'
+              description: 'Contains the properties for report file metadata, including downloadUrl, fileName, and size.'
             siteCount:
               maximum: 2147483647
               minimum: -2147483648
@@ -34831,7 +37481,6 @@ components:
         - condensePaths
         - friendlyName
         - splitSource
-        - optimizedPartitionSize
         - includeReport
       type: string
       x-ms-enum-flags:
@@ -34866,10 +37515,14 @@ components:
         - title: ediscoveryCaseSettings
           type: object
           properties:
+            caseType:
+              $ref: '#/components/schemas/microsoft.graph.security.caseType'
             ocr:
               $ref: '#/components/schemas/microsoft.graph.security.ocrSettings'
             redundancyDetection:
               $ref: '#/components/schemas/microsoft.graph.security.redundancyDetectionSettings'
+            reviewSetSettings:
+              $ref: '#/components/schemas/microsoft.graph.security.reviewSetSettings'
             topicModeling:
               $ref: '#/components/schemas/microsoft.graph.security.topicModelingSettings'
           additionalProperties:
@@ -35132,6 +37785,7 @@ components:
         - softDelete
         - moveToDeletedItems
         - unknownFutureValue
+        - moveToQuarantine
       type: string
     microsoft.graph.security.dataDiscoveryRoot:
       allOf:
@@ -35210,12 +37864,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.entityType'
-              description: 'The supported entity type. Possible values are: userName, ipAddress, machineName, other, unknown, unknownFutureValue.'
+              description: 'The supported entity type. The possible values are: userName, ipAddress, machineName, other, unknown, unknownFutureValue.'
             supportedTrafficTypes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.trafficType'
-              description: 'The supported traffic type. Possible values are: downloadedBytes, uploadedBytes, unknown, unknownFutureValue.'
+              description: 'The supported traffic type. The possible values are: downloadedBytes, uploadedBytes, unknown, unknownFutureValue.'
           additionalProperties:
             type: object
     microsoft.graph.security.discoveredCloudAppDetail:
@@ -35369,6 +38023,7 @@ components:
         - uploadFile
         - downloadText
         - downloadFile
+        - copyToClipboard
         - unknownFutureValue
       type: string
       x-ms-enum-flags:
@@ -35453,6 +38108,9 @@ components:
               nullable: true
             displayName:
               type: string
+              nullable: true
+            hasProtection:
+              type: boolean
               nullable: true
             isDefault:
               type: boolean
@@ -35810,6 +38468,19 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.identityAccounts'
+              description: Represents an identity's details in the context of Microsoft Defender for Identity.
+              x-ms-navigationProperty: true
+            sensorCandidateActivationConfiguration:
+              $ref: '#/components/schemas/microsoft.graph.security.sensorCandidateActivationConfiguration'
+            sensorCandidates:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.sensorCandidate'
+              x-ms-navigationProperty: true
+            sensorMigration:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.sensorMigration'
               x-ms-navigationProperty: true
             sensors:
               type: array
@@ -35817,6 +38488,8 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.security.sensor'
               description: Represents a customer's Microsoft Defender for Identity sensors.
               x-ms-navigationProperty: true
+            settings:
+              $ref: '#/components/schemas/microsoft.graph.security.settingsContainer'
           additionalProperties:
             type: object
     microsoft.graph.security.healthIssue:
@@ -35891,19 +38564,25 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.security.account'
+              description: Collection of accounts of the identity in different identity providers.
             cloudSecurityIdentifier:
               type: string
+              description: The cloud security identifier of the identityAccount.
               nullable: true
             displayName:
               type: string
+              description: The  Active Directory display name of the identityAccount.
               nullable: true
             domain:
               type: string
+              description: The Active Directory domain name of the identityAccount.
               nullable: true
             isEnabled:
               type: boolean
+              description: Boolean indicating if the identityAccounts is enabled.
             onPremisesSecurityIdentifier:
               type: string
+              description: The on-premises security identifier of the identityAccount.
               nullable: true
           additionalProperties:
             type: object
@@ -35932,13 +38611,94 @@ components:
       properties:
         accountId:
           type: string
+          description: The account ID.
         action:
           $ref: '#/components/schemas/microsoft.graph.security.action'
         correlationId:
           type: string
+          description: The unique identifier for tracking the request.
           nullable: true
         identityProvider:
           $ref: '#/components/schemas/microsoft.graph.security.identityProvider'
+      additionalProperties:
+        type: object
+    microsoft.graph.security.sensorCandidateActivationConfiguration:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: sensorCandidateActivationConfiguration
+          type: object
+          properties:
+            activationMode:
+              $ref: '#/components/schemas/microsoft.graph.security.sensorCandidateActivationMode'
+          additionalProperties:
+            type: object
+    microsoft.graph.security.sensorCandidate:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: sensorCandidate
+          type: object
+          properties:
+            computerDnsName:
+              type: string
+              description: The DNS name of the computer associated with the sensor.
+            domainName:
+              type: string
+              description: The domain name of the sensor.
+            lastSeenDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: The date and time when the sensor was last seen.
+              format: date-time
+            senseClientVersion:
+              type: string
+              description: The version of the Defender for Identity sensor client.  Supports $filter (eq).
+            sensorTypes:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.deviceType'
+              description: 'The list of device types for the sensor. The possible values are: domainController, adfs, adcs, entraConnect unknownFutureValue. This flagged enumeration allows multiple members to be returned simultaneously.'
+          additionalProperties:
+            type: object
+    microsoft.graph.security.sensorMigration:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: sensorMigration
+          type: object
+          properties:
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              format: date-time
+            displayName:
+              type: string
+            domainName:
+              type: string
+            healthStatus:
+              $ref: '#/components/schemas/microsoft.graph.security.sensorHealthStatus'
+            migrationState:
+              $ref: '#/components/schemas/microsoft.graph.security.migrationState'
+            sensorType:
+              $ref: '#/components/schemas/microsoft.graph.security.sensorType'
+            serviceStatus:
+              $ref: '#/components/schemas/microsoft.graph.security.serviceStatus'
+            version:
+              type: string
+          additionalProperties:
+            type: object
+    microsoft.graph.security.migrateSensorsResult:
+      title: migrateSensorsResult
+      type: object
+      properties:
+        failedMigrationSensorIds:
+          type: array
+          items:
+            type: string
+            nullable: true
+        successfulMigrationSensorIds:
+          type: array
+          items:
+            type: string
+            nullable: true
       additionalProperties:
         type: object
     microsoft.graph.security.sensor:
@@ -35962,12 +38722,16 @@ components:
               description: The fully qualified domain name of the sensor.
             healthStatus:
               $ref: '#/components/schemas/microsoft.graph.security.sensorHealthStatus'
+            migrationState:
+              $ref: '#/components/schemas/microsoft.graph.security.migrationState'
             openHealthIssuesCount:
               type: number
               description: This field displays the count of health issues related to this sensor.
               format: int64
             sensorType:
               $ref: '#/components/schemas/microsoft.graph.security.sensorType'
+            serviceStatus:
+              $ref: '#/components/schemas/microsoft.graph.security.serviceStatus'
             settings:
               $ref: '#/components/schemas/microsoft.graph.security.sensorSettings'
             version:
@@ -36002,6 +38766,27 @@ components:
           description: Version of the sensor.
       additionalProperties:
         type: object
+    microsoft.graph.security.settingsContainer:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: settingsContainer
+          type: object
+          properties:
+            autoAuditingConfiguration:
+              $ref: '#/components/schemas/microsoft.graph.security.autoAuditingConfiguration'
+          additionalProperties:
+            type: object
+    microsoft.graph.security.autoAuditingConfiguration:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: autoAuditingConfiguration
+          type: object
+          properties:
+            isAutomatic:
+              type: boolean
+              description: Indicates whether automatic auditing is enabled for Defender for Identity monitoring.
+          additionalProperties:
+            type: object
     microsoft.graph.security.incident:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -36053,6 +38838,13 @@ components:
               type: string
               description: Time when the incident was last updated.
               format: date-time
+            priorityScore:
+              maximum: 2147483647
+              minimum: -2147483648
+              type: number
+              description: 'A priority score for the incident from 0 to 100, with > 85 being the top priority, 15 - 85 medium priority, and < 15 low priority. This score is generated using machine learning and is based on multiple factors, including severity, disruption impact, threat intelligence, alert types, asset criticality, threat analytics, incident rarity, and additional priority signals. The value can also be null which indicates the feature is not open for the tenant or the value of the score is pending calculation.'
+              format: int32
+              nullable: true
             recommendedActions:
               type: string
               description: A rich text string that represents the actions that are reccomnded to take in order to resolve the incident.
@@ -36197,7 +38989,7 @@ components:
               nullable: true
             hasProtection:
               type: boolean
-              description: Indicates whether the label has protection actions configured.
+              description: Indicates whether the label has protection actions (such as encryption or do not forward) configured.
             isActive:
               type: boolean
               description: Indicates whether the label is active or not. Active labels should be hidden or disabled in the UI.
@@ -36228,7 +39020,7 @@ components:
       properties:
         contentFormat:
           type: string
-          description: 'The format of the content to be labeled. Possible values are: file, email.'
+          description: 'The format of the content to be labeled. The possible values are: file, email.'
           nullable: true
         identifier:
           type: string
@@ -36624,6 +39416,18 @@ components:
               nullable: true
           additionalProperties:
             type: object
+    microsoft.graph.security.huntingSchemaResult:
+      title: huntingSchemaResult
+      type: object
+      properties:
+        functions:
+          $ref: '#/components/schemas/microsoft.graph.security.huntingSchemaFunctions'
+        tables:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.huntingSchemaTable'
+      additionalProperties:
+        type: object
     microsoft.graph.security.huntingQueryResults:
       title: huntingQueryResults
       type: object
@@ -37128,6 +39932,187 @@ components:
               $ref: '#/components/schemas/microsoft.graph.securityVendorInformation'
           additionalProperties:
             type: object
+    microsoft.graph.securityCopilot:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: securityCopilot
+          type: object
+          properties:
+            workspaces:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.workspace'
+              description: References a workspace in Security Copilot.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.security.securityCopilot.workspace:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: workspace
+          type: object
+          properties:
+            displayName:
+              type: string
+              description: Name of the Security Copilot workspace.
+              nullable: true
+            plugins:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.plugin'
+              description: Represents plugins in Security Copilot.
+              x-ms-navigationProperty: true
+            sessions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.session'
+              description: Represents sessions in Security Copilot.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.security.securityCopilot.plugin:
+      title: plugin
+      type: object
+      properties:
+        authorization:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.pluginAuth'
+        catalogScope:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.pluginCatalogScope'
+        category:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.pluginCategory'
+        description:
+          type: string
+          description: Brief description of the plugin.
+          nullable: true
+        displayName:
+          type: string
+          description: Display name of the plugin.   Supports $filter (eq).
+          nullable: true
+        isEnabled:
+          type: boolean
+          description: Displays whether the plugin is enabled for use within the catalogScope.   Supports $filter (eq).
+        name:
+          type: string
+          description: 'Represents the name of the plugin. Primary key.   Supports $filter (eq, contains).'
+        previewState:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.pluginPreviewStates'
+        settings:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.pluginSetting'
+          description: Settings for the plugin.
+        supportedAuthTypes:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.pluginAuthTypes'
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.session:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: session
+          type: object
+          properties:
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Created time of the session (UTC).
+              format: date-time
+            displayName:
+              type: string
+              description: Display name for the session.
+              nullable: true
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Last modified time of the session (UTC). Updated when displayName changes.
+              format: date-time
+            prompts:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.prompt'
+              description: The collection of prompts in the session.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.security.securityCopilot.prompt:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: prompt
+          type: object
+          properties:
+            content:
+              type: string
+              description: Input content to the prompt.
+              nullable: true
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Created time.
+              format: date-time
+            inputs:
+              $ref: '#/components/schemas/microsoft.graph.Dictionary'
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Last modified time.
+              format: date-time
+            skillInputDescriptors:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.skillInputDescriptor'
+              description: Skill Input descriptor.
+            skillName:
+              type: string
+              description: Skill name.
+              nullable: true
+            type:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.promptType'
+            evaluations:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluation'
+              description: Collection of evaluations
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.security.securityCopilot.evaluation:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: evaluation
+          type: object
+          properties:
+            completedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Evaluation completion time.
+              format: date-time
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Evaluation created time.
+              format: date-time
+            executionCount:
+              type: number
+              description: Evaluation execution count.
+              format: int64
+            isCancelled:
+              type: boolean
+              description: Evaluation cancellation status.
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Evaluation modified time.
+              format: date-time
+            result:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluationResult'
+            runStartDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Evaluation Run start time.
+              format: date-time
+            state:
+              $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluationState'
+          additionalProperties:
+            type: object
     microsoft.graph.subjectRightsRequest:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -37250,11 +40235,11 @@ components:
           properties:
             aboutMe:
               type: string
-              description: A freeform text entry field for users to describe themselves. Returned only on $select.
+              description: A freeform text entry field for users to describe themselves. Requires $select to retrieve.
               nullable: true
             accountEnabled:
               type: boolean
-              description: 'true if the account is enabled; otherwise, false. This property is required when a user is created. Supports $filter (eq, ne, not, and in).'
+              description: 'true if the account is enabled; otherwise, false. This property is required when creating the object. Supports $filter (eq, ne, not, and in).'
               nullable: true
             ageGroup:
               type: string
@@ -37275,7 +40260,7 @@ components:
             birthday:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'The birthday of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z Returned only on $select.'
+              description: 'The birthday of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z Requires $select to retrieve.'
               format: date-time
             businessPhones:
               type: array
@@ -37373,13 +40358,19 @@ components:
             hireDate:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'The hire date of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.  Returned only on $select.  Note: This property is specific to SharePoint Online. We recommend using the native employeeHireDate property to set and update hire date values using Microsoft Graph APIs.'
+              description: 'The hire date of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.  Requires $select to retrieve.  Note: This property is specific to SharePoint Online. We recommend using the native employeeHireDate property to set and update hire date values using Microsoft Graph APIs.'
               format: date-time
             identities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.objectIdentity'
               description: 'Represents the identities that can be used to sign in to this user account. An identity can be provided by Microsoft (also known as a local account), by organizations, or by social identity providers such as Facebook, Google, and Microsoft and tied to a user account. It may contain multiple items with the same signInType value.  Supports $filter (eq) with limitations.'
+            identityGovernance:
+              $ref: '#/components/schemas/microsoft.graph.identityGovernanceUserSettings'
+            identityParentId:
+              type: string
+              description: 'The object ID of the parent identity for agent users. Always null for regular user accounts. For agentUser resources, this property references the object ID of the associated agent identity.'
+              nullable: true
             imAddresses:
               type: array
               items:
@@ -37396,7 +40387,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for users to describe their interests. Returned only on $select.
+              description: A list for users to describe their interests. Requires $select to retrieve.
             isLicenseReconciliationNeeded:
               type: boolean
               description: Indicates whether the user is pending an exchange mailbox license assignment.  Read-only.  Supports $filter (eq where true only).
@@ -37407,7 +40398,7 @@ components:
               nullable: true
             isResourceAccount:
               type: boolean
-              description: Do not use – reserved for future use.
+              description: Do not use. Reserved for future use.
               nullable: true
             jobTitle:
               type: string
@@ -37416,18 +40407,18 @@ components:
             lastPasswordChangeDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'When this Microsoft Entra user last changed their password or when their password was created, whichever date the latest action was performed. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only. Returned only on $select.'
+              description: 'When this Microsoft Entra user last changed their password or when their password was created, whichever date the latest action was performed. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only. Requires $select to retrieve.'
               format: date-time
               nullable: true
             legalAgeGroupClassification:
               type: string
-              description: 'Used by enterprise applications to determine the legal age group of the user. This property is read-only and calculated based on ageGroup and consentProvidedForMinor properties. Allowed values: null, Undefined, MinorWithOutParentalConsent, MinorWithParentalConsent, MinorNoParentalConsentRequired, NotAdult, and Adult. For more information, see legal age group property definitions. Returned only on $select.'
+              description: 'Used by enterprise applications to determine the legal age group of the user. This property is read-only and calculated based on ageGroup and consentProvidedForMinor properties. Allowed values: null, Undefined, MinorWithOutParentalConsent, MinorWithParentalConsent, MinorNoParentalConsentRequired, NotAdult, and Adult. For more information, see legal age group property definitions. Requires $select to retrieve.'
               nullable: true
             licenseAssignmentStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseAssignmentState'
-              description: State of license assignments for this user. It also indicates licenses that are directly assigned and the ones the user inherited through group memberships. Read-only. Returned only on $select.
+              description: State of license assignments for this user. It also indicates licenses that are directly assigned and the ones the user inherited through group memberships. Read-only. Requires $select to retrieve.
             mail:
               type: string
               description: 'The SMTP address for the user, for example, admin@contoso.com. Changes to this property also update the user''s proxyAddresses collection to include the value as an SMTP address. This property can''t contain accent characters.  NOTE: We don''t recommend updating this property for Azure AD B2C user profiles. Use the otherMails property instead.  Supports $filter (eq, ne, not, ge, le, in, startsWith, endsWith, and eq on null values).'
@@ -37444,7 +40435,7 @@ components:
               nullable: true
             mySite:
               type: string
-              description: The URL for the user's site. Returned only on $select.
+              description: The URL for the user's site. Requires $select to retrieve.
               nullable: true
             officeLocation:
               type: string
@@ -37509,7 +40500,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for users to enumerate their past projects. Returned only on $select.
+              description: A list for users to enumerate their past projects. Requires $select to retrieve.
             postalCode:
               type: string
               description: 'The postal code for the user''s postal address. The postal code is specific to the user''s country/region. In the United States of America, this attribute contains the ZIP code. Maximum length is 40 characters. Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values).'
@@ -37524,7 +40515,7 @@ components:
               nullable: true
             preferredName:
               type: string
-              description: The preferred name for the user. Not Supported. This attribute returns an empty string.Returned only on $select.
+              description: The preferred name for the user. Not Supported. This attribute returns an empty string.Requires $select to retrieve.
               nullable: true
             print:
               $ref: '#/components/schemas/microsoft.graph.userPrint'
@@ -37549,13 +40540,13 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for the user to enumerate their responsibilities. Returned only on $select.
+              description: A list for the user to enumerate their responsibilities. Requires $select to retrieve.
             schools:
               type: array
               items:
                 type: string
                 nullable: true
-              description: A list for the user to enumerate the schools they have attended. Returned only on $select.
+              description: A list for the user to enumerate the schools they have attended. Requires $select to retrieve.
             securityIdentifier:
               type: string
               description: 'Security identifier (SID) of the user, used in Windows scenarios. Read-only. Returned by default. Supports $select and $filter (eq, not, ge, le, startsWith).'
@@ -37582,7 +40573,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for the user to enumerate their skills. Returned only on $select.
+              description: A list for the user to enumerate their skills. Requires $select to retrieve.
             state:
               type: string
               description: 'The state or province in the user''s address. Maximum length is 128 characters. Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values).'
@@ -37612,6 +40603,12 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userActivity'
               description: The user's activities across devices. Read-only. Nullable.
+              x-ms-navigationProperty: true
+            adhocCalls:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.adhocCall'
+              description: Ad hoc calls associated with the user. Read-only. Nullable.
               x-ms-navigationProperty: true
             agreementAcceptances:
               type: array
@@ -37671,10 +40668,17 @@ components:
               x-ms-navigationProperty: true
             cloudClipboard:
               $ref: '#/components/schemas/microsoft.graph.cloudClipboardRoot'
+            cloudPcPools:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudPcPool'
+              description: The user's Cloud PC pools. Read-only. Nullable.
+              x-ms-navigationProperty: true
             cloudPCs:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudPC'
+              description: The user's Cloud PCs. Read-only. Nullable.
               x-ms-navigationProperty: true
             communications:
               $ref: '#/components/schemas/microsoft.graph.userCloudCommunication'
@@ -37840,6 +40844,8 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeeting'
               description: 'Information about a meeting, including the URL used to join a meeting, the attendees list, and the description.'
               x-ms-navigationProperty: true
+            onPremisesSyncBehavior:
+              $ref: '#/components/schemas/microsoft.graph.onPremisesSyncBehavior'
             outlook:
               $ref: '#/components/schemas/microsoft.graph.outlookUser'
             ownedDevices:
@@ -39232,7 +42238,7 @@ components:
               description: 'A string value representing a single security product to which the indicator should be applied. Acceptable values are: Azure Sentinel, Microsoft Defender ATP. Required'
             threatType:
               type: string
-              description: 'Each indicator must have a valid Indicator Threat Type. Possible values are: Botnet, C2, CryptoMining, Darknet, DDoS, MaliciousUrl, Malware, Phishing, Proxy, PUA, WatchList. Required.'
+              description: 'Each indicator must have a valid Indicator Threat Type. The possible values are: Botnet, C2, CryptoMining, Darknet, DDoS, MaliciousUrl, Malware, Phishing, Proxy, PUA, WatchList. Required.'
               nullable: true
             tlpLevel:
               $ref: '#/components/schemas/microsoft.graph.tlpLevel'
@@ -39391,6 +42397,62 @@ components:
               nullable: true
             vendorInformation:
               $ref: '#/components/schemas/microsoft.graph.securityVendorInformation'
+          additionalProperties:
+            type: object
+    microsoft.graph.security.zone:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: zone
+          type: object
+          properties:
+            created:
+              $ref: '#/components/schemas/microsoft.graph.security.auditInfo'
+            description:
+              type: string
+              description: 'Optional description of the zone. Up to 255 characters. Supports $filter (eq, contains). For example, $filter=contains(description, ''production'').'
+              nullable: true
+            displayName:
+              type: string
+              description: 'Human-readable name of the zone. Up to 1,024 characters. Supports $filter (eq, contains), and $orderby. For example, $filter=displayName eq ''Production Zone'' or $orderby=displayName asc.'
+            modified:
+              $ref: '#/components/schemas/microsoft.graph.security.auditInfo'
+            aggregations:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.aggregatedEnvironment'
+              description: 'Environment count summaries by type. Read-only. Supports $filter (eq) on the kind property. For example, $filter=aggregations/any(a: a/kind eq ''azureSubscription'').'
+              x-ms-navigationProperty: true
+            environments:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.security.environment'
+              description: Collection of attached environments. Supports $expand.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.security.aggregatedEnvironment:
+      title: aggregatedEnvironment
+      type: object
+      properties:
+        count:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: Number of environments of this type.
+          format: int32
+        kind:
+          type: string
+          description: Environment type.
+      additionalProperties:
+        type: object
+    microsoft.graph.security.environment:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: environment
+          type: object
+          properties:
+            kind:
+              $ref: '#/components/schemas/microsoft.graph.security.environmentKind'
           additionalProperties:
             type: object
     microsoft.graph.security.security:
@@ -40033,6 +43095,8 @@ components:
         - builtInMl
         - microsoftInsiderRiskManagement
         - microsoftThreatIntelligence
+        - microsoftDefenderForAIServices
+        - securityCopilot
         - microsoftSentinel
       type: string
     microsoft.graph.security.alertDetermination:
@@ -40091,6 +43155,29 @@ components:
           $ref: '#/components/schemas/microsoft.graph.security.evidenceVerdict'
       additionalProperties:
         type: object
+    microsoft.graph.security.investigationState:
+      title: investigationState
+      enum:
+        - unknown
+        - terminated
+        - successfullyRemediated
+        - benign
+        - failed
+        - partiallyRemediated
+        - running
+        - pendingApproval
+        - pendingResource
+        - queued
+        - innerFailure
+        - preexistingAlert
+        - unsupportedOs
+        - unsupportedAlertType
+        - suppressedAlert
+        - partiallyInvestigated
+        - terminatedByUser
+        - terminatedBySystem
+        - unknownFutureValue
+      type: string
     microsoft.graph.security.serviceSource:
       title: serviceSource
       enum:
@@ -40788,8 +43875,167 @@ components:
         - CPSOperation
         - ComplianceDLPExchangeDiscovery
         - PurviewMCRecommendation
+        - ComplianceDLPEndpointDiscovery
+        - InsiderRiskScopedUserInsights
+        - MicrosoftTeamsRetentionLabelAction
+        - AadRiskDetection
+        - AuditSearch
+        - AuditRetentionPolicy
+        - AuditConfig
+        - Microsoft365BackupBackupPolicy
+        - Microsoft365BackupRestoreTask
+        - Microsoft365BackupRestoreItem
+        - Microsoft365BackupBackupItem
+        - URBACAssignment
+        - URBACRole
+        - URBACEnableState
+        - IRMSecurityAlert
+        - PurviewInsiderRiskCases
+        - PurviewInsiderRiskAlerts
+        - InsiderRiskScopedUsers
+        - CdpConsumptionResource
+        - CreateCopilotPlugin
+        - UpdateCopilotPlugin
+        - DeleteCopilotPlugin
+        - EnableCopilotPlugin
+        - DisableCopilotPlugin
+        - CreateCopilotWorkspace
+        - UpdateCopilotWorkspace
+        - DeleteCopilotWorkspace
+        - EnableCopilotWorkspace
+        - DisableCopilotWorkspace
+        - CreateCopilotPromptBook
+        - UpdateCopilotPromptBook
+        - DeleteCopilotPromptBook
+        - EnableCopilotPromptBook
+        - DisableCopilotPromptBook
+        - UpdateCopilotSettings
+        - P4AIAssessmentRecord
+        - P4AIAssessmentLocationResultRecord
+        - ConnectedAIAppInteraction
+        - PrivaPrivacyConsentOperation
+        - PrivaPrivacyAssessmentOperation
+        - DataCatalogAccessRequests
+        - ComplianceSettingsChange
+        - DataSecurityInvestigation
+        - TeamCopilotInteraction
+        - IRMActivityAuditTrail
+        - SharePointContentSecurityPolicy
+        - CloudUpdateProfileConfig
+        - CloudUpdateTenantConfig
+        - CloudUpdateDeviceConfig
+        - DefenderPreviewFeatures
+        - DeviceDiscoverySettingsExclusion
+        - DeviceDiscoverySettingsAuthenticatedScans
+        - CriticalAssetManagementClassification
+        - DeviceDiscoverySettings
+        - USXWorkspaceOnboarding
+        - VivaGlintAdvancedConfiguration
+        - VivaGlintPulseProgram
+        - VivaGlintPulseProgramRespondentRate
+        - VivaGlintQuestion
+        - VivaGlintRole
+        - VivaGlintRubicon
+        - VivaGlintSupportAccess
+        - VivaGlintSystem
+        - VivaGlintUser
+        - VivaGlintUserGroup
+        - VivaGlintFeedbackProgram
+        - FabricAudit
+        - TrainableClassifier
+        - WebContentFiltering
+        - NoisyAlertPolicy
+        - OnDemandSharePointClassification
+        - AIInteractionsExport
+        - Microsoft365CopilotScheduledPrompt
+        - PlacesDirectory
+        - MDAAudit
+        - OpticalCharacterRecognition
+        - M365SearchSections
+        - OfficeClientRestrictedModeAction
+        - CrossTenantAccessPolicy
+        - OutlookCopilotAutomation
+        - VivaEngageNetworkAssociation
+        - AppAdminActivity
+        - AppSettingsAdminActivity
+        - UniversalPrintPrintJob
+        - SentinelNotebookOnLake
+        - SentinelJob
+        - SentinelGraph
+        - SentinelKQLOnLake
+        - SentinelPackage
+        - VivaAmplifyOutlookSensitivityLabel
+        - CopilotActions
+        - AIInteractionsSubscription
+        - AIInteractionsChangeNotification
+        - FilteringMailMetadataExtended
+        - SentinelLakeOnboarding
+        - SentinelLakeDataOnboarding
+        - OfficeRestrictedModeAction
+        - CopilotForSecurityTrigger
+        - CopilotAgentManagement
+        - P4AIAssessmentFabricScannerRecord
+        - PlannerGoal
+        - PlannerGoalList
+        - ThreatIntelligenceObject
+        - ThreatIntelligenceExport
+        - SubmissionAgenticGradingResult
+        - AgentAdminActivity
+        - DeployFeatureActivity
+        - AgentSettingsAdminActivity
+        - OrganizationalDataInM365
+        - PlannerChatMessage
+        - PlannerChatMessageList
+        - SentinelAITool
+        - M365ODSPAssetMetadata
+        - AIExecuteTool
+        - AIInvokeAgent
+        - AIInferenceCall
+        - CdpClassifierHealthRecord
+        - SensitiveInfoRemediationAgentData
+        - ComplianceDLPEnforcement
+        - A365AIExecuteTool
+        - A365AIInvokeAgent
+        - A365AIInferenceCall
+        - VivaEngageSegment
+        - RTIOperationsAgent
+        - ContentStoreMetadata
+        - CCRAIPolicyViolation
+        - PlannerPlanSensitivityLabel
+        - MosAgentInfoRecord
+        - A365AIRunSummary
+        - UnifiedCatalogConceptAction
+        - DefenderCaseManagement
+        - CopilotForSecurityLogging
+        - VivaEngageEvents
+        - CallActivityEvent
+        - SonarDetonationContentMetadata
+        - UniversalPrintManagement
+        - YammerUserHiding
+        - Microsoft365BackupGranularBrowseTask
+        - PurviewPostureAgent
+        - MSDECustomCollection
+        - SCPUsageEvent
+        - SCPConfigurationEvent
+        - MDCConfigurationEvent
+        - MDCUsageEvent
+        - A365SpanOutputs
+        - PowerPlatformTenantIsolation
+        - CDPDLMAIInteractionInsights
+        - P4AIAssessmentCategoryRecord
+        - SentinelLakeEncryption
+        - AZFWNetworkRule
+        - AZFWDnsQuery
+        - AZFWApplicationRuleAggregation
+        - TeamsEvalDataHubDataAccess
+        - TeamsEvalDataHubPermissionChange
+        - TeamsEvalDataHubAdminOperation
+        - VivaGlintOrganizationalData
+        - ReportSubmission
+        - ReportSubmissionResultDetail
         - unknownFutureValue
       type: string
+      description: Specifies the type of audit log record.
     microsoft.graph.security.auditLogQueryStatus:
       title: auditLogQueryStatus
       enum:
@@ -40800,11 +44046,13 @@ components:
         - cancelled
         - unknownFutureValue
       type: string
+      description: Status of an audit log query.
     microsoft.graph.security.auditData:
       title: auditData
       type: object
       additionalProperties:
         type: object
+      description: Abstract base type for audit event data.
     microsoft.graph.security.auditLogUserType:
       title: auditLogUserType
       enum:
@@ -40821,6 +44069,7 @@ components:
         - Guest
         - unknownFutureValue
       type: string
+      description: Type of user associated with an audit log record.
     microsoft.graph.security.case:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -40958,6 +44207,33 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.siteLockState:
+      title: siteLockState
+      enum:
+        - unlocked
+        - lockedReadOnly
+        - lockedNoAccess
+        - lockedNoAdditions
+        - unknownFutureValue
+      type: string
+    microsoft.graph.identityInput:
+      title: identityInput
+      type: object
+      properties:
+        alias:
+          type: string
+          description: The alias of the identity.
+          nullable: true
+        email:
+          type: string
+          description: The email of the identity.
+          nullable: true
+        objectId:
+          type: string
+          description: The unique object ID assigned to the identity in Microsoft Entra ID.
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.root:
       title: root
       type: object
@@ -41029,6 +44305,13 @@ components:
           $ref: '#/components/schemas/microsoft.graph.root'
       additionalProperties:
         type: object
+    microsoft.graph.siteTemplateType:
+      title: siteTemplateType
+      enum:
+        - sitepagepublishing
+        - sts
+        - unknownFutureValue
+      type: string
     microsoft.graph.itemAnalytics:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -41379,6 +44662,13 @@ components:
               type: string
               description: The displayable title of the list.
               nullable: true
+            itemCount:
+              maximum: 2147483647
+              minimum: -2147483648
+              type: number
+              description: The total count of items in the list. Read-only.
+              format: int32
+              nullable: true
             list:
               $ref: '#/components/schemas/microsoft.graph.listInfo'
             sharepointIds:
@@ -41695,6 +44985,11 @@ components:
       title: groupCloudLicensing
       type: object
       properties:
+        assignments:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.cloudLicensing.assignment'
+          x-ms-navigationProperty: true
         usageRights:
           type: array
           items:
@@ -41727,6 +45022,72 @@ components:
           nullable: true
         status:
           $ref: '#/components/schemas/microsoft.graph.MembershipRuleProcessingStatusDetails'
+      additionalProperties:
+        type: object
+    microsoft.graph.onPremisesExtensionAttributes:
+      title: onPremisesExtensionAttributes
+      type: object
+      properties:
+        extensionAttribute1:
+          type: string
+          description: First customizable extension attribute.
+          nullable: true
+        extensionAttribute10:
+          type: string
+          description: Tenth customizable extension attribute.
+          nullable: true
+        extensionAttribute11:
+          type: string
+          description: Eleventh customizable extension attribute.
+          nullable: true
+        extensionAttribute12:
+          type: string
+          description: Twelfth customizable extension attribute.
+          nullable: true
+        extensionAttribute13:
+          type: string
+          description: Thirteenth customizable extension attribute.
+          nullable: true
+        extensionAttribute14:
+          type: string
+          description: Fourteenth customizable extension attribute.
+          nullable: true
+        extensionAttribute15:
+          type: string
+          description: Fifteenth customizable extension attribute.
+          nullable: true
+        extensionAttribute2:
+          type: string
+          description: Second customizable extension attribute.
+          nullable: true
+        extensionAttribute3:
+          type: string
+          description: Third customizable extension attribute.
+          nullable: true
+        extensionAttribute4:
+          type: string
+          description: Fourth customizable extension attribute.
+          nullable: true
+        extensionAttribute5:
+          type: string
+          description: Fifth customizable extension attribute.
+          nullable: true
+        extensionAttribute6:
+          type: string
+          description: Sixth customizable extension attribute.
+          nullable: true
+        extensionAttribute7:
+          type: string
+          description: Seventh customizable extension attribute.
+          nullable: true
+        extensionAttribute8:
+          type: string
+          description: Eighth customizable extension attribute.
+          nullable: true
+        extensionAttribute9:
+          type: string
+          description: Ninth customizable extension attribute.
+          nullable: true
       additionalProperties:
         type: object
     microsoft.graph.onPremisesProvisioningError:
@@ -41838,7 +45199,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeetingProviderType'
-              description: 'Represent the online meeting service providers that can be used to create online meetings in this calendar. Possible values are: unknown, skypeForBusiness, skypeForConsumer, teamsForBusiness.'
+              description: 'Represent the online meeting service providers that can be used to create online meetings in this calendar. The possible values are: unknown, skypeForBusiness, skypeForConsumer, teamsForBusiness.'
             calendarGroupId:
               type: string
               description: 'The calendarGroup in which to create the calendar. If the user has never explicitly set a group for the calendar, this property is  null.'
@@ -42199,7 +45560,7 @@ components:
           properties:
             isCloudManaged:
               type: boolean
-              description: 'Indicates the state of synchronization for an object between the cloud and on-premises Active Directory. If true, updates from on-premises Active Directory are blocked in the cloud; if false, updates from on-premises Active Directory are allowed in the cloud and the object can be taken over by on-premises Active Directory.'
+              description: 'Indicates the state of synchronization for an object between the cloud and on-premises Active Directory. If true, updates from on-premises Active Directory are blocked in the cloud; if false, updates from on-premises Active Directory are allowed in the cloud and the on-premises Active Directory can take over the object.'
           additionalProperties:
             type: object
     microsoft.graph.resourceSpecificPermissionGrant:
@@ -42222,7 +45583,7 @@ components:
               nullable: true
             permissionType:
               type: string
-              description: 'The type of permission. Possible values are: Application, Delegated. Read-only.'
+              description: 'The type of permission. The possible values are: Application, Delegated. Read-only.'
               nullable: true
             resourceAppId:
               type: string
@@ -42386,6 +45747,7 @@ components:
         - purgeData
         - exportReport
         - exportResult
+        - holdPolicySync
       type: string
     microsoft.graph.security.caseOperationStatus:
       title: caseOperationStatus
@@ -42541,6 +45903,25 @@ components:
       type: string
       x-ms-enum-flags:
         isFlags: true
+    microsoft.graph.security.reportFileMetadata:
+      title: reportFileMetadata
+      type: object
+      properties:
+        downloadUrl:
+          type: string
+          description: The URL to download the report.
+          nullable: true
+        fileName:
+          type: string
+          description: The name of the file.
+          nullable: true
+        size:
+          type: number
+          description: The size of the file.
+          format: int64
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.security.statisticsOptions:
       title: statisticsOptions
       enum:
@@ -42553,6 +45934,13 @@ components:
       type: string
       x-ms-enum-flags:
         isFlags: true
+    microsoft.graph.security.caseType:
+      title: caseType
+      enum:
+        - standard
+        - premium
+        - unknownFutureValue
+      type: string
     microsoft.graph.security.ocrSettings:
       title: ocrSettings
       type: object
@@ -42607,6 +45995,15 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.security.reviewSetSettings:
+      title: reviewSetSettings
+      enum:
+        - none
+        - disableGrouping
+        - unknownFutureValue
+      type: string
+      x-ms-enum-flags:
+        isFlags: true
     microsoft.graph.security.topicModelingSettings:
       title: topicModelingSettings
       type: object
@@ -43280,7 +46677,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.processContentMetadataBase'
-          description: A collection of content entries to be processed. Each entry contains the content itself and its metadata. Use conversation metadata for content like prompts and responses and file metadata for files. Required.
+          description: 'A collection of content entries to be processed. Each entry contains the content itself and its metadata. Use conversation metadata for content like prompts and responses, file metadata for files, and content activity metadata for enforcement result status entries. Required.'
         deviceMetadata:
           $ref: '#/components/schemas/microsoft.graph.deviceMetadata'
         integratedAppMetadata:
@@ -43421,6 +46818,7 @@ components:
         - encryptedProtectionTypeNotSupportedException
         - purviewClaimsChallengeNotSupportedException
         - exception
+        - labelNotFoundException
         - unknownFutureValue
       type: string
       x-ms-enum-flags:
@@ -43589,7 +46987,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.logonType'
-          description: 'Collection of the logon types observed for the logged on user from when first to last seen. Possible values are: unknown, interactive, remoteInteractive, network, batch, service.'
+          description: 'Collection of the logon types observed for the logged on user from when first to last seen. The possible values are: unknown, interactive, remoteInteractive, network, batch, service.'
       additionalProperties:
         type: object
     microsoft.graph.networkInterface:
@@ -43649,12 +47047,72 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.security.action'
+          description: 'List of the type of action. The possible values are: disable, enable, forcePasswordReset, revokeAllSessions, requireUserToSignInAgain, markUserAsCompromised.'
         identifier:
           type: string
+          description: The account ID.
         identityProvider:
           $ref: '#/components/schemas/microsoft.graph.security.identityProvider'
       additionalProperties:
         type: object
+    microsoft.graph.security.sensorCandidateActivationMode:
+      title: sensorCandidateActivationMode
+      enum:
+        - manual
+        - automated
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.deviceType:
+      title: deviceType
+      enum:
+        - domainController
+        - adfs
+        - adcs
+        - entraConnect
+        - unknownFutureValue
+      type: string
+      x-ms-enum-flags:
+        isFlags: true
+    microsoft.graph.security.sensorHealthStatus:
+      title: sensorHealthStatus
+      enum:
+        - healthy
+        - notHealthyLow
+        - notHealthyMedium
+        - notHealthyHigh
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.migrationState:
+      title: migrationState
+      enum:
+        - readyForMigration
+        - notReadyForMigration
+        - upToDate
+        - migrationFailed
+        - migrating
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.sensorType:
+      title: sensorType
+      enum:
+        - adConnectIntegrated
+        - adcsIntegrated
+        - adfsIntegrated
+        - domainControllerIntegrated
+        - domainControllerStandalone
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.serviceStatus:
+      title: serviceStatus
+      enum:
+        - stopped
+        - starting
+        - running
+        - disabled
+        - onboarding
+        - unknown
+        - unknownFutureValue
+      type: string
     microsoft.graph.security.deploymentStatus:
       title: deploymentStatus
       enum:
@@ -43667,25 +47125,6 @@ components:
         - disconnected
         - startFailure
         - syncing
-        - unknownFutureValue
-      type: string
-    microsoft.graph.security.sensorHealthStatus:
-      title: sensorHealthStatus
-      enum:
-        - healthy
-        - notHealthyLow
-        - notHealthyMedium
-        - notHealthyHigh
-        - unknownFutureValue
-      type: string
-    microsoft.graph.security.sensorType:
-      title: sensorType
-      enum:
-        - adConnectIntegrated
-        - adcsIntegrated
-        - adfsIntegrated
-        - domainControllerIntegrated
-        - domainControllerStandalone
         - unknownFutureValue
       type: string
     microsoft.graph.security.sensorSettings:
@@ -43765,14 +47204,16 @@ components:
         - unknownFutureValue
       type: string
     microsoft.graph.security.incidentTaskResponseAction:
-      title: incidentTaskResponseAction
-      type: object
-      properties:
-        identifierValue:
-          type: string
-          description: Required. The identifier value for the response action. This value is specific to the type of action being performed.
-      additionalProperties:
-        type: object
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.security.responseAction'
+        - title: incidentTaskResponseAction
+          type: object
+          properties:
+            identifierValue:
+              type: string
+              description: Required. The identifier value for the response action. This value is specific to the type of action being performed.
+          additionalProperties:
+            type: object
     microsoft.graph.security.incidentTaskSource:
       title: incidentTaskSource
       enum:
@@ -43963,6 +47404,35 @@ components:
           type: object
           additionalProperties:
             type: object
+    microsoft.graph.security.huntingSchemaFunctions:
+      title: huntingSchemaFunctions
+      type: object
+      properties:
+        builtInFunctions:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.huntingSchemaBuiltInFunction'
+        savedFunctions:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.huntingSchemaSavedFunction'
+      additionalProperties:
+        type: object
+    microsoft.graph.security.huntingSchemaTable:
+      title: huntingSchemaTable
+      type: object
+      properties:
+        columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.huntingSchemaTableColumn'
+        description:
+          type: string
+          nullable: true
+        name:
+          type: string
+      additionalProperties:
+        type: object
     microsoft.graph.security.huntingRowResult:
       title: huntingRowResult
       type: object
@@ -44319,6 +47789,163 @@ components:
         - Completed
         - Failed
       type: string
+    microsoft.graph.security.securityCopilot.pluginAuth:
+      title: pluginAuth
+      type: object
+      properties:
+        authType:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.pluginAuthTypes'
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.pluginCatalogScope:
+      title: pluginCatalogScope
+      enum:
+        - none
+        - user
+        - workspace
+        - tenant
+        - global
+        - geoGlobal
+        - userWorkspace
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.securityCopilot.pluginCategory:
+      title: pluginCategory
+      enum:
+        - hidden
+        - microsoft
+        - microsoftConnectors
+        - other
+        - web
+        - testing
+        - plugin
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.securityCopilot.pluginPreviewStates:
+      title: pluginPreviewStates
+      enum:
+        - ga
+        - public
+        - private
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.securityCopilot.pluginSetting:
+      title: pluginSetting
+      type: object
+      properties:
+        acceptableValues:
+          type: array
+          items:
+            type: string
+          description: Acceptable values for plugin type
+        defaultValue:
+          type: string
+          description: Default value available for the plugin if not configured
+          nullable: true
+        description:
+          type: string
+          description: Description of the value requested
+          nullable: true
+        displayType:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.pluginSettingDisplayType'
+        hintText:
+          type: string
+          description: Hint for the plugin
+          nullable: true
+        isRequired:
+          type: boolean
+          description: Setting whether the value is required
+        label:
+          type: string
+          description: Label for the setting
+          nullable: true
+        name:
+          type: string
+          description: Name of the setting
+          nullable: true
+        settingValue:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.pluginSettingType'
+        value:
+          type: string
+          description: Value
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.pluginAuthTypes:
+      title: pluginAuthTypes
+      enum:
+        - none
+        - basic
+        - aPIKey
+        - oAuthAuthorizationCodeFlow
+        - oAuthClientCredentialsFlow
+        - aad
+        - serviceHttp
+        - aadDelegated
+        - oAuthPasswordGrantFlow
+        - unknownFutureValue
+      type: string
+    microsoft.graph.Dictionary:
+      title: Dictionary
+      type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.skillInputDescriptor:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.skillVariableDescriptor'
+        - title: skillInputDescriptor
+          type: object
+          properties:
+            defaultValue:
+              type: string
+              description: Unsupported.
+              nullable: true
+            isRequired:
+              type: boolean
+              description: Unsupported.
+            placeholderValue:
+              type: string
+              description: Unsupported.
+              nullable: true
+          additionalProperties:
+            type: object
+    microsoft.graph.security.securityCopilot.promptType:
+      title: promptType
+      enum:
+        - unknown
+        - context
+        - prompt
+        - skill
+        - feedback
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.securityCopilot.evaluationResult:
+      title: evaluationResult
+      type: object
+      properties:
+        content:
+          type: string
+          description: The final content.
+          nullable: true
+        previewState:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.skillPreviewState'
+        type:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluationResultType'
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.evaluationState:
+      title: evaluationState
+      enum:
+        - unknown
+        - created
+        - running
+        - completed
+        - cancelled
+        - pending
+        - deferred
+        - waitingForInput
+        - unknownFutureValue
+      type: string
     microsoft.graph.identity:
       title: identity
       type: object
@@ -44511,10 +48138,25 @@ components:
       title: userCloudLicensing
       type: object
       properties:
+        assignmentErrors:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.cloudLicensing.assignmentError'
+          x-ms-navigationProperty: true
+        assignments:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.cloudLicensing.assignment'
+          x-ms-navigationProperty: true
         usageRights:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.cloudLicensing.usageRight'
+          x-ms-navigationProperty: true
+        waitingMembers:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.cloudLicensing.waitingMember'
           x-ms-navigationProperty: true
       additionalProperties:
         type: object
@@ -44557,11 +48199,11 @@ components:
       properties:
         costCenter:
           type: string
-          description: The cost center associated with the user. Returned only on $select. Supports $filter.
+          description: The cost center associated with the user. Requires $select to retrieve. Supports $filter.
           nullable: true
         division:
           type: string
-          description: The name of the division in which the user works. Returned only on $select. Supports $filter.
+          description: The name of the division in which the user works. Requires $select to retrieve. Supports $filter.
           nullable: true
       additionalProperties:
         type: object
@@ -44581,6 +48223,14 @@ components:
           type: string
           description: 'Specifies the user sign-in types in your directory, such as emailAddress, userName, federated, or userPrincipalName. federated represents a unique identifier for a user from an issuer that can be in any format chosen by the issuer. Setting or updating a userPrincipalName identity updates the value of the userPrincipalName property on the user object. The validations performed on the userPrincipalName property on the user object, for example, verified domains and acceptable characters, are performed when setting or updating a userPrincipalName identity. Extra validation is enforced on issuerAssignedId when the sign-in type is set to emailAddress or userName. This property can also be set to any custom string.  For more information about filtering behavior for this property, see Filtering on the identities property of a user.'
           nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.identityGovernanceUserSettings:
+      title: identityGovernanceUserSettings
+      type: object
+      properties:
+        approverDelegate:
+          $ref: '#/components/schemas/microsoft.graph.approverDelegate'
       additionalProperties:
         type: object
     microsoft.graph.licenseAssignmentState:
@@ -44618,72 +48268,6 @@ components:
         state:
           type: string
           description: 'Indicate the current state of this assignment. Read-Only. The possible values are Active, ActiveWithError, Disabled, and Error.'
-          nullable: true
-      additionalProperties:
-        type: object
-    microsoft.graph.onPremisesExtensionAttributes:
-      title: onPremisesExtensionAttributes
-      type: object
-      properties:
-        extensionAttribute1:
-          type: string
-          description: First customizable extension attribute.
-          nullable: true
-        extensionAttribute10:
-          type: string
-          description: Tenth customizable extension attribute.
-          nullable: true
-        extensionAttribute11:
-          type: string
-          description: Eleventh customizable extension attribute.
-          nullable: true
-        extensionAttribute12:
-          type: string
-          description: Twelfth customizable extension attribute.
-          nullable: true
-        extensionAttribute13:
-          type: string
-          description: Thirteenth customizable extension attribute.
-          nullable: true
-        extensionAttribute14:
-          type: string
-          description: Fourteenth customizable extension attribute.
-          nullable: true
-        extensionAttribute15:
-          type: string
-          description: Fifteenth customizable extension attribute.
-          nullable: true
-        extensionAttribute2:
-          type: string
-          description: Second customizable extension attribute.
-          nullable: true
-        extensionAttribute3:
-          type: string
-          description: Third customizable extension attribute.
-          nullable: true
-        extensionAttribute4:
-          type: string
-          description: Fourth customizable extension attribute.
-          nullable: true
-        extensionAttribute5:
-          type: string
-          description: Fifth customizable extension attribute.
-          nullable: true
-        extensionAttribute6:
-          type: string
-          description: Sixth customizable extension attribute.
-          nullable: true
-        extensionAttribute7:
-          type: string
-          description: Seventh customizable extension attribute.
-          nullable: true
-        extensionAttribute8:
-          type: string
-          description: Eighth customizable extension attribute.
-          nullable: true
-        extensionAttribute9:
-          type: string
-          description: Ninth customizable extension attribute.
           nullable: true
       additionalProperties:
         type: object
@@ -44850,6 +48434,26 @@ components:
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
+    microsoft.graph.adhocCall:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: adhocCall
+          type: object
+          properties:
+            recordings:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.callRecording'
+              description: The recordings of a call. Read-only.
+              x-ms-navigationProperty: true
+            transcripts:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.callTranscript'
+              description: The transcripts of a call. Read-only.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
     microsoft.graph.agreementAcceptance:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -44943,7 +48547,7 @@ components:
               description: The identifier of the application. Required. Supports $filter (eq only) and $orderby.
             consentType:
               type: string
-              description: 'The consent type of the request. Possible values are: Static and Dynamic. These represent static and dynamic permissions, respectively, requested in the consent workflow. Supports $filter (eq only) and $orderby. Required.'
+              description: 'The consent type of the request. The possible values are: Static and Dynamic. These represent static and dynamic permissions, respectively, requested in the consent workflow. Supports $filter (eq only) and $orderby. Required.'
               nullable: true
             pendingScopes:
               type: array
@@ -45008,6 +48612,10 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.appRole'
               description: 'The roles exposed by the application, which this service principal represents. For more information, see the appRoles property definition on the application entity. Not nullable.'
+            createdByAppId:
+              type: string
+              description: The appId of the application that created this service principal. Set internally by Microsoft Entra ID. Read-only.
+              nullable: true
             customSecurityAttributes:
               $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeValue'
             description:
@@ -45016,7 +48624,7 @@ components:
               nullable: true
             disabledByMicrosoftStatus:
               type: string
-              description: 'Specifies whether Microsoft has disabled the registered application. Possible values are: null (default value), NotDisabled, and DisabledDueToViolationOfServicesAgreement (reasons may include suspicious, abusive, or malicious activity, or a violation of the Microsoft Services Agreement).  Supports $filter (eq, ne, not).'
+              description: 'Specifies whether Microsoft has disabled the registered application. The possible values are: null (default value), NotDisabled, and DisabledDueToViolationOfServicesAgreement (reasons may include suspicious, abusive, or malicious activity, or a violation of the Microsoft Services Agreement).  Supports $filter (eq, ne, not).'
               nullable: true
             displayName:
               type: string
@@ -45032,6 +48640,10 @@ components:
               nullable: true
             info:
               $ref: '#/components/schemas/microsoft.graph.informationalUrl'
+            isDisabled:
+              type: boolean
+              description: 'Specifies whether the service principal of the app in a tenant or across tenants for multi-tenant apps can obtain new access tokens or access protected resources. When set to true, existing tokens remain valid until they expire based on their configured lifetimes, and the app stays visible in the Enterprise apps list but users cannot sign in.true if the application is deactivated (disabled); otherwise false.'
+              nullable: true
             keyCredentials:
               type: array
               items:
@@ -45102,7 +48714,7 @@ components:
               description: 'Contains the list of identifiersUris, copied over from the associated application. More values can be added to hybrid applications. These values can be used to identify the permissions exposed by this app within Microsoft Entra ID. For example,Client apps can specify a resource URI that is based on the values of this property to acquire an access token, which is the URI returned in the ''aud'' claim.The any operator is required for filter expressions on multi-valued properties. Not nullable.  Supports $filter (eq, not, ge, le, startsWith).'
             servicePrincipalType:
               type: string
-              description: Identifies if the service principal represents an application or a managed identity. This is set by Microsoft Entra ID internally. For a service principal that represents an application this is set as Application. For a service principal that represents a managed identity this is set as ManagedIdentity. The SocialIdp type is for internal use.
+              description: 'Identifies if the service principal represents an application or a managed identity. This property is set by Microsoft Entra ID internally. For a service principal that represents an application this is set as Application. For a service principal that represents a managed identity this is set as ManagedIdentity.For a service principal that represents an agent identity, this is set to ServiceIdentity. The SocialIdp type is for internal use.'
               nullable: true
             signInAudience:
               type: string
@@ -45267,7 +48879,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalAuthenticationMethod'
-              description: Represents the external methods registered to a user for authentication.
+              description: Represents the external MFA registered to a user for authentication.
               x-ms-navigationProperty: true
             fido2Methods:
               type: array
@@ -45399,8 +49011,16 @@ components:
               description: Date and time at which the chat was renamed or list of members were last changed. Read-only.
               format: date-time
               nullable: true
+            migrationMode:
+              $ref: '#/components/schemas/microsoft.graph.migrationMode'
             onlineMeetingInfo:
               $ref: '#/components/schemas/microsoft.graph.teamworkOnlineMeetingInfo'
+            originalCreatedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Timestamp of the original creation time for the chat. The value is null if the chat never entered migration mode.
+              format: date-time
+              nullable: true
             tenantId:
               type: string
               description: The identifier of the tenant in which the chat was created. Read-only.
@@ -45459,6 +49079,12 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
               x-ms-navigationProperty: true
+            targetedMessages:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+              description: A collection of targeted messages in the chat that are visible only to specific users. Nullable.
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudClipboardRoot:
@@ -45472,6 +49098,43 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudClipboardItem'
               description: Represents a collection of Cloud Clipboard items.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.cloudPcPool:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: cloudPcPool
+          type: object
+          properties:
+            capabilities:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcPoolCapabilityConfiguration'
+            cloudPcConfiguration:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcConfiguration'
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time when the pool was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2026 is 2026-01-01T00:00:00Z. Read-only.'
+              format: date-time
+            description:
+              type: string
+              description: The description of the pool. The maximum length is 512 characters.
+              nullable: true
+            displayName:
+              type: string
+              description: The display name of the pool. The name is unique across Cloud PC pools in an organization. The maximum length is 60 characters.
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time when the pool was last modified. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2026 is 2026-01-01T00:00:00Z. Read-only.'
+              format: date-time
+            networkConfiguration:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcNetworkConfiguration'
+            assignments:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudPcPoolAssignment'
+              description: The collection of assignments that grant user or service principal identities access to this pool.
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
@@ -45515,6 +49178,8 @@ components:
               description: 'The date and time when the grace period ends and reprovisioning or deprovisioning happens. Required only if the status is inGracePeriod. The timestamp is shown in ISO 8601 format and Coordinated Universal Time (UTC). For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
               format: date-time
               nullable: true
+            groupDetail:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcEntraGroupDetail'
             imageDisplayName:
               type: string
               description: Name of the OS image that's on the Cloud PC.
@@ -45572,6 +49237,7 @@ components:
               items:
                 type: string
                 nullable: true
+              description: 'The scope IDs of the corresponding permission. Currently, it''s the Intune scope tag ID. Read-only.'
             servicePlanId:
               type: string
               description: The service plan ID of the Cloud PC.
@@ -45592,6 +49258,10 @@ components:
               $ref: '#/components/schemas/microsoft.graph.cloudPcStatusDetails'
             userAccountType:
               $ref: '#/components/schemas/microsoft.graph.cloudPcUserAccountType'
+            userDetail:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcEntraUserDetail'
+            userExperienceType:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcUserExperienceType'
             userPrincipalName:
               type: string
               description: The user principal name (UPN) of the user assigned to the Cloud PC.
@@ -45760,10 +49430,14 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.physicalAddress'
               description: 'Addresses associated with the contact, for example, home address and business address.'
+            primaryEmailAddress:
+              $ref: '#/components/schemas/microsoft.graph.emailAddress'
             profession:
               type: string
               description: The contact's profession.
               nullable: true
+            secondaryEmailAddress:
+              $ref: '#/components/schemas/microsoft.graph.emailAddress'
             spouseName:
               type: string
               description: The name of the contact's spouse/partner.
@@ -45772,6 +49446,8 @@ components:
               type: string
               description: The contact's surname.
               nullable: true
+            tertiaryEmailAddress:
+              $ref: '#/components/schemas/microsoft.graph.emailAddress'
             title:
               type: string
               description: The contact's title.
@@ -45962,7 +49638,7 @@ components:
               nullable: true
             deviceOwnership:
               type: string
-              description: 'Ownership of the device. Intune sets this property. Possible values are: unknown, company, personal.'
+              description: 'Ownership of the device. Intune sets this property. The possible values are: unknown, company, personal.'
               nullable: true
             deviceVersion:
               maximum: 2147483647
@@ -45985,7 +49661,7 @@ components:
               nullable: true
             enrollmentType:
               type: string
-              description: 'Enrollment type of the device. Intune sets this property. Possible values are: unknown, userEnrollment, deviceEnrollmentManager, appleBulkWithUser, appleBulkWithoutUser, windowsAzureADJoin, windowsBulkUserless, windowsAutoEnrollment, windowsBulkAzureDomainJoin, windowsCoManagement, windowsAzureADJoinUsingDeviceAuth,appleUserEnrollment, appleUserEnrollmentWithServiceAccount. NOTE: This property might return other values apart from those listed.'
+              description: 'Enrollment type of the device. Intune sets this property. The possible values are: unknown, userEnrollment, deviceEnrollmentManager, appleBulkWithUser, appleBulkWithoutUser, windowsAzureADJoin, windowsBulkUserless, windowsAutoEnrollment, windowsBulkAzureDomainJoin, windowsCoManagement, windowsAzureADJoinUsingDeviceAuth,appleUserEnrollment, appleUserEnrollmentWithServiceAccount. NOTE: This property might return other values apart from those listed.'
               nullable: true
             extensionAttributes:
               $ref: '#/components/schemas/microsoft.graph.onPremisesExtensionAttributes'
@@ -46017,7 +49693,7 @@ components:
               nullable: true
             managementType:
               type: string
-              description: 'Management channel of the device. Intune sets this property. Possible values are: eas, mdm, easMdm, intuneClient, easIntuneClient, configurationManagerClient, configurationManagerClientMdm, configurationManagerClientMdmEas, unknown, jamf, googleCloudDevicePolicyController.'
+              description: 'Management channel of the device. Intune sets this property. The possible values are: eas, mdm, easMdm, intuneClient, easIntuneClient, configurationManagerClient, configurationManagerClientMdm, configurationManagerClientMdmEas, unknown, jamf, googleCloudDevicePolicyController.'
               nullable: true
             manufacturer:
               type: string
@@ -46043,7 +49719,7 @@ components:
               nullable: true
             onPremisesSecurityIdentifier:
               type: string
-              description: The on-premises security identifier (SID) for the user who was synchronized from on-premises to the cloud. Read-only. Returned only on $select. Supports $filter (eq).
+              description: The on-premises security identifier (SID) for the user who was synchronized from on-premises to the cloud. Read-only. Requires $select to retrieve. Supports $filter (eq).
               nullable: true
             onPremisesSyncEnabled:
               type: boolean
@@ -46156,6 +49832,8 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.learningCourseActivity'
               x-ms-navigationProperty: true
+            storyline:
+              $ref: '#/components/schemas/microsoft.graph.storyline'
           additionalProperties:
             type: object
           description: Represents a container that exposes navigation properties for employee experience user resources.
@@ -46286,6 +49964,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.userConfiguration'
+              description: The user configuration objects associated to the mailFolder.
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
@@ -46305,10 +49984,6 @@ components:
               type: string
               description: The unique identifier of the app instance for which diagnostic logs were collected. Read-only.
               nullable: true
-            requestedBy:
-              type: string
-              description: The user principal name associated with the request for the managed application log collection. Read-only.
-              nullable: true
             requestedByUserPrincipalName:
               type: string
               description: The user principal name associated with the request for the managed application log collection. Read-only.
@@ -46318,10 +49993,6 @@ components:
               type: string
               description: 'DateTime of when the log upload request was received. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: ''2014-01-01T00:00:00Z''. Returned by default. Read-only.'
               format: date-time
-            status:
-              type: string
-              description: 'Indicates the status for the app log collection request - pending, completed or failed. Default is pending.'
-              nullable: true
             uploadedLogs:
               type: array
               items:
@@ -46906,7 +50577,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.internetMessageHeader'
-              description: A collection of message headers defined by RFC5322. The set includes message headers indicating the network path taken by a message from the sender to the recipient. It can also contain custom message headers that hold app data for the message.  Returned only on applying a $select query option. Read-only.
+              description: A collection of message headers defined by RFC5322. The set includes message headers indicating the network path taken by a message from the sender to the recipient. It can also contain custom message headers that hold app data for the message.  Requires $select to retrieve. Read-only.
             internetMessageId:
               type: string
               description: The message ID in the format specified by RFC5322. Updatable only if isDraft is true.
@@ -47165,7 +50836,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingCapabilities'
-              description: 'The list of meeting capabilities. Possible values are: questionAndAnswer,unknownFutureValue.'
+              description: 'The list of meeting capabilities. The possible values are: questionAndAnswer,unknownFutureValue.'
             creationDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
@@ -47477,11 +51148,11 @@ components:
           properties:
             activity:
               type: string
-              description: 'The supplemental information to a user''s availability. Possible values are Available, Away, BeRightBack, Busy, DoNotDisturb, InACall, InAConferenceCall, Inactive, InAMeeting, Offline, OffWork, OutOfOffice, PresenceUnknown, Presenting, UrgentInterruptionsOnly.'
+              description: 'The supplemental information to a user''s availability. Possible values are available, away, beRightBack, busy, doNotDisturb, offline, outOfOffice, presenceUnknown.'
               nullable: true
             availability:
               type: string
-              description: 'The base presence information for a user. Possible values are Available, AvailableIdle,  Away, BeRightBack, Busy, BusyIdle, DoNotDisturb, Offline, PresenceUnknown.'
+              description: 'The base presence information for a user. Possible values are available, away, beRightBack, busy, doNotDisturb, focusing, inACall, inAMeeting, offline, presenting, presenceUnknown.'
               nullable: true
             outOfOfficeSettings:
               $ref: '#/components/schemas/microsoft.graph.outOfOfficeSettings'
@@ -47492,6 +51163,8 @@ components:
               readOnly: true
             statusMessage:
               $ref: '#/components/schemas/microsoft.graph.presenceStatusMessage'
+            workLocation:
+              $ref: '#/components/schemas/microsoft.graph.userWorkLocation'
           additionalProperties:
             type: object
     microsoft.graph.profile:
@@ -47661,6 +51334,8 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.windowsSetting'
               description: The Windows settings of the user stored in the cloud.
               x-ms-navigationProperty: true
+            workHoursAndLocations:
+              $ref: '#/components/schemas/microsoft.graph.workHoursAndLocationsSetting'
           additionalProperties:
             type: object
     microsoft.graph.userSolutionRoot:
@@ -47698,6 +51373,12 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
+              x-ms-navigationProperty: true
+            sections:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSection'
+              description: The sections in the user's chat list.
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
@@ -48063,8 +51744,16 @@ components:
               $ref: '#/components/schemas/microsoft.graph.channelLayoutType'
             membershipType:
               $ref: '#/components/schemas/microsoft.graph.channelMembershipType'
+            migrationMode:
+              $ref: '#/components/schemas/microsoft.graph.migrationMode'
             moderationSettings:
               $ref: '#/components/schemas/microsoft.graph.channelModerationSettings'
+            originalCreatedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: Timestamp of the original creation time for the channel. The value is null if the channel never entered migration mode.
+              format: date-time
+              nullable: true
             summary:
               $ref: '#/components/schemas/microsoft.graph.channelSummary'
             tenantId:
@@ -48081,8 +51770,19 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.conversationMember'
               description: A collection of membership records associated with the channel. It includes both direct and indirect members of shared channels.
               x-ms-navigationProperty: true
+            enabledApps:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.teamsApp'
+              description: A collection of enabled apps in the channel.
+              x-ms-navigationProperty: true
             filesFolder:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
+            joinedUsers:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
@@ -48947,6 +52647,36 @@ components:
           $ref: '#/components/schemas/microsoft.graph.accountStatus'
       additionalProperties:
         type: object
+    microsoft.graph.security.auditInfo:
+      title: auditInfo
+      type: object
+      properties:
+        by:
+          type: string
+          description: Display name of the user or application that performed the action.
+        dateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Timestamp of the action. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+      additionalProperties:
+        type: object
+    microsoft.graph.security.environmentKind:
+      title: environmentKind
+      enum:
+        - azureSubscription
+        - awsOrganization
+        - awsAccount
+        - gcpOrganization
+        - gcpProject
+        - dockersHubOrganization
+        - devOpsConnection
+        - azureDevOpsOrganization
+        - gitHubOrganization
+        - gitLabGroup
+        - jFrogArtifactory
+        - unknownFutureValue
+      type: string
     microsoft.graph.ODataErrors.ODataError:
       required:
         - error
@@ -49518,6 +53248,32 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.security.sensorCandidateCollectionResponse:
+      title: Collection of sensorCandidate
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.sensorCandidate'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.sensorMigrationCollectionResponse:
+      title: Collection of sensorMigration
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.sensorMigration'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.security.sensorCollectionResponse:
       title: Collection of sensor
       type: object
@@ -49799,6 +53555,71 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.securityAction'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.workspaceCollectionResponse:
+      title: Collection of workspace
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.workspace'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.pluginCollectionResponse:
+      title: Collection of plugin
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.plugin'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.sessionCollectionResponse:
+      title: Collection of session
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.session'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.promptCollectionResponse:
+      title: Collection of prompt
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.prompt'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.evaluationCollectionResponse:
+      title: Collection of evaluation
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluation'
         '@odata.nextLink':
           type: string
           nullable: true
@@ -50176,6 +53997,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.userSecurityProfile'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.zoneCollectionResponse:
+      title: Collection of zone
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.zone'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.environmentCollectionResponse:
+      title: Collection of environment
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.environment'
         '@odata.nextLink':
           type: string
           nullable: true
@@ -50622,6 +54469,7 @@ components:
         archivedDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
+          description: 'Time when the container was archived. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
           format: date-time
           nullable: true
         archiveStatus:
@@ -50681,7 +54529,7 @@ components:
       properties:
         format:
           type: string
-          description: 'For dateTime output types, the format of the value. Possible values are: dateOnly or dateTime.'
+          description: 'For dateTime output types, the format of the value. The possible values are: dateOnly or dateTime.'
           nullable: true
         formula:
           type: string
@@ -50689,7 +54537,7 @@ components:
           nullable: true
         outputType:
           type: string
-          description: 'The output type used to format values in this column. Possible values are: boolean, currency, dateTime, number, or text.'
+          description: 'The output type used to format values in this column. The possible values are: boolean, currency, dateTime, number, or text.'
           nullable: true
       additionalProperties:
         type: object
@@ -51775,6 +55623,8 @@ components:
           properties:
             group:
               $ref: '#/components/schemas/microsoft.graph.identity'
+            sharePointGroup:
+              $ref: '#/components/schemas/microsoft.graph.sharePointGroupIdentity'
             siteGroup:
               $ref: '#/components/schemas/microsoft.graph.sharePointIdentity'
             siteUser:
@@ -51949,6 +55799,25 @@ components:
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
+    microsoft.graph.cloudLicensing.assignment:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: assignment
+          type: object
+          properties:
+            disabledServicePlanIds:
+              type: array
+              items:
+                pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+                type: string
+                format: uuid
+              description: The list of disabled service plans for this assignment. Not nullable.
+            allotment:
+              $ref: '#/components/schemas/microsoft.graph.cloudLicensing.allotment'
+            assignedTo:
+              $ref: '#/components/schemas/microsoft.graph.directoryObject'
+          additionalProperties:
+            type: object
     microsoft.graph.cloudLicensing.usageRight:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -51970,6 +55839,18 @@ components:
               type: string
               description: 'Unique SKU display name that is equal to the skuPartNumber on the related subscribedSku object; for example, AAD_Premium. Read-only.'
               nullable: true
+            allotments:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudLicensing.allotment'
+              description: The set of allotments associated with the assignments that combine to form this usageRight.
+              x-ms-navigationProperty: true
+            assignments:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudLicensing.assignment'
+              description: 'The set of assignments that combine to form this usageRight, including both direct assignments and assignments inherited through group membership.'
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.MembershipRuleProcessingStatusDetails:
@@ -52038,7 +55919,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.calendarRoleType'
-              description: 'List of allowed sharing or delegating permission levels for the calendar. Possible values are: none, freeBusyRead, limitedRead, read, write, delegateWithoutPrivateEventAccess, delegateWithPrivateEventAccess, custom.'
+              description: 'List of allowed sharing or delegating permission levels for the calendar. The possible values are: none, freeBusyRead, limitedRead, read, write, delegateWithoutPrivateEventAccess, delegateWithPrivateEventAccess, custom.'
             emailAddress:
               $ref: '#/components/schemas/microsoft.graph.emailAddress'
             isInsideOrganization:
@@ -52303,6 +56184,8 @@ components:
               $ref: '#/components/schemas/microsoft.graph.plannerArchivalInfo'
             container:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanContainer'
+            contentSensitivityLabelAssignment:
+              $ref: '#/components/schemas/microsoft.graph.contentSensitivityLabelAssignment'
             contexts:
               $ref: '#/components/schemas/microsoft.graph.plannerPlanContextCollection'
             createdBy:
@@ -52482,6 +56365,10 @@ components:
           description: Represents indicators and its associated verdict that suggests whether an email is compromised.
         detonationBehaviourDetails:
           $ref: '#/components/schemas/microsoft.graph.security.detonationBehaviourDetails'
+        detonationBehaviourDetailsV2:
+          type: string
+          description: 'Shows the exact events that took place during detonation, and problematic or benign observations that contain URLs, IPs, domains, and files that were found during detonation in a JSON format.'
+          nullable: true
         detonationChain:
           $ref: '#/components/schemas/microsoft.graph.security.detonationChain'
         detonationObservables:
@@ -52497,6 +56384,22 @@ components:
         detonationVerdictReason:
           type: string
           description: The reason for the verdict of the detonation.
+          nullable: true
+        entityMetadata:
+          type: string
+          description: Additional metadata about the entity in JSON format.
+          nullable: true
+        mitreTechniques:
+          type: string
+          description: 'The attack techniques, as aligned with the MITRE ATT&CK framework.'
+          nullable: true
+        staticAnalysis:
+          type: string
+          description: The results of static analysis performed on the file or URL.
+          nullable: true
+        submissionSource:
+          type: string
+          description: The source of the submission.
           nullable: true
       additionalProperties:
         type: object
@@ -52663,6 +56566,8 @@ components:
       properties:
         content:
           $ref: '#/components/schemas/microsoft.graph.contentBase'
+        contentCategory:
+          $ref: '#/components/schemas/microsoft.graph.contentCategory'
         correlationId:
           type: string
           description: 'An identifier used to group multiple related content entries (for example, different parts of the same file upload, messages in a conversation).'
@@ -52815,9 +56720,80 @@ components:
           type: object
           additionalProperties:
             type: object
-    microsoft.graph.Dictionary:
-      title: Dictionary
+    microsoft.graph.security.huntingSchemaBuiltInFunction:
+      title: huntingSchemaBuiltInFunction
       type: object
+      properties:
+        documentation:
+          type: string
+          nullable: true
+        huntingFunctionId:
+          type: number
+          format: int64
+          readOnly: true
+        inputParameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.huntingSchemaFunctionParameter'
+        name:
+          type: string
+        outputColumns:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.huntingSchemaTableColumn'
+        path:
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.huntingSchemaSavedFunction:
+      title: huntingSchemaSavedFunction
+      type: object
+      properties:
+        createdBy:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        huntingFunctionId:
+          type: number
+          format: int64
+          readOnly: true
+        inputParameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.huntingSchemaFunctionParameter'
+        lastModifiedBy:
+          type: string
+          nullable: true
+        lastModifiedDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        name:
+          type: string
+        outputColumns:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.security.huntingSchemaTableColumn'
+        path:
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.security.huntingSchemaTableColumn:
+      title: huntingSchemaTableColumn
+      type: object
+      properties:
+        dataType:
+          type: string
+        description:
+          type: string
+          nullable: true
+        name:
+          type: string
       additionalProperties:
         type: object
     microsoft.graph.partner.security.policyStatus:
@@ -52910,6 +56886,60 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.security.securityCopilot.pluginSettingDisplayType:
+      title: pluginSettingDisplayType
+      enum:
+        - none
+        - textbox
+        - checkbox
+        - dropdown
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.securityCopilot.pluginSettingType:
+      title: pluginSettingType
+      enum:
+        - string
+        - bool
+        - array
+        - enum
+        - secretString
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.securityCopilot.skillVariableDescriptor:
+      title: skillVariableDescriptor
+      type: object
+      properties:
+        description:
+          type: string
+          description: Unsupported.
+          nullable: true
+        name:
+          type: string
+          description: Unsupported.
+        type:
+          $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.skillTypeDescriptor'
+      additionalProperties:
+        type: object
+    microsoft.graph.security.securityCopilot.skillPreviewState:
+      title: skillPreviewState
+      enum:
+        - ga
+        - public
+        - private
+        - unknownFutureValue
+      type: string
+    microsoft.graph.security.securityCopilot.evaluationResultType:
+      title: evaluationResultType
+      enum:
+        - unknown
+        - success
+        - error
+        - needAdditionalClaims
+        - rejected
+        - timedOut
+        - capacityExceeded
+        - unknownFutureValue
+      type: string
     microsoft.graph.subjectRightsRequestStage:
       title: subjectRightsRequestStage
       enum:
@@ -52931,6 +56961,62 @@ components:
         - failed
         - unknownFutureValue
       type: string
+    microsoft.graph.cloudLicensing.assignmentError:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: assignmentError
+          type: object
+          properties:
+            code:
+              type: string
+              description: The error code associated with the assignment synchronization failure.
+            message:
+              type: string
+              description: The error message associated with the assignment synchronization failure.
+            occurrenceDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time at which the error most recently occurred. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+            skuId:
+              pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+              type: string
+              description: Unique identifier (GUID) for the service SKU that is equal to the skuId property on the related subscribedSku object. Read-only. Supports $filter.
+              format: uuid
+              nullable: true
+            assignedTo:
+              $ref: '#/components/schemas/microsoft.graph.directoryObject'
+            usageRight:
+              $ref: '#/components/schemas/microsoft.graph.cloudLicensing.usageRight'
+          additionalProperties:
+            type: object
+    microsoft.graph.cloudLicensing.waitingMember:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: waitingMember
+          type: object
+          properties:
+            waitingSinceDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Indicates the moment when the user or device first waited for this license. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+            allotment:
+              $ref: '#/components/schemas/microsoft.graph.cloudLicensing.allotment'
+            assignedTo:
+              $ref: '#/components/schemas/microsoft.graph.directoryObject'
+          additionalProperties:
+            type: object
+    microsoft.graph.approverDelegate:
+      title: approverDelegate
+      type: object
+      properties:
+        delegate:
+          $ref: '#/components/schemas/microsoft.graph.userSet'
+        schedule:
+          $ref: '#/components/schemas/microsoft.graph.requestSchedule'
+      additionalProperties:
+        type: object
     microsoft.graph.printerShare:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.printerBase'
@@ -53049,6 +57135,97 @@ components:
               nullable: true
             activity:
               $ref: '#/components/schemas/microsoft.graph.userActivity'
+          additionalProperties:
+            type: object
+    microsoft.graph.callRecording:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: callRecording
+          type: object
+          properties:
+            callId:
+              type: string
+              description: The unique identifier for the call that is related to this recording. Read-only.
+              nullable: true
+            content:
+              type: string
+              description: The content of the recording. Read-only.
+              format: base64url
+              nullable: true
+            contentCorrelationId:
+              type: string
+              description: The unique identifier that links the transcript with its corresponding recording. Read-only.
+              nullable: true
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time at which the recording was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
+              format: date-time
+              nullable: true
+            endDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time at which the recording ends. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
+              format: date-time
+              nullable: true
+            meetingId:
+              type: string
+              description: The unique identifier of the onlineMeeting related to this recording. Read-only.
+              nullable: true
+            meetingOrganizer:
+              $ref: '#/components/schemas/microsoft.graph.identitySet'
+            recordingContentUrl:
+              type: string
+              description: The URL that can be used to access the content of the recording. Read-only.
+              nullable: true
+          additionalProperties:
+            type: object
+    microsoft.graph.callTranscript:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: callTranscript
+          type: object
+          properties:
+            callId:
+              type: string
+              description: The unique identifier for the call that is related to this transcript. Read-only.
+              nullable: true
+            content:
+              type: string
+              description: The content of the transcript. Read-only.
+              format: base64url
+              nullable: true
+            contentCorrelationId:
+              type: string
+              description: The unique identifier that links the transcript with its corresponding recording. Read-only.
+              nullable: true
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time at which the transcript was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
+              format: date-time
+              nullable: true
+            endDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time at which the transcription ends. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
+              format: date-time
+              nullable: true
+            meetingId:
+              type: string
+              description: The unique identifier of the online meeting related to this transcript. Read-only.
+              nullable: true
+            meetingOrganizer:
+              $ref: '#/components/schemas/microsoft.graph.identitySet'
+            metadataContent:
+              type: string
+              description: The time-aligned metadata of the utterances in the transcript. Read-only.
+              format: base64url
+              nullable: true
+            transcriptContentUrl:
+              type: string
+              description: The URL that can be used to access the content of the transcript. Read-only.
+              nullable: true
           additionalProperties:
             type: object
     microsoft.graph.agreementAcceptanceState:
@@ -53228,7 +57405,7 @@ components:
           nullable: true
         key:
           type: string
-          description: 'Value for the key credential. Should be a Base64 encoded value. Returned only on $select for a single object, that is, GET applications/{applicationId}?$select=keyCredentials or GET servicePrincipals/{servicePrincipalId}?$select=keyCredentials; otherwise, it''s always null.  From a .cer certificate, you can read the key using the Convert.ToBase64String() method. For more information, see Get the certificate key.'
+          description: 'Value for the key credential. Should be a Base64 encoded value. Requires $select to retrieve; only available for single object requests (GET /applications/{applicationId}?$select=keyCredentials or GET /servicePrincipals/{servicePrincipalId}?$select=keyCredentials); otherwise, it''s always null.  From a .cer certificate, you can read the key using the Convert.ToBase64String() method. For more information, see Get the certificate key.'
           format: base64url
           nullable: true
         keyId:
@@ -53507,6 +57684,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvedClientApp'
+              description: The collection of approved client apps that are associated with the RDS configuration. Supports $expand.
               x-ms-navigationProperty: true
             targetDeviceGroups:
               type: array
@@ -53634,7 +57812,7 @@ components:
               description: A unique identifier used to manage the external auth method within Microsoft Entra ID.
             displayName:
               type: string
-              description: Custom name given to the registered external authentication method.
+              description: Custom name given to the registered external MFA.
           additionalProperties:
             type: object
     microsoft.graph.fido2AuthenticationMethod:
@@ -53663,6 +57841,8 @@ components:
               type: string
               description: The manufacturer-assigned model of the FIDO2 security key.
               nullable: true
+            passkeyType:
+              $ref: '#/components/schemas/microsoft.graph.passkeyType'
             publicKeyCredential:
               $ref: '#/components/schemas/microsoft.graph.webauthnPublicKeyCredential'
           additionalProperties:
@@ -53687,6 +57867,12 @@ components:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
               description: 'The date and time the authentication method was registered to the user. Read-only. Optional. This optional value is null if the authentication method doesn''t populate it. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            lastUsedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time the authentication method was last used by the user. Read-only. Optional. This optional value is null if the authentication method doesn''t populate it. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
               format: date-time
               nullable: true
           additionalProperties:
@@ -53858,6 +58044,13 @@ components:
         - oneOnOne
         - group
         - meeting
+        - unknownFutureValue
+      type: string
+    microsoft.graph.migrationMode:
+      title: migrationMode
+      enum:
+        - inProgress
+        - completed
         - unknownFutureValue
       type: string
     microsoft.graph.teamworkOnlineMeetingInfo:
@@ -54066,6 +58259,16 @@ components:
               $ref: '#/components/schemas/microsoft.graph.teamsApp'
           additionalProperties:
             type: object
+    microsoft.graph.targetedChatMessage:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        - title: targetedChatMessage
+          type: object
+          properties:
+            recipient:
+              $ref: '#/components/schemas/microsoft.graph.identity'
+          additionalProperties:
+            type: object
     microsoft.graph.cloudClipboardItem:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -54095,6 +58298,41 @@ components:
               description: A cloudClipboardItem can have multiple cloudClipboardItemPayload objects in the payloads. A window can place more than one clipboard object on the clipboard. Each one represents the same information in a different clipboard format.
           additionalProperties:
             type: object
+    microsoft.graph.cloudPcPoolCapabilityConfiguration:
+      title: cloudPcPoolCapabilityConfiguration
+      type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.cloudPcConfiguration:
+      title: cloudPcConfiguration
+      type: object
+      properties:
+        imageDisplayName:
+          type: string
+          description: The display name of the image. Read-only.
+          nullable: true
+        imageId:
+          type: string
+          description: 'The unique identifier of the operating system image used for provisioning new Cloud PCs. The format for a gallery type image is: {publisherNameofferNameskuName}.'
+        imageType:
+          $ref: '#/components/schemas/microsoft.graph.cloudPcProvisioningPolicyImageType'
+        osLocale:
+          type: string
+          description: The operating system locale for the Cloud PC.
+      additionalProperties:
+        type: object
+    microsoft.graph.cloudPcNetworkConfiguration:
+      title: cloudPcNetworkConfiguration
+      type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.cloudPcPoolAssignment:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: cloudPcPoolAssignment
+          type: object
+          additionalProperties:
+            type: object
     microsoft.graph.cloudPcConnectionSetting:
       title: cloudPcConnectionSetting
       type: object
@@ -54110,6 +58348,7 @@ components:
       properties:
         enableSingleSignOn:
           type: boolean
+          description: Indicates whether single sign-on is enabled. The default value is false.
       additionalProperties:
         type: object
     microsoft.graph.cloudPcConnectivityResult:
@@ -54171,6 +58410,20 @@ components:
         - notAvailable
         - unknownFutureValue
       type: string
+    microsoft.graph.cloudPcEntraGroupDetail:
+      title: cloudPcEntraGroupDetail
+      type: object
+      properties:
+        groupDisplayName:
+          type: string
+          description: The display name of the Microsoft Entra ID group. Read-only.
+          nullable: true
+        groupId:
+          type: string
+          description: The unique identifier (GUID) of the Microsoft Entra ID group. Read-only.
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.cloudPcLoginResult:
       title: cloudPcLoginResult
       type: object
@@ -54290,6 +58543,12 @@ components:
           type: string
           description: 'The user principal name (UPN) of the user to whom the device is currently assigned. If no user is assigned, this field remains empty. Example values, john.doe@contoso.onmicrosoft.com and .'
           nullable: true
+        sessionStartDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The date and time when the current user session starts, or null if no current user session exists. This value is autogenerated and assigned at the start of each session. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+          nullable: true
       additionalProperties:
         type: object
     microsoft.graph.cloudPcStatus:
@@ -54310,6 +58569,7 @@ components:
         - resizePendingLicense
         - updatingSingleSignOn
         - modifyingSingleSignOn
+        - refreshPolicyConfiguration
         - preparing
       type: string
     microsoft.graph.cloudPcStatusDetail:
@@ -54355,6 +58615,27 @@ components:
       enum:
         - standardUser
         - administrator
+        - unknownFutureValue
+      type: string
+    microsoft.graph.cloudPcEntraUserDetail:
+      title: cloudPcEntraUserDetail
+      type: object
+      properties:
+        userDisplayName:
+          type: string
+          description: The display name of the user. Read-only.
+          nullable: true
+        userId:
+          type: string
+          description: The unique identifier (GUID) of the user. Read-only.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.cloudPcUserExperienceType:
+      title: cloudPcUserExperienceType
+      enum:
+        - cloudPc
+        - cloudApp
         - unknownFutureValue
       type: string
     microsoft.graph.callSettings:
@@ -54706,7 +58987,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.engagementRoleMember'
-              description: Users who have been assigned this role.
+              description: Users that have this role assigned.
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
@@ -54747,6 +59028,27 @@ components:
               $ref: '#/components/schemas/microsoft.graph.courseStatus'
           additionalProperties:
             type: object
+    microsoft.graph.storyline:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: storyline
+          type: object
+          properties:
+            followers:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.storylineFollower'
+              description: The users who are following this user.
+              x-ms-navigationProperty: true
+            followings:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.storylineFollowing'
+              description: The users that this user is following.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+          description: User's storyline singleton container.
     microsoft.graph.inferenceClassificationOverride:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -54868,6 +59170,17 @@ components:
           properties:
             binaryData:
               type: string
+              description: Arbitrary binary data.
+              format: base64url
+              nullable: true
+            structuredData:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.structuredDataEntry'
+              description: Key-value pairs of supported data types.
+            xmlData:
+              type: string
+              description: Binary data for storing serialized XML.
               format: base64url
               nullable: true
           additionalProperties:
@@ -54876,10 +59189,6 @@ components:
       title: managedAppLogUpload
       type: object
       properties:
-        managedAppComponent:
-          type: string
-          description: 'The Mobile Application Management (MAM) Logs Uploading Component. Such components can be the application itself, the MAM SDK, and other on-device components that are capable of uploading diagnostic logs. Read-only.'
-          nullable: true
         managedAppComponentDescription:
           type: string
           description: 'The Mobile Application Management (MAM) Logs Uploading Component. Such components can be the application itself, the MAM SDK, and other on-device components that are capable of uploading diagnostic logs. Read-only.'
@@ -56055,6 +60364,7 @@ components:
         - wipeCanceled
         - retireCanceled
         - discovered
+        - unknownFutureValue
       type: string
       description: Management state of device in Microsoft Intune.
       x-ms-enum:
@@ -56097,6 +60407,9 @@ components:
           - value: discovered
             description: The device is discovered but not fully enrolled.
             name: discovered
+          - value: unknownFutureValue
+            description: Evolvable enumeration sentinel value. Do not use.
+            name: unknownFutureValue
     microsoft.graph.ownerType:
       title: ownerType
       enum:
@@ -56582,6 +60895,10 @@ components:
               type: string
               description: Current anti malware version
               nullable: true
+            controlledConfigurationEnabled:
+              type: boolean
+              description: 'When TRUE indicates the Windows Defender controlled configuration feature is enabled, when FALSE indicates the Windows Defender controlled configuration feature is not enabled. Defaults to setting on client device.'
+              nullable: true
             deviceState:
               $ref: '#/components/schemas/microsoft.graph.windowsDeviceHealthState'
             engineVersion:
@@ -56897,13 +61214,21 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.onlineMeetingRole'
-              description: 'Specifies whose identity is anonymized in the meeting. Possible values are: attendee. The attendee value can''t be removed through a PATCH operation once added.'
+              description: 'Specifies whose identity is anonymized in the meeting. The possible values are: attendee. The attendee value can''t be removed through a PATCH operation once added.'
             audioConferencing:
               $ref: '#/components/schemas/microsoft.graph.audioConferencing'
             chatInfo:
               $ref: '#/components/schemas/microsoft.graph.chatInfo'
             chatRestrictions:
               $ref: '#/components/schemas/microsoft.graph.chatRestrictions'
+            cloudVideoInteropInfo:
+              $ref: '#/components/schemas/microsoft.graph.cloudVideoInteropInfo'
+            expiryDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Indicates the date and time when the meeting resource expires. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
             isEndToEndEncryptionEnabled:
               type: boolean
               description: Indicates whether end-to-end encryption (E2EE) is enabled for the online meeting.
@@ -56922,10 +61247,20 @@ components:
               nullable: true
             lobbyBypassSettings:
               $ref: '#/components/schemas/microsoft.graph.lobbyBypassSettings'
+            meetingOptionsWebUrl:
+              type: string
+              description: Provides the URL to the Teams meeting options page for the specified meeting. This link allows only the organizer to configure meeting settings.
+              nullable: true
+            meetingSpokenLanguageTag:
+              type: string
+              description: Specifies the spoken language used during the meeting for recording and transcription purposes.
+              nullable: true
             recordAutomatically:
               type: boolean
               description: Indicates whether to record the meeting automatically.
               nullable: true
+            sensitivityLabelAssignment:
+              $ref: '#/components/schemas/microsoft.graph.onlineMeetingSensitivityLabelAssignment'
             shareMeetingChatHistoryDefault:
               $ref: '#/components/schemas/microsoft.graph.meetingChatHistoryDefaultMode'
             subject:
@@ -57011,32 +61346,26 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.actionItem'
-              description: The collection of AI-generated action items. Read-only.
             callId:
               type: string
-              description: The ID for the online meeting call for which the callAiInsight was generated. Read-only.
               nullable: true
             contentCorrelationId:
               type: string
-              description: The unique ID that correlates the transcript from which the insights were generated. Read-only.
               nullable: true
             createdDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'Date and time at which the corresponding transcript was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
               format: date-time
               nullable: true
             endDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'Date and time at which the corresponding transcription ends. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
               format: date-time
               nullable: true
             meetingNotes:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.meetingNote'
-              description: The collection of AI-generated meeting notes. Read-only.
             viewpoint:
               $ref: '#/components/schemas/microsoft.graph.callAiInsightViewPoint'
           additionalProperties:
@@ -57077,49 +61406,6 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.attendanceRecord'
               description: List of attendance records of an attendance report. Read-only.
               x-ms-navigationProperty: true
-          additionalProperties:
-            type: object
-    microsoft.graph.callRecording:
-      allOf:
-        - $ref: '#/components/schemas/microsoft.graph.entity'
-        - title: callRecording
-          type: object
-          properties:
-            callId:
-              type: string
-              description: The unique identifier for the call that is related to this recording. Read-only.
-              nullable: true
-            content:
-              type: string
-              description: The content of the recording. Read-only.
-              format: base64url
-              nullable: true
-            contentCorrelationId:
-              type: string
-              description: The unique identifier that links the transcript with its corresponding recording. Read-only.
-              nullable: true
-            createdDateTime:
-              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
-              type: string
-              description: 'Date and time at which the recording was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
-              format: date-time
-              nullable: true
-            endDateTime:
-              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
-              type: string
-              description: 'Date and time at which the recording ends. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
-              format: date-time
-              nullable: true
-            meetingId:
-              type: string
-              description: The unique identifier of the onlineMeeting related to this recording. Read-only.
-              nullable: true
-            meetingOrganizer:
-              $ref: '#/components/schemas/microsoft.graph.identitySet'
-            recordingContentUrl:
-              type: string
-              description: The URL that can be used to access the content of the recording. Read-only.
-              nullable: true
           additionalProperties:
             type: object
     microsoft.graph.meetingRegistration:
@@ -57170,54 +61456,6 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.meetingRegistrationQuestion'
               description: Custom registration questions.
               x-ms-navigationProperty: true
-          additionalProperties:
-            type: object
-    microsoft.graph.callTranscript:
-      allOf:
-        - $ref: '#/components/schemas/microsoft.graph.entity'
-        - title: callTranscript
-          type: object
-          properties:
-            callId:
-              type: string
-              description: The unique identifier for the call that is related to this transcript. Read-only.
-              nullable: true
-            content:
-              type: string
-              description: The content of the transcript. Read-only.
-              format: base64url
-              nullable: true
-            contentCorrelationId:
-              type: string
-              description: The unique identifier that links the transcript with its corresponding recording. Read-only.
-              nullable: true
-            createdDateTime:
-              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
-              type: string
-              description: 'Date and time at which the transcript was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
-              format: date-time
-              nullable: true
-            endDateTime:
-              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
-              type: string
-              description: 'Date and time at which the transcription ends. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only.'
-              format: date-time
-              nullable: true
-            meetingId:
-              type: string
-              description: The unique identifier of the online meeting related to this transcript. Read-only.
-              nullable: true
-            meetingOrganizer:
-              $ref: '#/components/schemas/microsoft.graph.identitySet'
-            metadataContent:
-              type: string
-              description: The time-aligned metadata of the utterances in the transcript. Read-only.
-              format: base64url
-              nullable: true
-            transcriptContentUrl:
-              type: string
-              description: The URL that can be used to access the content of the transcript. Read-only.
-              nullable: true
           additionalProperties:
             type: object
     microsoft.graph.outlookCategory:
@@ -57403,6 +61641,11 @@ components:
               type: string
               description: The type of query. Examples include MicrosoftGraph and ARM.
               nullable: true
+            reviewerId:
+              type: string
+              nullable: true
+            scopeType:
+              $ref: '#/components/schemas/microsoft.graph.accessReviewReviewerScopeType'
           additionalProperties:
             type: object
     microsoft.graph.accessReviewScope:
@@ -57449,6 +61692,10 @@ components:
               description: 'The timestamp when the approval decision was applied. The DatetimeOffset type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Supports $select. Read-only.'
               format: date-time
               nullable: true
+            applyDescription:
+              type: string
+              description: The description of the apply result.
+              nullable: true
             applyResult:
               type: string
               description: 'The result of applying the decision. Possible values: New, AppliedSuccessfully, AppliedWithUnknownFailure, AppliedSuccessfullyButObjectNotFound, and ApplyNotSupported. Supports $select, $orderby, and $filter (eq only). Read-only.'
@@ -57461,6 +61708,8 @@ components:
               type: string
               description: Justification left by the reviewer when they made the decision.
               nullable: true
+            permission:
+              $ref: '#/components/schemas/microsoft.graph.accessReviewInstanceDecisionItemPermission'
             principal:
               $ref: '#/components/schemas/microsoft.graph.identity'
             principalLink:
@@ -57718,9 +61967,12 @@ components:
               description: 'The date and time at which the task is due. The timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z'
               format: date-time
               nullable: true
+            hasChat:
+              type: boolean
+              description: 'Read-only. This value is true if the task has chat messages associated with it. Otherwise, false.'
             hasDescription:
               type: boolean
-              description: 'Read-only. This value is true if the details object of the task has a nonempty description. Otherwise,false.'
+              description: 'Read-only. This value is true if the details object of the task has a nonempty description. Otherwise, false.'
               nullable: true
             isArchived:
               type: boolean
@@ -57741,11 +61993,12 @@ components:
             lastModifiedDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
+              description: 'Read-only. Date and time at which this is last modified. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z'
               format: date-time
               nullable: true
             orderHint:
               type: string
-              description: 'The hint used to order items of this type in a list view. For more information, see Using order hints in plannern.'
+              description: 'The hint used to order items of this type in a list view. For more information, see Using order hints in planner.'
               nullable: true
             percentComplete:
               maximum: 2147483647
@@ -57793,6 +62046,12 @@ components:
               $ref: '#/components/schemas/microsoft.graph.plannerBucketTaskBoardTaskFormat'
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerTaskDetails'
+            messages:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+              description: Read-only. Nullable. Chat messages associated with the task.
+              x-ms-navigationProperty: true
             progressTaskBoardFormat:
               $ref: '#/components/schemas/microsoft.graph.plannerProgressTaskBoardTaskFormat'
           additionalProperties:
@@ -57827,6 +62086,20 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.userWorkLocation:
+      title: userWorkLocation
+      type: object
+      properties:
+        placeId:
+          type: string
+          description: 'Identifier of the place, if applicable.'
+          nullable: true
+        source:
+          $ref: '#/components/schemas/microsoft.graph.workLocationSource'
+        workLocationType:
+          $ref: '#/components/schemas/microsoft.graph.workLocationType'
+      additionalProperties:
+        type: object
     microsoft.graph.userAccountInformation:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.itemFacet'
@@ -57841,8 +62114,12 @@ components:
               type: string
               description: Contains the two-character country code associated with the users' account.
               nullable: true
+            originTenantInfo:
+              $ref: '#/components/schemas/microsoft.graph.originTenantInfo'
             preferredLanguageTag:
               $ref: '#/components/schemas/microsoft.graph.localeInfo'
+            userPersona:
+              $ref: '#/components/schemas/microsoft.graph.userPersona'
             userPrincipalName:
               type: string
               description: The user principal name (UPN) of the user associated with the account.
@@ -58417,6 +62694,7 @@ components:
           properties:
             inPlaceArchiveMailboxId:
               type: string
+              description: The unique identifier for the user's In-Place Archive mailbox.
               nullable: true
             primaryMailboxId:
               type: string
@@ -58507,6 +62785,28 @@ components:
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
+    microsoft.graph.workHoursAndLocationsSetting:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: workHoursAndLocationsSetting
+          type: object
+          properties:
+            maxSharedWorkLocationDetails:
+              $ref: '#/components/schemas/microsoft.graph.maxWorkLocationDetails'
+            occurrences:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.workPlanOccurrence'
+              description: Collection of work plan occurrences.
+              x-ms-navigationProperty: true
+            recurrences:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.workPlanRecurrence'
+              description: Collection of recurring work plans defined by the user.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
     microsoft.graph.workingTimeSchedule:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -58529,6 +62829,49 @@ components:
           properties:
             chat:
               $ref: '#/components/schemas/microsoft.graph.chat'
+          additionalProperties:
+            type: object
+    microsoft.graph.teamworkSection:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: teamworkSection
+          type: object
+          properties:
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the section was created. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            displayIcon:
+              $ref: '#/components/schemas/microsoft.graph.sectionDisplayIcon'
+            displayName:
+              type: string
+              description: 'The display name of the section. Required. Maximum length is 50 characters. Display names are case-sensitive and must be unique within a user''s sections. The following names are reserved for system-defined sections and can''t be used when creating a user-defined section: RecentChats, QuickViews, TeamsAndChannels, MutedChats, MeetingChats, EngageCommunities.'
+            isExpanded:
+              type: boolean
+              description: Indicates whether the section is expanded in the user interface. The default value is true.
+              nullable: true
+            isHierarchicalViewEnabled:
+              type: boolean
+              description: Indicates whether the hierarchical view is enabled for the section. Read-only.
+              nullable: true
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the section was last modified. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            sectionType:
+              $ref: '#/components/schemas/microsoft.graph.sectionType'
+            sortType:
+              $ref: '#/components/schemas/microsoft.graph.sectionSortType'
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSectionItem'
+              description: 'The items (chats, channels, meetings, or communities) organized within the section.'
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.todoTaskList:
@@ -58554,6 +62897,12 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
+              x-ms-navigationProperty: true
+            singleValueExtendedProperties:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.singleValueExtendedProperty'
+              description: The collection of single-value extended properties defined for the task list. Read-only. Nullable.
               x-ms-navigationProperty: true
             tasks:
               type: array
@@ -58707,6 +63056,30 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.teamsApp:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: teamsApp
+          type: object
+          properties:
+            displayName:
+              type: string
+              description: The name of the catalog app provided by the app developer in the Microsoft Teams zip app package.
+              nullable: true
+            distributionMethod:
+              $ref: '#/components/schemas/microsoft.graph.teamsAppDistributionMethod'
+            externalId:
+              type: string
+              description: The ID of the catalog provided by the app developer in the Microsoft Teams zip app package.
+              nullable: true
+            appDefinitions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
+              description: The details for each version of the app.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
     microsoft.graph.teamsChannelPlanner:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -58758,30 +63131,6 @@ components:
           $ref: '#/components/schemas/microsoft.graph.teamsAppInstallationScopes'
       additionalProperties:
         type: object
-    microsoft.graph.teamsApp:
-      allOf:
-        - $ref: '#/components/schemas/microsoft.graph.entity'
-        - title: teamsApp
-          type: object
-          properties:
-            displayName:
-              type: string
-              description: The name of the catalog app provided by the app developer in the Microsoft Teams zip app package.
-              nullable: true
-            distributionMethod:
-              $ref: '#/components/schemas/microsoft.graph.teamsAppDistributionMethod'
-            externalId:
-              type: string
-              description: The ID of the catalog provided by the app developer in the Microsoft Teams zip app package.
-              nullable: true
-            appDefinitions:
-              type: array
-              items:
-                $ref: '#/components/schemas/microsoft.graph.teamsAppDefinition'
-              description: The details for each version of the app.
-              x-ms-navigationProperty: true
-          additionalProperties:
-            type: object
     microsoft.graph.teamsAppDefinition:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -59960,8 +64309,12 @@ components:
       title: file
       type: object
       properties:
+        archiveStatus:
+          $ref: '#/components/schemas/microsoft.graph.fileArchiveStatus'
         hashes:
           $ref: '#/components/schemas/microsoft.graph.hashes'
+        lockInfo:
+          $ref: '#/components/schemas/microsoft.graph.lockInfo'
         mimeType:
           type: string
           description: The MIME type for the file. This is determined by logic on the server and might not be the value provided when the file was uploaded. Read-only.
@@ -60407,6 +64760,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.workbookComment'
+              description: Represents a collection of comments in a workbook.
               x-ms-navigationProperty: true
             functions:
               $ref: '#/components/schemas/microsoft.graph.workbookFunctions'
@@ -60839,6 +65193,22 @@ components:
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
+    microsoft.graph.sharePointGroupIdentity:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.identity'
+        - title: sharePointGroupIdentity
+          type: object
+          properties:
+            principalId:
+              type: string
+              description: The principal ID of the SharePoint group in the tenant. Read-only.
+              nullable: true
+            title:
+              type: string
+              description: The title of the SharePoint group. Read-only.
+              nullable: true
+          additionalProperties:
+            type: object
     microsoft.graph.sharePointIdentity:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.identity'
@@ -60900,6 +65270,60 @@ components:
               $ref: '#/components/schemas/microsoft.graph.termStore.set'
             toTerm:
               $ref: '#/components/schemas/microsoft.graph.termStore.term'
+          additionalProperties:
+            type: object
+    microsoft.graph.cloudLicensing.allotment:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: allotment
+          type: object
+          properties:
+            allottedUnits:
+              maximum: 2147483647
+              minimum: -2147483648
+              type: number
+              description: The number of licenses contained within the allotment. Not nullable. Read-only.
+              format: int32
+            assignableTo:
+              $ref: '#/components/schemas/microsoft.graph.cloudLicensing.assigneeTypes'
+            consumedUnits:
+              maximum: 2147483647
+              minimum: -2147483648
+              type: number
+              description: The number of licenses that are currently consumed by assignments from this allotment. Not nullable. Read-only.
+              format: int32
+            services:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudLicensing.service'
+              description: The list of services that might be enabled or disabled for assignments from this allotment. Not nullable. Read-only.
+            skuId:
+              pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+              type: string
+              description: Unique identifier (GUID) for the service SKU that is equal to the skuId property on the related subscribedSku object. Read-only. Supports $filter.
+              format: uuid
+              nullable: true
+            skuPartNumber:
+              type: string
+              description: 'Unique SKU display name that is equal to the skuPartNumber on the related subscribedSku object; for example, AAD_Premium. Read-only.'
+              nullable: true
+            subscriptions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudLicensing.subscription'
+              description: Basic information about the subscriptions that supports this allotment.
+            assignments:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudLicensing.assignment'
+              description: The list of license assignments that consume licenses from this allotment. Not nullable.
+              x-ms-navigationProperty: true
+            waitingMembers:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudLicensing.waitingMember'
+              description: List of over-assigned users who are in the waiting room for an allotment due to license capacity limits.
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.cloudLicensing.service:
@@ -61114,6 +65538,26 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.contentSensitivityLabelAssignment:
+      title: contentSensitivityLabelAssignment
+      type: object
+      properties:
+        assignmentMethod:
+          $ref: '#/components/schemas/microsoft.graph.sensitivityLabelAssignmentMethod'
+        justificationText:
+          type: string
+          description: The justification text provided when you change the sensitivity label. Used during label downgrade to document the reason. Optional.
+          nullable: true
+        sensitivityLabelId:
+          type: string
+          description: The unique identifier of the sensitivity label applied to the content. This ID corresponds to a label defined in the Microsoft Information Protection policy.
+          nullable: true
+        tenantId:
+          type: string
+          description: The unique identifier of the tenant where the sensitivity label is defined and applied.
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.plannerPlanContextCollection:
       title: plannerPlanContextCollection
       type: object
@@ -61286,6 +65730,7 @@ components:
         - uploadFile
         - downloadText
         - downloadFile
+        - copyToClipboard
         - unknownFutureValue
       type: string
     microsoft.graph.contentBase:
@@ -61293,6 +65738,13 @@ components:
       type: object
       additionalProperties:
         type: object
+    microsoft.graph.contentCategory:
+      title: contentCategory
+      enum:
+        - none
+        - ai
+        - unknownFutureValue
+      type: string
     microsoft.graph.dlpAction:
       title: dlpAction
       enum:
@@ -61308,6 +65760,7 @@ components:
         - sPRuntimeAccessControl
         - sPSharingNotifyUser
         - sPSharingGenerateIncidentReport
+        - restrictWebGrounding
       type: string
     microsoft.graph.contentProcessingErrorType:
       title: contentProcessingErrorType
@@ -61411,6 +65864,19 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.security.huntingSchemaFunctionParameter:
+      title: huntingSchemaFunctionParameter
+      type: object
+      properties:
+        cslType:
+          type: string
+        defaultValue:
+          type: string
+          nullable: true
+        name:
+          type: string
+      additionalProperties:
+        type: object
     microsoft.graph.security.impactedAsset:
       title: impactedAsset
       type: object
@@ -61422,6 +65888,42 @@ components:
         - deviceGroup
         - unknownFutureValue
       type: string
+    microsoft.graph.security.securityCopilot.skillTypeDescriptor:
+      title: skillTypeDescriptor
+      type: object
+      properties:
+        name:
+          type: string
+          description: Unsupported.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.userSet:
+      title: userSet
+      type: object
+      properties:
+        isBackup:
+          type: boolean
+          description: 'For a user in an approval stage, this property indicates whether the user is a backup fallback approver.'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.requestSchedule:
+      title: requestSchedule
+      type: object
+      properties:
+        expiration:
+          $ref: '#/components/schemas/microsoft.graph.expirationPattern'
+        recurrence:
+          $ref: '#/components/schemas/microsoft.graph.patternedRecurrence'
+        startDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. In PIM, when the  eligible or active assignment becomes active.'
+          format: date-time
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.printerBase:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -61707,6 +66209,7 @@ components:
           properties:
             displayName:
               type: string
+              description: Display name for the client application.
               nullable: true
           additionalProperties:
             type: object
@@ -61819,6 +66322,13 @@ components:
         - notAttested
         - unknownFutureValue
       type: string
+    microsoft.graph.passkeyType:
+      title: passkeyType
+      enum:
+        - deviceBound
+        - synced
+        - unknownFutureValue
+      type: string
     microsoft.graph.webauthnPublicKeyCredential:
       title: webauthnPublicKeyCredential
       type: object
@@ -61843,6 +66353,12 @@ components:
               $ref: '#/components/schemas/microsoft.graph.identity'
             hashFunction:
               $ref: '#/components/schemas/microsoft.graph.hardwareOathTokenHashFunction'
+            lastUsedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time the authentication method was last used by the user. Read-only. Optional. This optional value is null if the authentication method doesn''t populate it. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
             manufacturer:
               type: string
               description: Manufacturer name of the hardware token. Supports $filter (eq).
@@ -62180,6 +66696,13 @@ components:
           description: For a list of possible values see formatName values.
       additionalProperties:
         type: object
+    microsoft.graph.cloudPcProvisioningPolicyImageType:
+      title: cloudPcProvisioningPolicyImageType
+      enum:
+        - gallery
+        - custom
+        - unknownFutureValue
+      type: string
     microsoft.graph.cloudPcHealthCheckItem:
       title: cloudPcHealthCheckItem
       type: object
@@ -62209,6 +66732,8 @@ components:
         - availableWithWarning
         - unavailable
         - unknownFutureValue
+        - underServiceMaintenance
+        - inUse
       type: string
     microsoft.graph.cloudPcDisasterRecoveryCapabilityType:
       title: cloudPcDisasterRecoveryCapabilityType
@@ -62406,7 +66931,7 @@ components:
             createdDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: The timestamp when the role was assigned to the user.
+              description: 'The date and time when the role was assigned to the user. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
               format: date-time
               readOnly: true
             userId:
@@ -62427,6 +66952,28 @@ components:
         - completed
         - unknownFutureValue
       type: string
+    microsoft.graph.storylineFollower:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: storylineFollower
+          type: object
+          properties:
+            follower:
+              $ref: '#/components/schemas/microsoft.graph.engagementIdentitySet'
+          additionalProperties:
+            type: object
+          description: Engagement storyline follower.
+    microsoft.graph.storylineFollowing:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: storylineFollowing
+          type: object
+          properties:
+            following:
+              $ref: '#/components/schemas/microsoft.graph.engagementIdentitySet'
+          additionalProperties:
+            type: object
+          description: Engagement storyline following.
     microsoft.graph.sharedInsight:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -62686,6 +67233,16 @@ components:
         - failed
         - unknownFutureValue
       type: string
+    microsoft.graph.structuredDataEntry:
+      title: structuredDataEntry
+      type: object
+      properties:
+        keyEntry:
+          $ref: '#/components/schemas/microsoft.graph.structuredDataEntryTypedValue'
+        valueEntry:
+          $ref: '#/components/schemas/microsoft.graph.structuredDataEntryTypedValue'
+      additionalProperties:
+        type: object
     microsoft.graph.managedAppLogUploadState:
       title: managedAppLogUploadState
       enum:
@@ -63889,6 +68446,21 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.cloudVideoInteropInfo:
+      title: cloudVideoInteropInfo
+      type: object
+      properties:
+        moreInfoWebUrl:
+          type: string
+          nullable: true
+        tenantKey:
+          type: string
+          nullable: true
+        videoTeleconferenceId:
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.joinMeetingIdSettings:
       title: joinMeetingIdSettings
       type: object
@@ -63917,6 +68489,16 @@ components:
           nullable: true
         scope:
           $ref: '#/components/schemas/microsoft.graph.lobbyBypassScope'
+      additionalProperties:
+        type: object
+    microsoft.graph.onlineMeetingSensitivityLabelAssignment:
+      title: onlineMeetingSensitivityLabelAssignment
+      type: object
+      properties:
+        sensitivityLabelId:
+          type: string
+          description: Id of the sensitivity label that is applied to the Teams meeting.
+          nullable: true
       additionalProperties:
         type: object
     microsoft.graph.meetingChatHistoryDefaultMode:
@@ -63988,15 +68570,12 @@ components:
       properties:
         ownerDisplayName:
           type: string
-          description: The display name of the owner of the action item.
           nullable: true
         text:
           type: string
-          description: The text content of the action item.
           nullable: true
         title:
           type: string
-          description: The title of the action item.
           nullable: true
       additionalProperties:
         type: object
@@ -64008,14 +68587,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.meetingNoteSubpoint'
-          description: A collection of subpoints of the meeting note.
         text:
           type: string
-          description: The text of the meeting note.
           nullable: true
         title:
           type: string
-          description: The title of the meeting note.
           nullable: true
       additionalProperties:
         type: object
@@ -64027,7 +68603,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.mentionEvent'
-          description: The collection of AI-generated mention events.
       additionalProperties:
         type: object
     microsoft.graph.virtualEventExternalInformation:
@@ -64059,6 +68634,11 @@ components:
               type: string
               description: Email address of the user associated with this attendance record.
               nullable: true
+            engagements:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.meetingEngagement'
+              description: The list of real-time participant interaction behaviors during a meeting.
             externalRegistrationInformation:
               $ref: '#/components/schemas/microsoft.graph.virtualEventExternalRegistrationInformation'
             identity:
@@ -64073,7 +68653,7 @@ components:
               nullable: true
             role:
               type: string
-              description: 'Role of the attendee. Possible values are: None, Attendee, Presenter, and Organizer.'
+              description: 'Role of the attendee. The possible values are: None, Attendee, Presenter, and Organizer.'
               nullable: true
             totalAttendanceInSeconds:
               maximum: 2147483647
@@ -64191,6 +68771,18 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.accessReviewReviewerScopeType:
+      title: accessReviewReviewerScopeType
+      enum:
+        - user
+        - group
+        - self
+        - manager
+        - sponsor
+        - resourceOwner
+        - managerOrSponsor
+        - unknownFutureValue
+      type: string
     microsoft.graph.userIdentity:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.identity'
@@ -64207,6 +68799,28 @@ components:
               nullable: true
           additionalProperties:
             type: object
+    microsoft.graph.accessReviewInstanceDecisionItemPermission:
+      title: accessReviewInstanceDecisionItemPermission
+      type: object
+      properties:
+        description:
+          type: string
+          description: The description of the permission.
+          nullable: true
+        displayName:
+          type: string
+          description: The display name of the permission.
+          nullable: true
+        id:
+          type: string
+          description: The identifier of the permission.
+          nullable: true
+        type:
+          type: string
+          description: The type of the permission.
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.decisionItemPrincipalResourceMembership:
       title: decisionItemPrincipalResourceMembership
       type: object
@@ -64219,6 +68833,10 @@ components:
       title: accessReviewInstanceDecisionItemResource
       type: object
       properties:
+        description:
+          type: string
+          description: Description of the resource
+          nullable: true
         displayName:
           type: string
           description: Display name of the resource
@@ -64229,7 +68847,7 @@ components:
           nullable: true
         type:
           type: string
-          description: 'Type of resource. Types include: Group, ServicePrincipal, DirectoryRole, AzureRole, AccessPackageAssignmentPolicy.'
+          description: 'Type of resource. Types include: Group, ServicePrincipal, DirectoryRole, AzureRole, AccessPackageAssignmentPolicy, and CustomDataProvidedResource.'
           nullable: true
       additionalProperties:
         type: object
@@ -64293,6 +68911,9 @@ components:
           type: number
           description: 'Duration of each recurrence of review (accessReviewInstance) in number of days. NOTE: If the stageSettings of the accessReviewScheduleDefinition object is defined, its durationInDays setting will be used instead of the value of this property.'
           format: int32
+        isAgenticExperienceEnabled:
+          type: boolean
+          nullable: true
         justificationRequiredOnApproval:
           type: boolean
           description: Indicates whether reviewers are required to provide justification with their decision. Default value is false.
@@ -64492,6 +69113,51 @@ components:
               $ref: '#/components/schemas/microsoft.graph.plannerExternalReferences'
           additionalProperties:
             type: object
+    microsoft.graph.plannerTaskChatMessage:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: plannerTaskChatMessage
+          type: object
+          properties:
+            content:
+              type: string
+              description: The content of the chat message. Supports plain text and sanitized HTML.
+              nullable: true
+            createdBy:
+              $ref: '#/components/schemas/microsoft.graph.identitySet'
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time when the message was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+            deletedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              format: date-time
+              nullable: true
+            editedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              format: date-time
+              nullable: true
+            mentions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMention'
+              description: The list of mentions in the message.
+            messageType:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessageType'
+            parentEntityId:
+              type: string
+              description: The ID of the parent plannerTask that this message belongs to.
+              nullable: true
+            reactions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatReaction'
+              description: The reactions on the message.
+          additionalProperties:
+            type: object
     microsoft.graph.plannerProgressTaskBoardTaskFormat:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.plannerDelta'
@@ -64504,6 +69170,24 @@ components:
               nullable: true
           additionalProperties:
             type: object
+    microsoft.graph.workLocationSource:
+      title: workLocationSource
+      enum:
+        - none
+        - manual
+        - scheduled
+        - automatic
+        - unknownFutureValue
+      type: string
+    microsoft.graph.workLocationType:
+      title: workLocationType
+      enum:
+        - unspecified
+        - office
+        - remote
+        - timeOff
+        - unknownFutureValue
+      type: string
     microsoft.graph.itemFacet:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -64542,6 +69226,30 @@ components:
               description: Where the values within an entity originated if synced from another source.
           additionalProperties:
             type: object
+    microsoft.graph.originTenantInfo:
+      title: originTenantInfo
+      type: object
+      properties:
+        originTenantId:
+          type: string
+          description: The identifier of the tenant where the user account was originally provisioned.
+          nullable: true
+        originUserId:
+          type: string
+          description: The identifier of the user in the origin tenant.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.userPersona:
+      title: userPersona
+      enum:
+        - unknown
+        - externalMember
+        - externalGuest
+        - internalMember
+        - internalGuest
+        - unknownFutureValue
+      type: string
     microsoft.graph.personAnnualEventType:
       title: personAnnualEventType
       enum:
@@ -64577,7 +69285,7 @@ components:
       properties:
         abbreviation:
           type: string
-          description: 'Shortened name of the degree or program (example: PhD, MBA)'
+          description: 'Shortened name of the degree or program, for example, PhD and MBA.'
           nullable: true
         activities:
           type: array
@@ -64604,14 +69312,14 @@ components:
           items:
             type: string
             nullable: true
-          description: Majors and minors associated with the program. (if applicable)
+          description: 'Majors and minors associated with the program, if applicable.'
         grade:
           type: string
-          description: 'The final grade, class, GPA, or score.'
+          description: 'The final grade, class, grade point average (GPA), or score.'
           nullable: true
         notes:
           type: string
-          description: More notes the user provided.
+          description: More notes provided by the user.
           nullable: true
         webUrl:
           type: string
@@ -64681,6 +69389,14 @@ components:
           type: string
           description: A description for the position in question.
           nullable: true
+        employeeId:
+          type: string
+          description: The identifier assigned to the employee.
+          nullable: true
+        employeeType:
+          type: string
+          description: The type of employment for the position.
+          nullable: true
         endMonthYear:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$'
           type: string
@@ -64736,6 +69452,10 @@ components:
           type: string
           description: 'Legal entity number of the company or its subdivision. For information on how to set the value for the companyCode, see profileSourceAnnotation.'
           nullable: true
+        costCenter:
+          type: string
+          description: The cost center associated with the company or department.
+          nullable: true
         department:
           type: string
           description: Department Name within a company.
@@ -64743,6 +69463,10 @@ components:
         displayName:
           type: string
           description: Company name.
+          nullable: true
+        division:
+          type: string
+          description: The division within the company.
           nullable: true
         officeLocation:
           type: string
@@ -64957,6 +69681,59 @@ components:
               description: Base64-encoded JSON setting value.
           additionalProperties:
             type: object
+    microsoft.graph.maxWorkLocationDetails:
+      title: maxWorkLocationDetails
+      enum:
+        - unknown
+        - none
+        - approximate
+        - specific
+        - unknownFutureValue
+      type: string
+    microsoft.graph.workPlanOccurrence:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: workPlanOccurrence
+          type: object
+          properties:
+            end:
+              $ref: '#/components/schemas/microsoft.graph.dateTimeTimeZone'
+            placeId:
+              type: string
+              description: Identifier of a place from the Microsoft Graph Places Directory API. Only applicable when workLocationType is set to office.
+              nullable: true
+            recurrenceId:
+              type: string
+              description: The identifier of the parent recurrence pattern that generated this occurrence. The value is null for time-off occurrences because they don't have a parent recurrence.
+              nullable: true
+            start:
+              $ref: '#/components/schemas/microsoft.graph.dateTimeTimeZone'
+            timeOffDetails:
+              $ref: '#/components/schemas/microsoft.graph.timeOffDetails'
+            workLocationType:
+              $ref: '#/components/schemas/microsoft.graph.workLocationType'
+          additionalProperties:
+            type: object
+    microsoft.graph.workPlanRecurrence:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: workPlanRecurrence
+          type: object
+          properties:
+            end:
+              $ref: '#/components/schemas/microsoft.graph.dateTimeTimeZone'
+            placeId:
+              type: string
+              description: Identifier of a place from the Microsoft Graph Places Directory API. Only applicable when workLocationType is set to office.
+              nullable: true
+            recurrence:
+              $ref: '#/components/schemas/microsoft.graph.patternedRecurrence'
+            start:
+              $ref: '#/components/schemas/microsoft.graph.dateTimeTimeZone'
+            workLocationType:
+              $ref: '#/components/schemas/microsoft.graph.workLocationType'
+          additionalProperties:
+            type: object
     microsoft.graph.teamInfo:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -64975,6 +69752,63 @@ components:
               $ref: '#/components/schemas/microsoft.graph.team'
           additionalProperties:
             type: object
+    microsoft.graph.sectionDisplayIcon:
+      title: sectionDisplayIcon
+      type: object
+      properties:
+        contentUrl:
+          type: string
+          description: The URL to a custom icon image. Applicable when iconType is custom.
+          nullable: true
+        displayName:
+          type: string
+          description: The human-readable name of the icon.
+          nullable: true
+        iconType:
+          type: string
+          description: 'The type of icon. Use an emoji character such as 👍 for an emoji icon, or custom for a custom image icon.'
+        skinTone:
+          $ref: '#/components/schemas/microsoft.graph.sectionIconSkinTone'
+      additionalProperties:
+        type: object
+    microsoft.graph.sectionType:
+      title: sectionType
+      enum:
+        - userDefined
+        - systemDefined
+        - unknownFutureValue
+      type: string
+    microsoft.graph.sectionSortType:
+      title: sectionSortType
+      enum:
+        - mostRecent
+        - unreadThenMostRecent
+        - nameAlphabetical
+        - userDefinedCustomOrder
+        - unknownFutureValue
+      type: string
+    microsoft.graph.teamworkSectionItem:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: teamworkSectionItem
+          type: object
+          properties:
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the item was added to the section. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            itemType:
+              $ref: '#/components/schemas/microsoft.graph.sectionItemType'
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the item was last modified. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+          additionalProperties:
+            type: object
     microsoft.graph.wellknownListName:
       title: wellknownListName
       enum:
@@ -64983,6 +69817,18 @@ components:
         - flaggedEmails
         - unknownFutureValue
       type: string
+    microsoft.graph.singleValueExtendedProperty:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: singleValueExtendedProperty
+          type: object
+          properties:
+            value:
+              type: string
+              description: The value of the property.
+              nullable: true
+          additionalProperties:
+            type: object
     microsoft.graph.todoTask:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -65070,6 +69916,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.singleValueExtendedProperty'
+              description: A collection of custom fields linked to the task.
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
@@ -65094,6 +69941,12 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.virtualEventExternalInformation'
               description: 'The external information of a virtual event. Returned only for event organizers or coorganizers; otherwise, null.'
+            isRegistrationEnabled:
+              type: boolean
+              nullable: true
+            isRegistrationRequired:
+              type: boolean
+              nullable: true
             settings:
               $ref: '#/components/schemas/microsoft.graph.virtualEventSettings'
             startDateTime:
@@ -65138,13 +69991,6 @@ components:
         - $ref: '#/components/schemas/microsoft.graph.virtualEventRegistrationConfiguration'
         - title: virtualEventWebinarRegistrationConfiguration
           type: object
-          properties:
-            isManualApprovalEnabled:
-              type: boolean
-              nullable: true
-            isWaitlistEnabled:
-              type: boolean
-              nullable: true
           additionalProperties:
             type: object
     microsoft.graph.virtualEventRegistration:
@@ -65224,6 +70070,14 @@ components:
         - moderators
         - unknownFutureValue
       type: string
+    microsoft.graph.teamsAppDistributionMethod:
+      title: teamsAppDistributionMethod
+      enum:
+        - store
+        - organization
+        - sideloaded
+        - unknownFutureValue
+      type: string
     microsoft.graph.teamsAppResourceSpecificPermission:
       title: teamsAppResourceSpecificPermission
       type: object
@@ -65246,14 +70100,6 @@ components:
       type: string
       x-ms-enum-flags:
         isFlags: true
-    microsoft.graph.teamsAppDistributionMethod:
-      title: teamsAppDistributionMethod
-      enum:
-        - store
-        - organization
-        - sideloaded
-        - unknownFutureValue
-      type: string
     microsoft.graph.teamsAppAuthorization:
       title: teamsAppAuthorization
       type: object
@@ -65992,6 +70838,14 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.fileArchiveStatus:
+      title: fileArchiveStatus
+      enum:
+        - notArchived
+        - fullyArchived
+        - reactivating
+        - unknownFutureValue
+      type: string
     microsoft.graph.hashes:
       title: hashes
       type: object
@@ -66012,6 +70866,28 @@ components:
           type: string
           description: This property isn't supported. Don't use.
           nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.lockInfo:
+      title: lockInfo
+      type: object
+      properties:
+        createdDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        expirationDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        lockType:
+          $ref: '#/components/schemas/microsoft.graph.lockType'
+        owners:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.userIdentity'
       additionalProperties:
         type: object
     microsoft.graph.folderView:
@@ -66198,7 +71074,7 @@ components:
           properties:
             calculationMode:
               type: string
-              description: 'Returns the calculation mode used in the workbook. Possible values are: Automatic, AutomaticExceptTables, Manual.'
+              description: 'Returns the calculation mode used in the workbook. The possible values are: Automatic, AutomaticExceptTables, Manual.'
           additionalProperties:
             type: object
     microsoft.graph.workbookComment:
@@ -66207,13 +71083,26 @@ components:
         - title: workbookComment
           type: object
           properties:
+            cellAddress:
+              type: string
+              description: 'The cell where the comment is located. The address value is in A1-style, which contains the sheet reference (for example, Sheet1!A1). Read-only.'
+              nullable: true
             content:
               type: string
-              description: The content of the comment.
+              description: The content of the comment that is the String displayed to end-users.
               nullable: true
             contentType:
               type: string
-              description: The content type of the comment.
+              description: 'The content type of the comment. Supported values are: plain, mention.'
+            mentions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.workbookCommentMention'
+              description: 'A collection that contains all the people mentioned within the comment. When contentType is plain, this property is an empty array. Read-only.'
+            richContent:
+              type: string
+              description: 'The rich content of the comment (for example, comment content with mentions, where the first mentioned entity has an ID attribute of 0 and the second has an ID attribute of 1). When contentType is plain, this property is empty. Read-only.'
+              nullable: true
             replies:
               type: array
               items:
@@ -66250,7 +71139,7 @@ components:
               description: Indicates whether the name is scoped to the workbook or to a specific worksheet. Read-only.
             type:
               type: string
-              description: 'The type of reference is associated with the name. Possible values are: String, Integer, Double, Boolean, Range. Read-only.'
+              description: 'The type of reference is associated with the name. The possible values are: String, Integer, Double, Boolean, Range. Read-only.'
               nullable: true
             value:
               $ref: '#/components/schemas/microsoft.graph.Json'
@@ -66314,7 +71203,7 @@ components:
               description: Indicates whether the total row is visible or not. This value can be set to show or remove the total row.
             style:
               type: string
-              description: 'A constant value that represents the Table style. Possible values are: TableStyleLight1 through TableStyleLight21, TableStyleMedium1 through TableStyleMedium28, TableStyleStyleDark1 through TableStyleStyleDark11. A custom user-defined style present in the workbook can also be specified.'
+              description: 'A constant value that represents the Table style. The possible values are: TableStyleLight1 through TableStyleLight21, TableStyleMedium1 through TableStyleMedium28, TableStyleStyleDark1 through TableStyleStyleDark11. A custom user-defined style present in the workbook can also be specified.'
               nullable: true
             columns:
               type: array
@@ -66552,6 +71441,29 @@ components:
       type: string
       x-ms-enum-flags:
         isFlags: true
+    microsoft.graph.cloudLicensing.subscription:
+      title: subscription
+      type: object
+      properties:
+        nextLifecycleDate:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$'
+          type: string
+          description: The date on which the current state transitions to the next state.
+          format: date
+        startDate:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$'
+          type: string
+          description: The date when the subscription started.
+          format: date
+        state:
+          $ref: '#/components/schemas/microsoft.graph.cloudLicensing.subscriptionState'
+        subscriptionId:
+          type: string
+          description: Identifier for the subscription object.
+        tags:
+          $ref: '#/components/schemas/microsoft.graph.cloudLicensing.subscriptionTags'
+      additionalProperties:
+        type: object
     microsoft.graph.attendeeType:
       title: attendeeType
       enum:
@@ -66597,6 +71509,14 @@ components:
         - teamsChannel
         - onlineMeeting
         - plannerTask
+      type: string
+    microsoft.graph.sensitivityLabelAssignmentMethod:
+      title: sensitivityLabelAssignmentMethod
+      enum:
+        - standard
+        - privileged
+        - auto
+        - unknownFutureValue
       type: string
     microsoft.graph.plannerCreationSourceKind:
       title: plannerCreationSourceKind
@@ -66786,6 +71706,26 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.expirationPattern:
+      title: expirationPattern
+      type: object
+      properties:
+        duration:
+          pattern: '^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$'
+          type: string
+          description: 'The requestor''s desired duration of access represented in ISO 8601 format for durations. For example, PT3H refers to three hours.  If specified in a request, endDateTime shouldn''t be present and the type property should be set to afterDuration.'
+          format: duration
+          nullable: true
+        endDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Timestamp of date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014, is 2014-01-01T00:00:00Z.'
+          format: date-time
+          nullable: true
+        type:
+          $ref: '#/components/schemas/microsoft.graph.expirationPatternType'
+      additionalProperties:
+        type: object
     microsoft.graph.printerCapabilities:
       title: printerCapabilities
       type: object
@@ -66872,13 +71812,13 @@ components:
           items:
             type: string
             nullable: true
-          description: 'The media (that is, paper) colors supported by the printer.'
+          description: 'The media (for example, paper) colors supported by the printer.'
         mediaSizes:
           type: array
           items:
             type: string
             nullable: true
-          description: The media sizes supported by the printer. Supports standard size names for ISO and ANSI media sizes. Valid values are in the following table.
+          description: 'The media sizes supported by the printer. Supports standard size names for ISO and ANSI media sizes. For the list of supported values, see mediaSizes values.'
         mediaTypes:
           type: array
           items:
@@ -67317,12 +72257,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.keyCredentialConfiguration'
-          x-ms-navigationProperty: true
+          description: Collection of certificate restrictions settings to be applied to an application or service principal.
         passwordCredentials:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.passwordCredentialConfiguration'
-          x-ms-navigationProperty: true
+          description: Collection of password restrictions settings to be applied to an application or service principal.
       additionalProperties:
         type: object
     microsoft.graph.customAppManagementApplicationConfiguration:
@@ -67333,6 +72273,8 @@ components:
           $ref: '#/components/schemas/microsoft.graph.audiencesConfiguration'
         identifierUris:
           $ref: '#/components/schemas/microsoft.graph.identifierUriConfiguration'
+        redirectUris:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriConfiguration'
       additionalProperties:
         type: object
     microsoft.graph.customClaimConfiguration:
@@ -67775,6 +72717,19 @@ components:
           - value: exclude
             description: 'Indicates out-filter, rule matching will not offer the payload to devices.'
             name: exclude
+    microsoft.graph.engagementIdentitySet:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.identitySet'
+        - title: engagementIdentitySet
+          type: object
+          properties:
+            audience:
+              $ref: '#/components/schemas/microsoft.graph.identity'
+            group:
+              $ref: '#/components/schemas/microsoft.graph.identity'
+          additionalProperties:
+            type: object
+          description: The Viva Engage identities.
     microsoft.graph.sharingDetail:
       title: sharingDetail
       type: object
@@ -67903,6 +72858,19 @@ components:
           description: The minimum size (in kilobytes) that an incoming message must have in order for a condition or exception to apply.
           format: int32
           nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.structuredDataEntryTypedValue:
+      title: structuredDataEntryTypedValue
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/microsoft.graph.structuredDataEntryValueType'
+        values:
+          type: array
+          items:
+            type: string
+          description: 'Represents the value. The contained elements might be one of the following cases: when the type is stringArray, it contains arbitrary string values; otherwise, it contains exactly one string value. The caller is responsible for data type conversion.'
       additionalProperties:
         type: object
     microsoft.graph.settingSource:
@@ -68334,11 +73302,9 @@ components:
       properties:
         text:
           type: string
-          description: The text of the meeting note subpoint.
           nullable: true
         title:
           type: string
-          description: The title of the meeting note subpoint.
           nullable: true
       additionalProperties:
         type: object
@@ -68349,14 +73315,12 @@ components:
         eventDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
-          description: 'The date and time of the mention event. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
           format: date-time
           nullable: true
         speaker:
           $ref: '#/components/schemas/microsoft.graph.identitySet'
         transcriptUtterance:
           type: string
-          description: The utterance in the online meeting transcript that contains the mention event.
           nullable: true
       additionalProperties:
         type: object
@@ -68383,6 +73347,24 @@ components:
           description: The time the attendee left in UTC.
           format: date-time
           nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.meetingEngagement:
+      title: meetingEngagement
+      type: object
+      properties:
+        dateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The UTC date and time when the engagement event occurred, in ISO 8601 format.'
+          format: date-time
+          nullable: true
+        engagementSubType:
+          type: string
+          description: 'The specific engagement action within the type (e.g., like, love, applause, laugh, surprised for reactions; raiseHand for hand; cameraOn for camera; unmute, mute for microphone).'
+          nullable: true
+        engagementType:
+          $ref: '#/components/schemas/microsoft.graph.meetingEngagementType'
       additionalProperties:
         type: object
     microsoft.graph.virtualEventExternalRegistrationInformation:
@@ -68538,6 +73520,45 @@ components:
       type: object
       additionalProperties:
         type: object
+    microsoft.graph.plannerTaskChatMention:
+      title: plannerTaskChatMention
+      type: object
+      properties:
+        mentioned:
+          type: string
+          description: The ID of the mentioned user.
+          nullable: true
+        mentionType:
+          $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMentionType'
+        position:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: The zero-based position of the mention in the message content.
+          format: int32
+      additionalProperties:
+        type: object
+    microsoft.graph.plannerTaskChatMessageType:
+      title: plannerTaskChatMessageType
+      enum:
+        - richTextHtml
+        - plainText
+        - unknownFutureValue
+      type: string
+    microsoft.graph.plannerTaskChatReaction:
+      title: plannerTaskChatReaction
+      type: object
+      properties:
+        reactionEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.plannerTaskChatReactionEvent'
+        reactionType:
+          type: string
+          description: 'The type of reaction, such as like, heart, or emoji characters.'
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.allowedAudiences:
       title: allowedAudiences
       enum:
@@ -68661,6 +73682,38 @@ components:
           type: object
           additionalProperties:
             type: object
+    microsoft.graph.timeOffDetails:
+      title: timeOffDetails
+      type: object
+      properties:
+        isAllDay:
+          type: boolean
+          description: Indicates whether the time-off entry spans the entire day.
+        subject:
+          type: string
+          description: The subject or reason for the time-off entry.
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.sectionIconSkinTone:
+      title: sectionIconSkinTone
+      enum:
+        - light
+        - mediumLight
+        - medium
+        - mediumDark
+        - dark
+        - unknownFutureValue
+      type: string
+    microsoft.graph.sectionItemType:
+      title: sectionItemType
+      enum:
+        - chat
+        - channel
+        - meeting
+        - community
+        - unknownFutureValue
+      type: string
     microsoft.graph.attachmentBase:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -68765,17 +73818,6 @@ components:
               nullable: true
           additionalProperties:
             type: object
-    microsoft.graph.singleValueExtendedProperty:
-      allOf:
-        - $ref: '#/components/schemas/microsoft.graph.entity'
-        - title: singleValueExtendedProperty
-          type: object
-          properties:
-            value:
-              type: string
-              nullable: true
-          additionalProperties:
-            type: object
     microsoft.graph.communicationsIdentitySet:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.identitySet'
@@ -68845,6 +73887,13 @@ components:
         - title: virtualEventSession
           type: object
           properties:
+            capacity:
+              maximum: 2147483647
+              minimum: -2147483648
+              type: number
+              description: Represents the expected number of attendees for town hall session.
+              format: int32
+              nullable: true
             endDateTime:
               $ref: '#/components/schemas/microsoft.graph.dateTimeTimeZone'
             startDateTime:
@@ -68877,6 +73926,14 @@ components:
               type: number
               description: Total capacity of the virtual event.
               format: int32
+              nullable: true
+            isManualApprovalEnabled:
+              type: boolean
+              description: Indicates whether registrations require organizer approval before a participant is confirmed.
+              nullable: true
+            isWaitlistEnabled:
+              type: boolean
+              description: Indicates whether more registrants are automatically placed on a waitlist when capacity is reached.
               nullable: true
             registrationWebUrl:
               type: string
@@ -69033,6 +74090,14 @@ components:
           $ref: '#/components/schemas/microsoft.graph.scheduleEntityTheme'
       additionalProperties:
         type: object
+    microsoft.graph.lockType:
+      title: lockType
+      enum:
+        - none
+        - exclusive
+        - shared
+        - unknownFutureValue
+      type: string
     microsoft.graph.mediaSourceContentCategory:
       title: mediaSourceContentCategory
       enum:
@@ -69075,6 +74140,26 @@ components:
           $ref: '#/components/schemas/microsoft.graph.linkScopeAbilities'
       additionalProperties:
         type: object
+    microsoft.graph.workbookCommentMention:
+      title: workbookCommentMention
+      type: object
+      properties:
+        email:
+          type: string
+          description: Represents the email address of the person that is mentioned in a comment.
+          nullable: true
+        id:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: Represents the ID of the person that is mentioned in a comment.
+          format: int32
+        name:
+          type: string
+          description: Represents the display name of the person that is mentioned in a comment.
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.workbookCommentReply:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -69083,11 +74168,20 @@ components:
           properties:
             content:
               type: string
-              description: The content of the reply.
+              description: The content of the reply that is the displayed to end-users.
               nullable: true
             contentType:
               type: string
-              description: The content type for the reply.
+              description: 'The content type for the reply. Supported values are: plain, mention.'
+            mentions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.workbookCommentMention'
+              description: 'A collection that contains all the people mentioned within the reply. When contentType is plain, this property is an empty array. Read-only.'
+            richContent:
+              type: string
+              description: 'The rich content of the reply (for example, reply content with mentions, where the first mentioned entity has an ID attribute of 0 and the second has an ID attribute of 1). When contentType is plain, this property is empty. Read-only.'
+              nullable: true
             task:
               $ref: '#/components/schemas/microsoft.graph.workbookDocumentTask'
           additionalProperties:
@@ -69307,6 +74401,33 @@ components:
               description: Indicates whether the worksheet is protected.  Read-only.
           additionalProperties:
             type: object
+    microsoft.graph.cloudLicensing.subscriptionState:
+      title: subscriptionState
+      enum:
+        - active
+        - warning
+        - suspended
+        - lockedOut
+        - deleted
+        - unknownFutureValue
+      type: string
+    microsoft.graph.cloudLicensing.subscriptionTags:
+      title: subscriptionTags
+      enum:
+        - none
+        - trial
+        - unknownFutureValue
+      type: string
+      x-ms-enum-flags:
+        isFlags: true
+    microsoft.graph.expirationPatternType:
+      title: expirationPatternType
+      enum:
+        - notSpecified
+        - noExpiration
+        - afterDateTime
+        - afterDuration
+      type: string
     microsoft.graph.printColorMode:
       title: printColorMode
       enum:
@@ -70424,7 +75545,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.printFinishing'
-          description: Finishing processes to use when printing.
+          description: 'Finishing processes to use when printing. Possible values are: none, staple, punch, cover, bind, saddleStitch, stitchEdge, stapleTopLeft, stapleBottomLeft, stapleTopRight, stapleBottomRight, stitchLeftEdge, stitchTopEdge, stitchRightEdge, stitchBottomEdge, stapleDualLeft, stapleDualTop, stapleDualRight, stapleDualBottom, unknownFutureValue. You must use the Prefer: include-unknown-enum-members request header to get the following values in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerottom,bindLeft,bindTop,bindRight,bindBottom,foldAccordion,foldDoubleGate,foldGate,foldHalf,foldHalfZ,foldLeftGate,foldLetter,foldParallel,foldPoster,foldRightGate,foldZ,foldEngineeringZ,punchTopLeft,punchBottomLeft,punchTopRight,punchBottomRight,punchDualLeft,punchDualTop,punchDualRight,punchDualBottom,punchTripleLeft,punchTripleTop,punchTripleRight,punchTripleBottom,punchQuadLeft,punchQuadTop,punchQuadRight,punchQuadBottom,fold,trim,bale,bookletMaker,coat,laminate,trimAfterPages,trimAfterDocuments,trimAfterCopies,trimAfterJob`.'
         fitPdfToPage:
           type: boolean
           nullable: true
@@ -70595,7 +75716,7 @@ components:
         maxLifetime:
           pattern: '^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$'
           type: string
-          description: 'String value that indicates the maximum lifetime for key expiration, defined as an ISO 8601 duration. For example, P4DT12H30M5S represents four days, 12 hours, 30 minutes, and five seconds. This property is required when restrictionType is set to keyLifetime.'
+          description: 'String value that indicates the maximum lifetime for key expiration, defined as an ISO 8601 duration. For example, P4DT12H30M5S represents four days, 12 hours, 30 minutes, and five seconds. This property is required when restrictionType is set to asymmetricKeyLifetime.'
           format: duration
           nullable: true
         restrictForAppsCreatedAfterDateTime:
@@ -70639,7 +75760,7 @@ components:
       type: object
       properties:
         azureAdMultipleOrgs:
-          $ref: '#/components/schemas/microsoft.graph.audienceRestriction'
+          $ref: '#/components/schemas/microsoft.graph.azureAdMultipleOrgsAudienceRestriction'
         personalMicrosoftAccount:
           $ref: '#/components/schemas/microsoft.graph.audienceRestriction'
       additionalProperties:
@@ -70652,6 +75773,22 @@ components:
           $ref: '#/components/schemas/microsoft.graph.identifierUriRestriction'
         uriAdditionWithoutUniqueTenantIdentifier:
           $ref: '#/components/schemas/microsoft.graph.identifierUriRestriction'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriConfiguration:
+      title: redirectUriConfiguration
+      type: object
+      properties:
+        uriWithBlockedDomain:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriBlockedDomainConfiguration'
+        uriWithBlockedScheme:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriBlockedSchemeConfiguration'
+        uriWithoutAllowedDomain:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriAllowedDomainConfiguration'
+        uriWithoutAllowedScheme:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriAllowedSchemeConfiguration'
+        uriWithWildcard:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriWildcardConfiguration'
       additionalProperties:
         type: object
     microsoft.graph.customClaimAttributeBase:
@@ -70970,6 +76107,21 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.structuredDataEntryValueType:
+      title: structuredDataEntryValueType
+      enum:
+        - dateTime
+        - boolean
+        - byte
+        - string
+        - integer32
+        - unsignedInteger32
+        - integer64
+        - unsignedInteger64
+        - stringArray
+        - byteArray
+        - unknownFutureValue
+      type: string
     microsoft.graph.settingSourceType:
       title: settingSourceType
       enum:
@@ -70983,6 +76135,15 @@ components:
         - deviceIntent
       type: string
       description: Authoring source of a policy
+    microsoft.graph.meetingEngagementType:
+      title: meetingEngagementType
+      enum:
+        - reaction
+        - hand
+        - camera
+        - microphone
+        - unknownFutureValue
+      type: string
     microsoft.graph.plannerApprovalStatus:
       title: plannerApprovalStatus
       enum:
@@ -71024,6 +76185,26 @@ components:
             type: string
             nullable: true
           description: Read-only. A collection of keys from the plannerFormsDictionary that identify the plannerFormReference objects that specify the requirements to complete the plannerTask.
+      additionalProperties:
+        type: object
+    microsoft.graph.plannerTaskChatMentionType:
+      title: plannerTaskChatMentionType
+      enum:
+        - user
+        - application
+        - unknownFutureValue
+      type: string
+    microsoft.graph.plannerTaskChatReactionEvent:
+      title: plannerTaskChatReactionEvent
+      type: object
+      properties:
+        createdBy:
+          $ref: '#/components/schemas/microsoft.graph.identitySet'
+        createdDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The date and time when the reaction was added. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
       additionalProperties:
         type: object
     microsoft.graph.storageQuotaBreakdown:
@@ -71134,6 +76315,29 @@ components:
         - darkPink
         - darkYellow
         - unknownFutureValue
+        - darkRed
+        - cranberry
+        - darkOrange
+        - bronze
+        - peach
+        - gold
+        - lime
+        - forest
+        - lightGreen
+        - jade
+        - lightTeal
+        - darkTeal
+        - steel
+        - skyBlue
+        - blueGray
+        - lavender
+        - lilac
+        - plum
+        - magenta
+        - darkBrown
+        - beige
+        - charcoal
+        - silver
       type: string
     microsoft.graph.sharingRole:
       title: sharingRole
@@ -71277,7 +76481,7 @@ components:
               nullable: true
             type:
               type: string
-              description: 'The type of the change history. Possible values are: create, assign, unassign, unassignAll, setPriority, setTitle, setPercentComplete, setSchedule, remove, restore, undo.'
+              description: 'The type of the change history. The possible values are: create, assign, unassign, unassignAll, setPriority, setTitle, setPercentComplete, setSchedule, remove, restore, undo.'
             undoChangeId:
               type: string
               description: The ID of the workbookDocumentTaskChange that was undone for the undo change action. Only exists on an undo change history. Nullable.
@@ -71307,7 +76511,7 @@ components:
           nullable: true
         dataOption:
           type: string
-          description: 'Represents additional sorting options for this field. Possible values are: Normal, TextAsNumber.'
+          description: 'Represents additional sorting options for this field. The possible values are: Normal, TextAsNumber.'
         icon:
           $ref: '#/components/schemas/microsoft.graph.workbookIcon'
         key:
@@ -71318,7 +76522,7 @@ components:
           format: int32
         sortOn:
           type: string
-          description: 'Represents the type of sorting of this condition. Possible values are: Value, CellColor, FontColor, Icon.'
+          description: 'Represents the type of sorting of this condition. The possible values are: Value, CellColor, FontColor, Icon.'
       additionalProperties:
         type: object
     microsoft.graph.workbookChartAxes:
@@ -71658,7 +76862,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeExemption'
-          x-ms-navigationProperty: true
+          description: The collection of customSecurityAttributeExemption to exempt from the policy enforcement. Limit of 5.
       additionalProperties:
         type: object
     microsoft.graph.appKeyCredentialRestrictionType:
@@ -71685,6 +76889,13 @@ components:
         - customPasswordAddition
         - unknownFutureValue
       type: string
+    microsoft.graph.azureAdMultipleOrgsAudienceRestriction:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.audienceRestriction'
+        - title: azureAdMultipleOrgsAudienceRestriction
+          type: object
+          additionalProperties:
+            type: object
     microsoft.graph.audienceRestriction:
       title: audienceRestriction
       type: object
@@ -71712,7 +76923,7 @@ components:
           $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
         excludeAppsReceivingV2Tokens:
           type: boolean
-          description: 'If true, the restriction isn''t enforced for applications that are configured to receive V2 tokens in Microsoft Entra ID; else, the restriction isn''t enforced for those applications.'
+          description: 'If true, the restriction isn''t enforced for applications that are configured to receive V2 tokens in Microsoft Entra ID; else, the restriction is enforced for those applications.'
           nullable: true
         excludeSaml:
           type: boolean
@@ -71726,6 +76937,142 @@ components:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
           description: 'Specifies the date from which the policy restriction applies to newly created applications. For existing applications, the enforcement date can be retroactively applied.'
+          format: date-time
+          nullable: true
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriBlockedDomainConfiguration:
+      title: redirectUriBlockedDomainConfiguration
+      type: object
+      properties:
+        blockedDomains:
+          type: array
+          items:
+            type: string
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        publicClient:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedDomainConfiguration'
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        spa:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedDomainConfiguration'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+        web:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedDomainConfiguration'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriBlockedSchemeConfiguration:
+      title: redirectUriBlockedSchemeConfiguration
+      type: object
+      properties:
+        blockedSchemes:
+          type: array
+          items:
+            type: string
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        exemptFormats:
+          type: array
+          items:
+            type: string
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        publicClient:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedSchemeConfiguration'
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        spa:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedSchemeConfiguration'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+        web:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformBlockedSchemeConfiguration'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriAllowedDomainConfiguration:
+      title: redirectUriAllowedDomainConfiguration
+      type: object
+      properties:
+        allowedDomains:
+          type: array
+          items:
+            type: string
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        publicClient:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedDomainConfiguration'
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        spa:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedDomainConfiguration'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+        web:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedDomainConfiguration'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriAllowedSchemeConfiguration:
+      title: redirectUriAllowedSchemeConfiguration
+      type: object
+      properties:
+        allowedSchemes:
+          type: array
+          items:
+            type: string
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        publicClient:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedSchemeConfiguration'
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        spa:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedSchemeConfiguration'
+        state:
+          $ref: '#/components/schemas/microsoft.graph.appManagementRestrictionState'
+        web:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriPlatformAllowedSchemeConfiguration'
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriWildcardConfiguration:
+      title: redirectUriWildcardConfiguration
+      type: object
+      properties:
+        excludeActors:
+          $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
+        excludeFormats:
+          $ref: '#/components/schemas/microsoft.graph.redirectUriWildcardExcludeFormats'
+        isStateSetByMicrosoft:
+          type: boolean
+          readOnly: true
+        restrictForAppsCreatedAfterDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
           format: date-time
           nullable: true
         state:
@@ -71979,7 +77326,7 @@ components:
           format: int32
         set:
           type: string
-          description: 'The set that the icon is part of. Possible values are: Invalid, ThreeArrows, ThreeArrowsGray, ThreeFlags, ThreeTrafficLights1, ThreeTrafficLights2, ThreeSigns, ThreeSymbols, ThreeSymbols2, FourArrows, FourArrowsGray, FourRedToBlack, FourRating, FourTrafficLights, FiveArrows, FiveArrowsGray, FiveRating, FiveQuarters, ThreeStars, ThreeTriangles, FiveBoxes.'
+          description: 'The set that the icon is part of. The possible values are: Invalid, ThreeArrows, ThreeArrowsGray, ThreeFlags, ThreeTrafficLights1, ThreeTrafficLights2, ThreeSigns, ThreeSymbols, ThreeSymbols2, FourArrows, FourArrowsGray, FourRedToBlack, FourRating, FourTrafficLights, FiveArrows, FiveArrowsGray, FiveRating, FiveQuarters, ThreeStars, ThreeTriangles, FiveBoxes.'
       additionalProperties:
         type: object
     microsoft.graph.workbookChartAxis:
@@ -72121,10 +77468,68 @@ components:
         - title: customSecurityAttributeExemption
           type: object
           properties:
+            id:
+              type: string
             operator:
               $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeComparisonOperator'
           additionalProperties:
             type: object
+    microsoft.graph.redirectUriPlatformBlockedDomainConfiguration:
+      title: redirectUriPlatformBlockedDomainConfiguration
+      type: object
+      properties:
+        blockedDomains:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriPlatformBlockedSchemeConfiguration:
+      title: redirectUriPlatformBlockedSchemeConfiguration
+      type: object
+      properties:
+        blockedSchemes:
+          type: array
+          items:
+            type: string
+        exemptFormats:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriPlatformAllowedDomainConfiguration:
+      title: redirectUriPlatformAllowedDomainConfiguration
+      type: object
+      properties:
+        allowedDomains:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriPlatformAllowedSchemeConfiguration:
+      title: redirectUriPlatformAllowedSchemeConfiguration
+      type: object
+      properties:
+        allowedSchemes:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: object
+    microsoft.graph.redirectUriWildcardExcludeFormats:
+      title: redirectUriWildcardExcludeFormats
+      type: object
+      properties:
+        excludeWildcardsInPath:
+          type: boolean
+        excludeWildcardsInPathWithDomains:
+          type: array
+          items:
+            type: string
+      additionalProperties:
+        type: object
     microsoft.graph.attributeMapping:
       title: attributeMapping
       type: object
@@ -72829,6 +78234,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/microsoft.graph.security.identityAccountsCollectionResponse'
+    microsoft.graph.security.sensorCandidateCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.security.sensorCandidateCollectionResponse'
+    microsoft.graph.security.sensorMigrationCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.security.sensorMigrationCollectionResponse'
     microsoft.graph.security.sensorCollectionResponse:
       description: Retrieved collection
       content:
@@ -72961,6 +78378,36 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/microsoft.graph.securityActionCollectionResponse'
+    microsoft.graph.security.securityCopilot.workspaceCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.workspaceCollectionResponse'
+    microsoft.graph.security.securityCopilot.pluginCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.pluginCollectionResponse'
+    microsoft.graph.security.securityCopilot.sessionCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.sessionCollectionResponse'
+    microsoft.graph.security.securityCopilot.promptCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.promptCollectionResponse'
+    microsoft.graph.security.securityCopilot.evaluationCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.security.securityCopilot.evaluationCollectionResponse'
     microsoft.graph.subjectRightsRequestCollectionResponse:
       description: Retrieved collection
       content:
@@ -73135,6 +78582,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/microsoft.graph.userSecurityProfileCollectionResponse'
+    microsoft.graph.security.zoneCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.security.zoneCollectionResponse'
+    microsoft.graph.security.environmentCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.security.environmentCollectionResponse'
   parameters:
     top:
       name: $top

--- a/openApiDocs/beta/Teams.yml
+++ b/openApiDocs/beta/Teams.yml
@@ -6295,6 +6295,1835 @@ paths:
           $ref: '#/components/responses/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+  '/chats/{chat-id}/targetedMessages':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get targetedMessages from chats
+      description: A collection of targeted messages in the chat that are visible only to specific users. Nullable.
+      operationId: chat_ListTargetedMessage
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.targetedChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - chats.targetedChatMessage
+      summary: Create new navigation property to targetedMessages for chats
+      operationId: chat_CreateTargetedMessage
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get targetedMessages from chats
+      description: A collection of targeted messages in the chat that are visible only to specific users. Nullable.
+      operationId: chat_GetTargetedMessage
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - chats.targetedChatMessage
+      summary: Update the navigation property targetedMessages in chats
+      operationId: chat_UpdateTargetedMessage
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - chats.targetedChatMessage
+      summary: Delete navigation property targetedMessages for chats
+      operationId: chat_DeleteTargetedMessage
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/hostedContents':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get hostedContents from chats
+      description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
+      operationId: chat.targetedMessage_ListHostedContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.chatMessageHostedContentCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - chats.targetedChatMessage
+      summary: Create new navigation property to hostedContents for chats
+      operationId: chat.targetedMessage_CreateHostedContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/hostedContents/{chatMessageHostedContent-id}':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get hostedContents from chats
+      description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
+      operationId: chat.targetedMessage_GetHostedContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - chats.targetedChatMessage
+      summary: Update the navigation property hostedContents in chats
+      operationId: chat.targetedMessage_UpdateHostedContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - chats.targetedChatMessage
+      summary: Delete navigation property hostedContents for chats
+      operationId: chat.targetedMessage_DeleteHostedContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/hostedContents/{chatMessageHostedContent-id}/$value':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get media content for the navigation property hostedContents from chats
+      description: The unique identifier for an entity. Read-only.
+      operationId: chat.targetedMessage_GetHostedContentsContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - chats.targetedChatMessage
+      summary: Update media content for the navigation property hostedContents in chats
+      description: The unique identifier for an entity. Read-only.
+      operationId: chat.targetedMessage_SetHostedContentsContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - chats.targetedChatMessage
+      summary: Delete media content for the navigation property hostedContents in chats
+      description: The unique identifier for an entity. Read-only.
+      operationId: chat.targetedMessage_DeleteHostedContentsContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/hostedContents/$count':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get the number of the resource
+      operationId: chat.targetedMessage.hostedContent_GetCount
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get replies from chats
+      description: Replies for a specified message. Supports $expand for channel messages.
+      operationId: chat.targetedMessage_ListReply
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.chatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - chats.targetedChatMessage
+      summary: Create new navigation property to replies for chats
+      operationId: chat.targetedMessage_CreateReply
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get replies from chats
+      description: Replies for a specified message. Supports $expand for channel messages.
+      operationId: chat.targetedMessage_GetReply
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - chats.targetedChatMessage
+      summary: Update the navigation property replies in chats
+      operationId: chat.targetedMessage_UpdateReply
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - chats.targetedChatMessage
+      summary: Delete navigation property replies for chats
+      operationId: chat.targetedMessage_DeleteReply
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/hostedContents':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get hostedContents from chats
+      description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
+      operationId: chat.targetedMessage.reply_ListHostedContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.chatMessageHostedContentCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - chats.targetedChatMessage
+      summary: Create new navigation property to hostedContents for chats
+      operationId: chat.targetedMessage.reply_CreateHostedContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get hostedContents from chats
+      description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
+      operationId: chat.targetedMessage.reply_GetHostedContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - chats.targetedChatMessage
+      summary: Update the navigation property hostedContents in chats
+      operationId: chat.targetedMessage.reply_UpdateHostedContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - chats.targetedChatMessage
+      summary: Delete navigation property hostedContents for chats
+      operationId: chat.targetedMessage.reply_DeleteHostedContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}/$value':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get media content for the navigation property hostedContents from chats
+      description: The unique identifier for an entity. Read-only.
+      operationId: chat.targetedMessage.reply_GetHostedContentsContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - chats.targetedChatMessage
+      summary: Update media content for the navigation property hostedContents in chats
+      description: The unique identifier for an entity. Read-only.
+      operationId: chat.targetedMessage.reply_SetHostedContentsContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - chats.targetedChatMessage
+      summary: Delete media content for the navigation property hostedContents in chats
+      description: The unique identifier for an entity. Read-only.
+      operationId: chat.targetedMessage.reply_DeleteHostedContentsContent
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/hostedContents/$count':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get the number of the resource
+      operationId: chat.targetedMessage.reply.hostedContent_GetCount
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - chats.targetedChatMessage
+      summary: Invoke action setReaction
+      operationId: chat.targetedMessage.reply_setReaction
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+                  nullable: true
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/microsoft.graph.softDelete':
+    post:
+      tags:
+        - chats.targetedChatMessage
+      summary: Invoke action softDelete
+      description: Delete a single chatMessage or a chat message reply in a channel or a chat.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chatmessage-softdelete?view=graph-rest-beta
+      operationId: chat.targetedMessage.reply_softDelete
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/microsoft.graph.undoSoftDelete':
+    post:
+      tags:
+        - chats.targetedChatMessage
+      summary: Invoke action undoSoftDelete
+      description: Undo soft deletion of a single chatMessage or a chat message reply in a channel or a chat.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chatmessage-undosoftdelete?view=graph-rest-beta
+      operationId: chat.targetedMessage.reply_undoSoftDelete
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - chats.targetedChatMessage
+      summary: Invoke action unsetReaction
+      operationId: chat.targetedMessage.reply_unsetReaction
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+                  nullable: true
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/$count':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get the number of the resource
+      operationId: chat.targetedMessage.reply_GetCount
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/microsoft.graph.delta()':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Invoke function delta
+      description: 'Get the list of messages from all chats in which a user is a participant, including one-on-one chats, group chats, and meeting chats. When you use delta query, you can obtain new or updated messages. To get the replies for a message, use the list message replies or the get message reply operations. A GET request with the delta function returns one of the following: State tokens are opaque to the client. To proceed with a round of change tracking, copy and apply the @odata.nextLink or @odata.deltaLink URL returned from the last GET request to the next delta function call. An @odata.deltaLink returned in a response signifies that the current round of change tracking is complete. You can save and use the @odata.deltaLink URL when you begin to retrieve more changes (messages changed or posted after you acquire @odata.deltaLink). For more information, see the delta query documentation.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chatmessage-delta?view=graph-rest-beta
+      operationId: chat.targetedMessage.reply_delta
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of chatMessage
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.chatMessage'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                  '@odata.deltaLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/microsoft.graph.forwardToChat':
+    post:
+      tags:
+        - chats.targetedChatMessage
+      summary: Invoke action forwardToChat
+      description: 'Forward a chat message, a channel message, or a channel message reply to a chat.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chatmessage-forwardtochat?view=graph-rest-beta
+      operationId: chat.targetedMessage.reply_forwardToChat
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targetChatIds:
+                  type: array
+                  items:
+                    type: string
+                    nullable: true
+                messageIds:
+                  type: array
+                  items:
+                    type: string
+                    nullable: true
+                additionalMessage:
+                  $ref: '#/components/schemas/microsoft.graph.chatMessage'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/microsoft.graph.replyWithQuote':
+    post:
+      tags:
+        - chats.targetedChatMessage
+      summary: Invoke action replyWithQuote
+      description: Reply with quote to a single chat message or multiple chat messages in a chat.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chatmessage-replywithquote?view=graph-rest-beta
+      operationId: chat.targetedMessage.reply_replyGraphWPreQuote
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                messageIds:
+                  type: array
+                  items:
+                    type: string
+                    nullable: true
+                replyMessage:
+                  $ref: '#/components/schemas/microsoft.graph.chatMessage'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/chats/{chat-id}/targetedMessages/$count':
+    get:
+      tags:
+        - chats.targetedChatMessage
+      summary: Get the number of the resource
+      operationId: chat.targetedMessage_GetCount
+      parameters:
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   /chats/$count:
     get:
       tags:
@@ -7832,6 +9661,420 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+  '/groups/{group-id}/team/channels/{channel-id}/joinedUsers':
+    get:
+      tags:
+        - groups.team
+      summary: Get joinedUsers from groups
+      operationId: group.team.channel_ListJoinedUser
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.conversationMemberCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - groups.team
+      summary: Create new navigation property to joinedUsers for groups
+      operationId: group.team.channel_CreateJoinedUser
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/channels/{channel-id}/joinedUsers/{conversationMember-id}':
+    get:
+      tags:
+        - groups.team
+      summary: Get joinedUsers from groups
+      operationId: group.team.channel_GetJoinedUser
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - groups.team
+      summary: Update the navigation property joinedUsers in groups
+      operationId: group.team.channel_UpdateJoinedUser
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - groups.team
+      summary: Delete navigation property joinedUsers for groups
+      operationId: group.team.channel_DeleteJoinedUser
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/channels/{channel-id}/joinedUsers/$count':
+    get:
+      tags:
+        - groups.team
+      summary: Get the number of the resource
+      operationId: group.team.channel.joinedUser_GetCount
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/groups/{group-id}/team/channels/{channel-id}/joinedUsers/microsoft.graph.add':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action add
+      description: Add multiple members in a single request to a team. The response provides details about which memberships could and couldn't be created.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmembers-add?view=graph-rest-beta
+      operationId: group.team.channel.joinedUser_add
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/groups/{group-id}/team/channels/{channel-id}/joinedUsers/microsoft.graph.remove':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action remove
+      description: Remove multiple members from a team in a single request. The response provides details about which memberships could and couldn't be removed.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmember-remove?view=graph-rest-beta
+      operationId: group.team.channel.joinedUser_remove
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
   '/groups/{group-id}/team/channels/{channel-id}/members':
     get:
       tags:
@@ -12707,6 +14950,592 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - groups.team
+      summary: Get messages from groups
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: group.team.channel.planner.plan.bucket.task_ListMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - groups.team
+      summary: Create new navigation property to messages for groups
+      operationId: group.team.channel.planner.plan.bucket.task_CreateMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - groups.team
+      summary: Get messages from groups
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: group.team.channel.planner.plan.bucket.task_GetMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - groups.team
+      summary: Update the navigation property messages in groups
+      operationId: group.team.channel.planner.plan.bucket.task_UpdateMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - groups.team
+      summary: Delete navigation property messages for groups
+      operationId: group.team.channel.planner.plan.bucket.task_DeleteMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: group.team.channel.planner.plan.bucket.task.message_setReaction
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: group.team.channel.planner.plan.bucket.task.message_unsetReaction
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - groups.team
+      summary: Get the number of the resource
+      operationId: group.team.channel.planner.plan.bucket.task.message_GetCount
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -14407,6 +17236,528 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - groups.team
+      summary: Get messages from groups
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: group.team.channel.planner.plan.task_ListMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - groups.team
+      summary: Create new navigation property to messages for groups
+      operationId: group.team.channel.planner.plan.task_CreateMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - groups.team
+      summary: Get messages from groups
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: group.team.channel.planner.plan.task_GetMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - groups.team
+      summary: Update the navigation property messages in groups
+      operationId: group.team.channel.planner.plan.task_UpdateMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - groups.team
+      summary: Delete navigation property messages for groups
+      operationId: group.team.channel.planner.plan.task_DeleteMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: group.team.channel.planner.plan.task.message_setReaction
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: group.team.channel.planner.plan.task.message_unsetReaction
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - groups.team
+      summary: Get the number of the resource
+      operationId: group.team.channel.planner.plan.task.message_GetCount
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/groups/{group-id}/team/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -17549,7 +20900,7 @@ paths:
       tags:
         - groups.team
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: group.team.owner_GetMailboxSetting
       parameters:
         - name: group-id
@@ -19013,6 +22364,356 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+  '/groups/{group-id}/team/primaryChannel/joinedUsers':
+    get:
+      tags:
+        - groups.team
+      summary: Get joinedUsers from groups
+      operationId: group.team.primaryChannel_ListJoinedUser
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.conversationMemberCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - groups.team
+      summary: Create new navigation property to joinedUsers for groups
+      operationId: group.team.primaryChannel_CreateJoinedUser
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/primaryChannel/joinedUsers/{conversationMember-id}':
+    get:
+      tags:
+        - groups.team
+      summary: Get joinedUsers from groups
+      operationId: group.team.primaryChannel_GetJoinedUser
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - groups.team
+      summary: Update the navigation property joinedUsers in groups
+      operationId: group.team.primaryChannel_UpdateJoinedUser
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - groups.team
+      summary: Delete navigation property joinedUsers for groups
+      operationId: group.team.primaryChannel_DeleteJoinedUser
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/primaryChannel/joinedUsers/$count':
+    get:
+      tags:
+        - groups.team
+      summary: Get the number of the resource
+      operationId: group.team.primaryChannel.joinedUser_GetCount
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/groups/{group-id}/team/primaryChannel/joinedUsers/microsoft.graph.add':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action add
+      description: Add multiple members in a single request to a team. The response provides details about which memberships could and couldn't be created.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmembers-add?view=graph-rest-beta
+      operationId: group.team.primaryChannel.joinedUser_add
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/groups/{group-id}/team/primaryChannel/joinedUsers/microsoft.graph.remove':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action remove
+      description: Remove multiple members from a team in a single request. The response provides details about which memberships could and couldn't be removed.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmember-remove?view=graph-rest-beta
+      operationId: group.team.primaryChannel.joinedUser_remove
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
   '/groups/{group-id}/team/primaryChannel/members':
     get:
       tags:
@@ -23200,6 +26901,528 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - groups.team
+      summary: Get messages from groups
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: group.team.primaryChannel.planner.plan.bucket.task_ListMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - groups.team
+      summary: Create new navigation property to messages for groups
+      operationId: group.team.primaryChannel.planner.plan.bucket.task_CreateMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - groups.team
+      summary: Get messages from groups
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: group.team.primaryChannel.planner.plan.bucket.task_GetMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - groups.team
+      summary: Update the navigation property messages in groups
+      operationId: group.team.primaryChannel.planner.plan.bucket.task_UpdateMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - groups.team
+      summary: Delete navigation property messages for groups
+      operationId: group.team.primaryChannel.planner.plan.bucket.task_DeleteMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: group.team.primaryChannel.planner.plan.bucket.task.message_setReaction
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: group.team.primaryChannel.planner.plan.bucket.task.message_unsetReaction
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - groups.team
+      summary: Get the number of the resource
+      operationId: group.team.primaryChannel.planner.plan.bucket.task.message_GetCount
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -24676,6 +28899,464 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - groups.team
+      summary: Get messages from groups
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: group.team.primaryChannel.planner.plan.task_ListMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - groups.team
+      summary: Create new navigation property to messages for groups
+      operationId: group.team.primaryChannel.planner.plan.task_CreateMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - groups.team
+      summary: Get messages from groups
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: group.team.primaryChannel.planner.plan.task_GetMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - groups.team
+      summary: Update the navigation property messages in groups
+      operationId: group.team.primaryChannel.planner.plan.task_UpdateMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - groups.team
+      summary: Delete navigation property messages for groups
+      operationId: group.team.primaryChannel.planner.plan.task_DeleteMessage
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: group.team.primaryChannel.planner.plan.task.message_setReaction
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - groups.team
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: group.team.primaryChannel.planner.plan.task.message_unsetReaction
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - groups.team
+      summary: Get the number of the resource
+      operationId: group.team.primaryChannel.planner.plan.task.message_GetCount
+      parameters:
+        - name: group-id
+          in: path
+          description: The unique identifier of group
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: group
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/groups/{group-id}/team/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -31184,6 +35865,420 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+  '/teams/{team-id}/channels/{channel-id}/joinedUsers':
+    get:
+      tags:
+        - teams.channel
+      summary: Get joinedUsers from teams
+      operationId: team.channel_ListJoinedUser
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.conversationMemberCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teams.channel
+      summary: Create new navigation property to joinedUsers for teams
+      operationId: team.channel_CreateJoinedUser
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/channels/{channel-id}/joinedUsers/{conversationMember-id}':
+    get:
+      tags:
+        - teams.channel
+      summary: Get joinedUsers from teams
+      operationId: team.channel_GetJoinedUser
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teams.channel
+      summary: Update the navigation property joinedUsers in teams
+      operationId: team.channel_UpdateJoinedUser
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teams.channel
+      summary: Delete navigation property joinedUsers for teams
+      operationId: team.channel_DeleteJoinedUser
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/channels/{channel-id}/joinedUsers/$count':
+    get:
+      tags:
+        - teams.channel
+      summary: Get the number of the resource
+      operationId: team.channel.joinedUser_GetCount
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/teams/{team-id}/channels/{channel-id}/joinedUsers/microsoft.graph.add':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action add
+      description: Add multiple members in a single request to a team. The response provides details about which memberships could and couldn't be created.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmembers-add?view=graph-rest-beta
+      operationId: team.channel.joinedUser_add
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/teams/{team-id}/channels/{channel-id}/joinedUsers/microsoft.graph.remove':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action remove
+      description: Remove multiple members from a team in a single request. The response provides details about which memberships could and couldn't be removed.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmember-remove?view=graph-rest-beta
+      operationId: team.channel.joinedUser_remove
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
   '/teams/{team-id}/channels/{channel-id}/members':
     get:
       tags:
@@ -36116,6 +41211,592 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - teams.channel
+      summary: Get messages from teams
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: team.channel.planner.plan.bucket.task_ListMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teams.channel
+      summary: Create new navigation property to messages for teams
+      operationId: team.channel.planner.plan.bucket.task_CreateMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - teams.channel
+      summary: Get messages from teams
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: team.channel.planner.plan.bucket.task_GetMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teams.channel
+      summary: Update the navigation property messages in teams
+      operationId: team.channel.planner.plan.bucket.task_UpdateMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teams.channel
+      summary: Delete navigation property messages for teams
+      operationId: team.channel.planner.plan.bucket.task_DeleteMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: team.channel.planner.plan.bucket.task.message_setReaction
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: team.channel.planner.plan.bucket.task.message_unsetReaction
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - teams.channel
+      summary: Get the number of the resource
+      operationId: team.channel.planner.plan.bucket.task.message_GetCount
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -37816,6 +43497,528 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - teams.channel
+      summary: Get messages from teams
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: team.channel.planner.plan.task_ListMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teams.channel
+      summary: Create new navigation property to messages for teams
+      operationId: team.channel.planner.plan.task_CreateMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - teams.channel
+      summary: Get messages from teams
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: team.channel.planner.plan.task_GetMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teams.channel
+      summary: Update the navigation property messages in teams
+      operationId: team.channel.planner.plan.task_UpdateMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teams.channel
+      summary: Delete navigation property messages for teams
+      operationId: team.channel.planner.plan.task_DeleteMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: team.channel.planner.plan.task.message_setReaction
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: team.channel.planner.plan.task.message_unsetReaction
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - teams.channel
+      summary: Get the number of the resource
+      operationId: team.channel.planner.plan.task.message_GetCount
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/teams/{team-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -41009,7 +47212,7 @@ paths:
       tags:
         - teams.user
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: team.owner_GetMailboxSetting
       parameters:
         - name: team-id
@@ -42486,6 +48689,356 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+  '/teams/{team-id}/primaryChannel/joinedUsers':
+    get:
+      tags:
+        - teams.channel
+      summary: Get joinedUsers from teams
+      operationId: team.primaryChannel_ListJoinedUser
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.conversationMemberCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teams.channel
+      summary: Create new navigation property to joinedUsers for teams
+      operationId: team.primaryChannel_CreateJoinedUser
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/primaryChannel/joinedUsers/{conversationMember-id}':
+    get:
+      tags:
+        - teams.channel
+      summary: Get joinedUsers from teams
+      operationId: team.primaryChannel_GetJoinedUser
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teams.channel
+      summary: Update the navigation property joinedUsers in teams
+      operationId: team.primaryChannel_UpdateJoinedUser
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teams.channel
+      summary: Delete navigation property joinedUsers for teams
+      operationId: team.primaryChannel_DeleteJoinedUser
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/primaryChannel/joinedUsers/$count':
+    get:
+      tags:
+        - teams.channel
+      summary: Get the number of the resource
+      operationId: team.primaryChannel.joinedUser_GetCount
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/teams/{team-id}/primaryChannel/joinedUsers/microsoft.graph.add':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action add
+      description: Add multiple members in a single request to a team. The response provides details about which memberships could and couldn't be created.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmembers-add?view=graph-rest-beta
+      operationId: team.primaryChannel.joinedUser_add
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/teams/{team-id}/primaryChannel/joinedUsers/microsoft.graph.remove':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action remove
+      description: Remove multiple members from a team in a single request. The response provides details about which memberships could and couldn't be removed.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmember-remove?view=graph-rest-beta
+      operationId: team.primaryChannel.joinedUser_remove
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
   '/teams/{team-id}/primaryChannel/members':
     get:
       tags:
@@ -46673,6 +53226,528 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - teams.channel
+      summary: Get messages from teams
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: team.primaryChannel.planner.plan.bucket.task_ListMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teams.channel
+      summary: Create new navigation property to messages for teams
+      operationId: team.primaryChannel.planner.plan.bucket.task_CreateMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - teams.channel
+      summary: Get messages from teams
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: team.primaryChannel.planner.plan.bucket.task_GetMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teams.channel
+      summary: Update the navigation property messages in teams
+      operationId: team.primaryChannel.planner.plan.bucket.task_UpdateMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teams.channel
+      summary: Delete navigation property messages for teams
+      operationId: team.primaryChannel.planner.plan.bucket.task_DeleteMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: team.primaryChannel.planner.plan.bucket.task.message_setReaction
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: team.primaryChannel.planner.plan.bucket.task.message_unsetReaction
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - teams.channel
+      summary: Get the number of the resource
+      operationId: team.primaryChannel.planner.plan.bucket.task.message_GetCount
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -48149,6 +55224,464 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - teams.channel
+      summary: Get messages from teams
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: team.primaryChannel.planner.plan.task_ListMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teams.channel
+      summary: Create new navigation property to messages for teams
+      operationId: team.primaryChannel.planner.plan.task_CreateMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - teams.channel
+      summary: Get messages from teams
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: team.primaryChannel.planner.plan.task_GetMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teams.channel
+      summary: Update the navigation property messages in teams
+      operationId: team.primaryChannel.planner.plan.task_UpdateMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teams.channel
+      summary: Delete navigation property messages for teams
+      operationId: team.primaryChannel.planner.plan.task_DeleteMessage
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: team.primaryChannel.planner.plan.task.message_setReaction
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - teams.channel
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: team.primaryChannel.planner.plan.task.message_unsetReaction
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - teams.channel
+      summary: Get the number of the resource
+      operationId: team.primaryChannel.planner.plan.task.message_GetCount
+      parameters:
+        - name: team-id
+          in: path
+          description: The unique identifier of team
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: team
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/teams/{team-id}/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -55320,6 +62853,420 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/joinedUsers':
+    get:
+      tags:
+        - teamwork.deletedTeam
+      summary: Get joinedUsers from teamwork
+      operationId: teamwork.deletedTeam.channel_ListJoinedUser
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.conversationMemberCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teamwork.deletedTeam
+      summary: Create new navigation property to joinedUsers for teamwork
+      operationId: teamwork.deletedTeam.channel_CreateJoinedUser
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/joinedUsers/{conversationMember-id}':
+    get:
+      tags:
+        - teamwork.deletedTeam
+      summary: Get joinedUsers from teamwork
+      operationId: teamwork.deletedTeam.channel_GetJoinedUser
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teamwork.deletedTeam
+      summary: Update the navigation property joinedUsers in teamwork
+      operationId: teamwork.deletedTeam.channel_UpdateJoinedUser
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teamwork.deletedTeam
+      summary: Delete navigation property joinedUsers for teamwork
+      operationId: teamwork.deletedTeam.channel_DeleteJoinedUser
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/joinedUsers/$count':
+    get:
+      tags:
+        - teamwork.deletedTeam
+      summary: Get the number of the resource
+      operationId: teamwork.deletedTeam.channel.joinedUser_GetCount
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/joinedUsers/microsoft.graph.add':
+    post:
+      tags:
+        - teamwork.deletedTeam
+      summary: Invoke action add
+      description: Add multiple members in a single request to a team. The response provides details about which memberships could and couldn't be created.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmembers-add?view=graph-rest-beta
+      operationId: teamwork.deletedTeam.channel.joinedUser_add
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/joinedUsers/microsoft.graph.remove':
+    post:
+      tags:
+        - teamwork.deletedTeam
+      summary: Invoke action remove
+      description: Remove multiple members from a team in a single request. The response provides details about which memberships could and couldn't be removed.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmember-remove?view=graph-rest-beta
+      operationId: teamwork.deletedTeam.channel.joinedUser_remove
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
   '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members':
     get:
       tags:
@@ -60195,6 +68142,592 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - teamwork.deletedTeam
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.deletedTeam.channel.planner.plan.bucket.task_ListMessage
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teamwork.deletedTeam
+      summary: Create new navigation property to messages for teamwork
+      operationId: teamwork.deletedTeam.channel.planner.plan.bucket.task_CreateMessage
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - teamwork.deletedTeam
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.deletedTeam.channel.planner.plan.bucket.task_GetMessage
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teamwork.deletedTeam
+      summary: Update the navigation property messages in teamwork
+      operationId: teamwork.deletedTeam.channel.planner.plan.bucket.task_UpdateMessage
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teamwork.deletedTeam
+      summary: Delete navigation property messages for teamwork
+      operationId: teamwork.deletedTeam.channel.planner.plan.bucket.task_DeleteMessage
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - teamwork.deletedTeam
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: teamwork.deletedTeam.channel.planner.plan.bucket.task.message_setReaction
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - teamwork.deletedTeam
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: teamwork.deletedTeam.channel.planner.plan.bucket.task.message_unsetReaction
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - teamwork.deletedTeam
+      summary: Get the number of the resource
+      operationId: teamwork.deletedTeam.channel.planner.plan.bucket.task.message_GetCount
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -61895,6 +70428,528 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - teamwork.deletedTeam
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.deletedTeam.channel.planner.plan.task_ListMessage
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teamwork.deletedTeam
+      summary: Create new navigation property to messages for teamwork
+      operationId: teamwork.deletedTeam.channel.planner.plan.task_CreateMessage
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - teamwork.deletedTeam
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.deletedTeam.channel.planner.plan.task_GetMessage
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teamwork.deletedTeam
+      summary: Update the navigation property messages in teamwork
+      operationId: teamwork.deletedTeam.channel.planner.plan.task_UpdateMessage
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teamwork.deletedTeam
+      summary: Delete navigation property messages for teamwork
+      operationId: teamwork.deletedTeam.channel.planner.plan.task_DeleteMessage
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - teamwork.deletedTeam
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: teamwork.deletedTeam.channel.planner.plan.task.message_setReaction
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - teamwork.deletedTeam
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: teamwork.deletedTeam.channel.planner.plan.task.message_unsetReaction
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - teamwork.deletedTeam
+      summary: Get the number of the resource
+      operationId: teamwork.deletedTeam.channel.planner.plan.task.message_GetCount
+      parameters:
+        - name: deletedTeam-id
+          in: path
+          description: The unique identifier of deletedTeam
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: deletedTeam
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -66532,6 +75587,484 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/joinedUsers':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get joinedUsers from teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel_ListJoinedUser
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.conversationMemberCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Create new navigation property to joinedUsers for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel_CreateJoinedUser
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/joinedUsers/{conversationMember-id}':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get joinedUsers from teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel_GetJoinedUser
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teamwork.teamTemplate
+      summary: Update the navigation property joinedUsers in teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel_UpdateJoinedUser
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teamwork.teamTemplate
+      summary: Delete navigation property joinedUsers for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel_DeleteJoinedUser
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/joinedUsers/$count':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get the number of the resource
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.joinedUser_GetCount
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/joinedUsers/microsoft.graph.add':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action add
+      description: Add multiple members in a single request to a team. The response provides details about which memberships could and couldn't be created.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmembers-add?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.joinedUser_add
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/joinedUsers/microsoft.graph.remove':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action remove
+      description: Remove multiple members from a team in a single request. The response provides details about which memberships could and couldn't be removed.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmember-remove?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.joinedUser_remove
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
   '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/members':
     get:
       tags:
@@ -72095,6 +81628,656 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.bucket.task_ListMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Create new navigation property to messages for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.bucket.task_CreateMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.bucket.task_GetMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teamwork.teamTemplate
+      summary: Update the navigation property messages in teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.bucket.task_UpdateMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teamwork.teamTemplate
+      summary: Delete navigation property messages for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.bucket.task_DeleteMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.bucket.task.message_setReaction
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.bucket.task.message_unsetReaction
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get the number of the resource
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.bucket.task.message_GetCount
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -74019,6 +84202,592 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.task_ListMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Create new navigation property to messages for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.task_CreateMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.task_GetMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teamwork.teamTemplate
+      summary: Update the navigation property messages in teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.task_UpdateMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teamwork.teamTemplate
+      summary: Delete navigation property messages for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.task_DeleteMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.task.message_setReaction
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.task.message_unsetReaction
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get the number of the resource
+      operationId: teamwork.teamTemplate.definition.teamDefinition.channel.planner.plan.task.message_GetCount
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: channel-id
+          in: path
+          description: The unique identifier of channel
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: channel
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/channels/{channel-id}/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -77673,7 +88442,7 @@ paths:
       tags:
         - teamwork.teamTemplate
       summary: Get mailboxSettings property value
-      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Returned only on $select.'
+      description: 'Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale, and time zone. For more information, see User preferences for languages and regional formats. Requires $select to retrieve.'
       operationId: teamwork.teamTemplate.definition.teamDefinition.owner_GetMailboxSetting
       parameters:
         - name: teamTemplate-id
@@ -79441,6 +90210,420 @@ paths:
           description: Success
         default:
           $ref: '#/components/responses/error'
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/joinedUsers':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get joinedUsers from teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel_ListJoinedUser
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.conversationMemberCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Create new navigation property to joinedUsers for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel_CreateJoinedUser
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/joinedUsers/{conversationMember-id}':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get joinedUsers from teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel_GetJoinedUser
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teamwork.teamTemplate
+      summary: Update the navigation property joinedUsers in teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel_UpdateJoinedUser
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teamwork.teamTemplate
+      summary: Delete navigation property joinedUsers for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel_DeleteJoinedUser
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: conversationMember-id
+          in: path
+          description: The unique identifier of conversationMember
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: conversationMember
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/joinedUsers/$count':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get the number of the resource
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.joinedUser_GetCount
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/joinedUsers/microsoft.graph.add':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action add
+      description: Add multiple members in a single request to a team. The response provides details about which memberships could and couldn't be created.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmembers-add?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.joinedUser_add
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/joinedUsers/microsoft.graph.remove':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action remove
+      description: Remove multiple members from a team in a single request. The response provides details about which memberships could and couldn't be removed.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/conversationmember-remove?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.joinedUser_remove
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
   '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/members':
     get:
       tags:
@@ -84316,6 +95499,592 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.bucket.task_ListMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Create new navigation property to messages for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.bucket.task_CreateMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.bucket.task_GetMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teamwork.teamTemplate
+      summary: Update the navigation property messages in teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.bucket.task_UpdateMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teamwork.teamTemplate
+      summary: Delete navigation property messages for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.bucket.task_DeleteMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.bucket.task.message_setReaction
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.bucket.task.message_unsetReaction
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get the number of the resource
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.bucket.task.message_GetCount
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerBucket-id
+          in: path
+          description: The unique identifier of plannerBucket
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerBucket
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/buckets/{plannerBucket-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -86016,6 +97785,528 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.task_ListMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.plannerTaskChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Create new navigation property to messages for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.task_CreateMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get messages from teamwork
+      description: Read-only. Nullable. Chat messages associated with the task.
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.task_GetMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - teamwork.teamTemplate
+      summary: Update the navigation property messages in teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.task_UpdateMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - teamwork.teamTemplate
+      summary: Delete navigation property messages for teamwork
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.task_DeleteMessage
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action setReaction
+      description: Set a reaction to a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-setreaction?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.task.message_setReaction
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/{plannerTaskChatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - teamwork.teamTemplate
+      summary: Invoke action unsetReaction
+      description: Remove a reaction from a plannerTaskChatMessage for the current user.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/plannertaskchatmessage-unsetreaction?view=graph-rest-beta
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.task.message_unsetReaction
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - name: plannerTaskChatMessage-id
+          in: path
+          description: The unique identifier of plannerTaskChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTaskChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/messages/$count':
+    get:
+      tags:
+        - teamwork.teamTemplate
+      summary: Get the number of the resource
+      operationId: teamwork.teamTemplate.definition.teamDefinition.primaryChannel.planner.plan.task.message_GetCount
+      parameters:
+        - name: teamTemplate-id
+          in: path
+          description: The unique identifier of teamTemplate
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplate
+        - name: teamTemplateDefinition-id
+          in: path
+          description: The unique identifier of teamTemplateDefinition
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamTemplateDefinition
+        - name: plannerPlan-id
+          in: path
+          description: The unique identifier of plannerPlan
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerPlan
+        - name: plannerTask-id
+          in: path
+          description: The unique identifier of plannerTask
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: plannerTask
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/teamwork/teamTemplates/{teamTemplate-id}/definitions/{teamTemplateDefinition-id}/teamDefinition/primaryChannel/planner/plans/{plannerPlan-id}/tasks/{plannerTask-id}/progressTaskBoardFormat':
     get:
       tags:
@@ -97724,6 +110015,2135 @@ paths:
           $ref: '#/components/responses/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+  '/users/{user-id}/chats/{chat-id}/targetedMessages':
+    get:
+      tags:
+        - users.chat
+      summary: Get targetedMessages from users
+      description: A collection of targeted messages in the chat that are visible only to specific users. Nullable.
+      operationId: user.chat_ListTargetedMessage
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.targetedChatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - users.chat
+      summary: Create new navigation property to targetedMessages for users
+      operationId: user.chat_CreateTargetedMessage
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}':
+    get:
+      tags:
+        - users.chat
+      summary: Get targetedMessages from users
+      description: A collection of targeted messages in the chat that are visible only to specific users. Nullable.
+      operationId: user.chat_GetTargetedMessage
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - users.chat
+      summary: Update the navigation property targetedMessages in users
+      operationId: user.chat_UpdateTargetedMessage
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - users.chat
+      summary: Delete targetedChatMessage
+      description: Delete a specific targeted message from a chat context. Teams administrators can use this API to remove targeted messages from group chats.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chat-delete-targetedmessages?view=graph-rest-beta
+      operationId: user.chat_DeleteTargetedMessage
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/hostedContents':
+    get:
+      tags:
+        - users.chat
+      summary: Get hostedContents from users
+      description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
+      operationId: user.chat.targetedMessage_ListHostedContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.chatMessageHostedContentCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - users.chat
+      summary: Create new navigation property to hostedContents for users
+      operationId: user.chat.targetedMessage_CreateHostedContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/hostedContents/{chatMessageHostedContent-id}':
+    get:
+      tags:
+        - users.chat
+      summary: Get hostedContents from users
+      description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
+      operationId: user.chat.targetedMessage_GetHostedContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - users.chat
+      summary: Update the navigation property hostedContents in users
+      operationId: user.chat.targetedMessage_UpdateHostedContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - users.chat
+      summary: Delete navigation property hostedContents for users
+      operationId: user.chat.targetedMessage_DeleteHostedContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/hostedContents/{chatMessageHostedContent-id}/$value':
+    get:
+      tags:
+        - users.chat
+      summary: Get media content for the navigation property hostedContents from users
+      description: The unique identifier for an entity. Read-only.
+      operationId: user.chat.targetedMessage_GetHostedContentsContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - users.chat
+      summary: Update media content for the navigation property hostedContents in users
+      description: The unique identifier for an entity. Read-only.
+      operationId: user.chat.targetedMessage_SetHostedContentsContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - users.chat
+      summary: Delete media content for the navigation property hostedContents in users
+      description: The unique identifier for an entity. Read-only.
+      operationId: user.chat.targetedMessage_DeleteHostedContentsContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/hostedContents/$count':
+    get:
+      tags:
+        - users.chat
+      summary: Get the number of the resource
+      operationId: user.chat.targetedMessage.hostedContent_GetCount
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies':
+    get:
+      tags:
+        - users.chat
+      summary: Get replies from users
+      description: Replies for a specified message. Supports $expand for channel messages.
+      operationId: user.chat.targetedMessage_ListReply
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.chatMessageCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - users.chat
+      summary: Create new navigation property to replies for users
+      operationId: user.chat.targetedMessage_CreateReply
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}':
+    get:
+      tags:
+        - users.chat
+      summary: Get replies from users
+      description: Replies for a specified message. Supports $expand for channel messages.
+      operationId: user.chat.targetedMessage_GetReply
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - users.chat
+      summary: Update the navigation property replies in users
+      operationId: user.chat.targetedMessage_UpdateReply
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - users.chat
+      summary: Delete navigation property replies for users
+      operationId: user.chat.targetedMessage_DeleteReply
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/hostedContents':
+    get:
+      tags:
+        - users.chat
+      summary: Get hostedContents from users
+      description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
+      operationId: user.chat.targetedMessage.reply_ListHostedContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.chatMessageHostedContentCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - users.chat
+      summary: Create new navigation property to hostedContents for users
+      operationId: user.chat.targetedMessage.reply_CreateHostedContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}':
+    get:
+      tags:
+        - users.chat
+      summary: Get hostedContents from users
+      description: 'Content in a message hosted by Microsoft Teams - for example, images or code snippets.'
+      operationId: user.chat.targetedMessage.reply_GetHostedContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - users.chat
+      summary: Update the navigation property hostedContents in users
+      operationId: user.chat.targetedMessage.reply_UpdateHostedContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessageHostedContent'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - users.chat
+      summary: Delete navigation property hostedContents for users
+      operationId: user.chat.targetedMessage.reply_DeleteHostedContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}/$value':
+    get:
+      tags:
+        - users.chat
+      summary: Get media content for the navigation property hostedContents from users
+      description: The unique identifier for an entity. Read-only.
+      operationId: user.chat.targetedMessage.reply_GetHostedContentsContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      responses:
+        2XX:
+          description: Retrieved media content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          $ref: '#/components/responses/error'
+    put:
+      tags:
+        - users.chat
+      summary: Update media content for the navigation property hostedContents in users
+      description: The unique identifier for an entity. Read-only.
+      operationId: user.chat.targetedMessage.reply_SetHostedContentsContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+      requestBody:
+        description: New media content.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+    delete:
+      tags:
+        - users.chat
+      summary: Delete media content for the navigation property hostedContents in users
+      description: The unique identifier for an entity. Read-only.
+      operationId: user.chat.targetedMessage.reply_DeleteHostedContentsContent
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - name: chatMessageHostedContent-id
+          in: path
+          description: The unique identifier of chatMessageHostedContent
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessageHostedContent
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/hostedContents/$count':
+    get:
+      tags:
+        - users.chat
+      summary: Get the number of the resource
+      operationId: user.chat.targetedMessage.reply.hostedContent_GetCount
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/microsoft.graph.setReaction':
+    post:
+      tags:
+        - users.chat
+      summary: Invoke action setReaction
+      operationId: user.chat.targetedMessage.reply_setReaction
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+                  nullable: true
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/microsoft.graph.softDelete':
+    post:
+      tags:
+        - users.chat
+      summary: Invoke action softDelete
+      description: Delete a single chatMessage or a chat message reply in a channel or a chat.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chatmessage-softdelete?view=graph-rest-beta
+      operationId: user.chat.targetedMessage.reply_softDelete
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/microsoft.graph.undoSoftDelete':
+    post:
+      tags:
+        - users.chat
+      summary: Invoke action undoSoftDelete
+      description: Undo soft deletion of a single chatMessage or a chat message reply in a channel or a chat.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chatmessage-undosoftdelete?view=graph-rest-beta
+      operationId: user.chat.targetedMessage.reply_undoSoftDelete
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/{chatMessage-id}/microsoft.graph.unsetReaction':
+    post:
+      tags:
+        - users.chat
+      summary: Invoke action unsetReaction
+      operationId: user.chat.targetedMessage.reply_unsetReaction
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - name: chatMessage-id
+          in: path
+          description: The unique identifier of chatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reactionType:
+                  type: string
+                  nullable: true
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/$count':
+    get:
+      tags:
+        - users.chat
+      summary: Get the number of the resource
+      operationId: user.chat.targetedMessage.reply_GetCount
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/microsoft.graph.delta()':
+    get:
+      tags:
+        - users.chat
+      summary: Invoke function delta
+      description: 'Get the list of messages from all chats in which a user is a participant, including one-on-one chats, group chats, and meeting chats. When you use delta query, you can obtain new or updated messages. To get the replies for a message, use the list message replies or the get message reply operations. A GET request with the delta function returns one of the following: State tokens are opaque to the client. To proceed with a round of change tracking, copy and apply the @odata.nextLink or @odata.deltaLink URL returned from the last GET request to the next delta function call. An @odata.deltaLink returned in a response signifies that the current round of change tracking is complete. You can save and use the @odata.deltaLink URL when you begin to retrieve more changes (messages changed or posted after you acquire @odata.deltaLink). For more information, see the delta query documentation.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chatmessage-delta?view=graph-rest-beta
+      operationId: user.chat.targetedMessage.reply_delta
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of chatMessage
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.chatMessage'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                  '@odata.deltaLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/microsoft.graph.forwardToChat':
+    post:
+      tags:
+        - users.chat
+      summary: Invoke action forwardToChat
+      description: 'Forward a chat message, a channel message, or a channel message reply to a chat.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chatmessage-forwardtochat?view=graph-rest-beta
+      operationId: user.chat.targetedMessage.reply_forwardToChat
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targetChatIds:
+                  type: array
+                  items:
+                    type: string
+                    nullable: true
+                messageIds:
+                  type: array
+                  items:
+                    type: string
+                    nullable: true
+                additionalMessage:
+                  $ref: '#/components/schemas/microsoft.graph.chatMessage'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.actionResultPart'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/{targetedChatMessage-id}/replies/microsoft.graph.replyWithQuote':
+    post:
+      tags:
+        - users.chat
+      summary: Invoke action replyWithQuote
+      description: Reply with quote to a single chat message or multiple chat messages in a chat.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/chatmessage-replywithquote?view=graph-rest-beta
+      operationId: user.chat.targetedMessage.reply_replyGraphWPreQuote
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - name: targetedChatMessage-id
+          in: path
+          description: The unique identifier of targetedChatMessage
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: targetedChatMessage
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                messageIds:
+                  type: array
+                  items:
+                    type: string
+                    nullable: true
+                replyMessage:
+                  $ref: '#/components/schemas/microsoft.graph.chatMessage'
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/users/{user-id}/chats/{chat-id}/targetedMessages/$count':
+    get:
+      tags:
+        - users.chat
+      summary: Get the number of the resource
+      operationId: user.chat.targetedMessage_GetCount
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: chat-id
+          in: path
+          description: The unique identifier of chat
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: chat
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
   '/users/{user-id}/chats/$count':
     get:
       tags:
@@ -98937,6 +113357,203 @@ paths:
           $ref: '#/components/responses/ODataCountResponse'
         default:
           $ref: '#/components/responses/error'
+  '/users/{user-id}/teamwork/microsoft.graph.deleteTargetedMessage':
+    post:
+      tags:
+        - users.userTeamwork
+      summary: Invoke action deleteTargetedMessage
+      description: 'Delete a specific targeted message from a channel context. Teams administrators can use this API to remove targeted messages by providing the message ID, team ID, and channel ID.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/userteamwork-deletetargetedmessage?view=graph-rest-beta
+      operationId: user.teamwork_deleteTargetedMessage
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                teamId:
+                  type: string
+                channelId:
+                  type: string
+                messageId:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/users/{user-id}/teamwork/microsoft.graph.getAllRetainedTargetedMessages()':
+    get:
+      tags:
+        - users.userTeamwork
+      summary: Invoke function getAllRetainedTargetedMessages
+      description: Get all retained targeted messages sent to a specific user in group chats and channels.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/userteamwork-getallretainedtargetedmessages?view=graph-rest-beta
+      operationId: user.teamwork_getAllRetainedTargetedMessage
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of targetedChatMessage
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+  '/users/{user-id}/teamwork/microsoft.graph.getAllTargetedMessages()':
+    get:
+      tags:
+        - users.userTeamwork
+      summary: Invoke function getAllTargetedMessages
+      description: Get all targeted messages sent to a specific user in group chats and channels.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/userteamwork-getalltargetedmessages?view=graph-rest-beta
+      operationId: user.teamwork_getAllTargetedMessage
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: Collection of targetedChatMessage
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+                  '@odata.nextLink':
+                    type: string
+                    nullable: true
+                additionalProperties:
+                  type: object
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: function
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
   '/users/{user-id}/teamwork/microsoft.graph.sendActivityNotification':
     post:
       tags:
@@ -98993,6 +113610,620 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: action
+  '/users/{user-id}/teamwork/sections':
+    get:
+      tags:
+        - users.userTeamwork
+      summary: List sections
+      description: Get the list of sections in a user's teamwork.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/userteamwork-list-sections?view=graph-rest-beta
+      operationId: user.teamwork_ListSection
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.teamworkSectionCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - users.userTeamwork
+      summary: Create teamworkSection
+      description: Create a new section in a user's teamwork.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/userteamwork-post-sections?view=graph-rest-beta
+      operationId: user.teamwork_CreateSection
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.teamworkSection'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSection'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/teamwork/sections/{teamworkSection-id}':
+    get:
+      tags:
+        - users.userTeamwork
+      summary: Get teamworkSection
+      description: Read the properties of a section in a user's teamwork.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/teamworksection-get?view=graph-rest-beta
+      operationId: user.teamwork_GetSection
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: teamworkSection-id
+          in: path
+          description: The unique identifier of teamworkSection
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSection
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSection'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - users.userTeamwork
+      summary: Update teamworkSection
+      description: 'Update the properties of a section in a user''s teamwork. For system-defined sections, only the sortType property can be updated.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/teamworksection-update?view=graph-rest-beta
+      operationId: user.teamwork_UpdateSection
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: teamworkSection-id
+          in: path
+          description: The unique identifier of teamworkSection
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSection
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.teamworkSection'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSection'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - users.userTeamwork
+      summary: Delete teamworkSection
+      description: Delete a user-defined section from a user's teamwork. System-defined sections can't be deleted.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/teamworksection-delete?view=graph-rest-beta
+      operationId: user.teamwork_DeleteSection
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: teamworkSection-id
+          in: path
+          description: The unique identifier of teamworkSection
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSection
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/teamwork/sections/{teamworkSection-id}/items':
+    get:
+      tags:
+        - users.userTeamwork
+      summary: List items
+      description: Get the list of items in a section of a user's teamwork.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/teamworksection-list-items?view=graph-rest-beta
+      operationId: user.teamwork.section_ListItem
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: teamworkSection-id
+          in: path
+          description: The unique identifier of teamworkSection
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSection
+        - $ref: '#/components/parameters/top'
+        - $ref: '#/components/parameters/skip'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/count'
+        - name: $orderby
+          in: query
+          description: Order items by property values
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          $ref: '#/components/responses/microsoft.graph.teamworkSectionItemCollectionResponse'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-pageable:
+        nextLinkName: '@odata.nextLink'
+        operationName: listMore
+      x-ms-docs-operation-type: operation
+    post:
+      tags:
+        - users.userTeamwork
+      summary: Add teamworkSectionItem
+      description: 'Add an item, such as a chat, channel, meeting, or community, to a user-defined section in a user''s teamwork. Each item can belong to only one section at a time. You can only add items that are currently in a system-defined section. If the item is already in another user-defined section, use the move action to relocate it.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/teamworksection-post-items?view=graph-rest-beta
+      operationId: user.teamwork.section_CreateItem
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: teamworkSection-id
+          in: path
+          description: The unique identifier of teamworkSection
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSection
+      requestBody:
+        description: New navigation property
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.teamworkSectionItem'
+        required: true
+      responses:
+        2XX:
+          description: Created navigation property.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSectionItem'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/teamwork/sections/{teamworkSection-id}/items/{teamworkSectionItem-id}':
+    get:
+      tags:
+        - users.userTeamwork
+      summary: Get items from users
+      description: 'The items (chats, channels, meetings, or communities) organized within the section.'
+      operationId: user.teamwork.section_GetItem
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: teamworkSection-id
+          in: path
+          description: The unique identifier of teamworkSection
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSection
+        - name: teamworkSectionItem-id
+          in: path
+          description: The unique identifier of teamworkSectionItem
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSectionItem
+        - name: $select
+          in: query
+          description: Select properties to be returned
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+      responses:
+        2XX:
+          description: Retrieved navigation property
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSectionItem'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    patch:
+      tags:
+        - users.userTeamwork
+      summary: Update the navigation property items in users
+      operationId: user.teamwork.section_UpdateItem
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: teamworkSection-id
+          in: path
+          description: The unique identifier of teamworkSection
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSection
+        - name: teamworkSectionItem-id
+          in: path
+          description: The unique identifier of teamworkSectionItem
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSectionItem
+      requestBody:
+        description: New navigation property values
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/microsoft.graph.teamworkSectionItem'
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSectionItem'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - users.userTeamwork
+      summary: Remove teamworkSectionItem
+      description: 'Remove an item from a user-defined section in a user''s teamwork. This API doesn''t delete the underlying chat, channel, meeting, or community; it only removes the item from the user-defined section. The item is automatically moved back to its default system-defined section.'
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/teamworksectionitem-delete?view=graph-rest-beta
+      operationId: user.teamwork.section_DeleteItem
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: teamworkSection-id
+          in: path
+          description: The unique identifier of teamworkSection
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSection
+        - name: teamworkSectionItem-id
+          in: path
+          description: The unique identifier of teamworkSectionItem
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSectionItem
+        - name: If-Match
+          in: header
+          description: ETag
+          style: simple
+          schema:
+            type: string
+      responses:
+        2XX:
+          description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/users/{user-id}/teamwork/sections/{teamworkSection-id}/items/{teamworkSectionItem-id}/microsoft.graph.move':
+    post:
+      tags:
+        - users.userTeamwork
+      summary: Invoke action move
+      description: Move an item from one user-defined section to another user-defined section in a user's teamwork. Each item can belong to only one section at a time. This action removes the item from its current section and adds it to the target section. Use this action instead of add when the item is already in a user-defined section.
+      externalDocs:
+        description: Find more info here
+        url: https://learn.microsoft.com/graph/api/teamworksectionitem-move?view=graph-rest-beta
+      operationId: user.teamwork.section.item_move
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: teamworkSection-id
+          in: path
+          description: The unique identifier of teamworkSection
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSection
+        - name: teamworkSectionItem-id
+          in: path
+          description: The unique identifier of teamworkSectionItem
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSectionItem
+      requestBody:
+        description: Action parameters
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targetSectionId:
+                  type: string
+              additionalProperties:
+                type: object
+        required: true
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSectionItem'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: action
+  '/users/{user-id}/teamwork/sections/{teamworkSection-id}/items/$count':
+    get:
+      tags:
+        - users.userTeamwork
+      summary: Get the number of the resource
+      operationId: user.teamwork.section.item_GetCount
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - name: teamworkSection-id
+          in: path
+          description: The unique identifier of teamworkSection
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: teamworkSection
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
+  '/users/{user-id}/teamwork/sections/$count':
+    get:
+      tags:
+        - users.userTeamwork
+      summary: Get the number of the resource
+      operationId: user.teamwork.section_GetCount
+      parameters:
+        - name: user-id
+          in: path
+          description: The unique identifier of user
+          required: true
+          style: simple
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/filter'
+      responses:
+        2XX:
+          $ref: '#/components/responses/ODataCountResponse'
+        default:
+          $ref: '#/components/responses/error'
 components:
   schemas:
     microsoft.graph.teamsApp:
@@ -99231,6 +114462,12 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.teamsTab'
               description: A collection of all the tabs in the chat. Nullable.
+              x-ms-navigationProperty: true
+            targetedMessages:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+              description: A collection of targeted messages in the chat that are visible only to specific users. Nullable.
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
@@ -99599,6 +114836,16 @@ components:
               $ref: '#/components/schemas/microsoft.graph.teamsApp'
           additionalProperties:
             type: object
+    microsoft.graph.targetedChatMessage:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.chatMessage'
+        - title: targetedChatMessage
+          type: object
+          properties:
+            recipient:
+              $ref: '#/components/schemas/microsoft.graph.identity'
+          additionalProperties:
+            type: object
     microsoft.graph.team:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -99800,6 +115047,11 @@ components:
               x-ms-navigationProperty: true
             filesFolder:
               $ref: '#/components/schemas/microsoft.graph.driveItem'
+            joinedUsers:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.conversationMember'
+              x-ms-navigationProperty: true
             members:
               type: array
               items:
@@ -100132,9 +115384,10 @@ components:
               nullable: true
             hasChat:
               type: boolean
+              description: 'Read-only. This value is true if the task has chat messages associated with it. Otherwise, false.'
             hasDescription:
               type: boolean
-              description: 'Read-only. This value is true if the details object of the task has a nonempty description. Otherwise,false.'
+              description: 'Read-only. This value is true if the details object of the task has a nonempty description. Otherwise, false.'
               nullable: true
             isArchived:
               type: boolean
@@ -100155,11 +115408,12 @@ components:
             lastModifiedDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
+              description: 'Read-only. Date and time at which this is last modified. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z'
               format: date-time
               nullable: true
             orderHint:
               type: string
-              description: 'The hint used to order items of this type in a list view. For more information, see Using order hints in plannern.'
+              description: 'The hint used to order items of this type in a list view. For more information, see Using order hints in planner.'
               nullable: true
             percentComplete:
               maximum: 2147483647
@@ -100207,6 +115461,12 @@ components:
               $ref: '#/components/schemas/microsoft.graph.plannerBucketTaskBoardTaskFormat'
             details:
               $ref: '#/components/schemas/microsoft.graph.plannerTaskDetails'
+            messages:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
+              description: Read-only. Nullable. Chat messages associated with the task.
+              x-ms-navigationProperty: true
             progressTaskBoardFormat:
               $ref: '#/components/schemas/microsoft.graph.plannerProgressTaskBoardTaskFormat'
           additionalProperties:
@@ -100261,6 +115521,51 @@ components:
               $ref: '#/components/schemas/microsoft.graph.plannerPreviewType'
             references:
               $ref: '#/components/schemas/microsoft.graph.plannerExternalReferences'
+          additionalProperties:
+            type: object
+    microsoft.graph.plannerTaskChatMessage:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: plannerTaskChatMessage
+          type: object
+          properties:
+            content:
+              type: string
+              description: The content of the chat message. Supports plain text and sanitized HTML.
+              nullable: true
+            createdBy:
+              $ref: '#/components/schemas/microsoft.graph.identitySet'
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time when the message was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+              format: date-time
+            deletedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              format: date-time
+              nullable: true
+            editedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              format: date-time
+              nullable: true
+            mentions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMention'
+              description: The list of mentions in the message.
+            messageType:
+              $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessageType'
+            parentEntityId:
+              type: string
+              description: The ID of the parent plannerTask that this message belongs to.
+              nullable: true
+            reactions:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.plannerTaskChatReaction'
+              description: The reactions on the message.
           additionalProperties:
             type: object
     microsoft.graph.plannerProgressTaskBoardTaskFormat:
@@ -100347,21 +115652,21 @@ components:
               $ref: '#/components/schemas/microsoft.graph.groupAccessType'
             allowExternalSenders:
               type: boolean
-              description: 'Indicates if people external to the organization can send messages to the group. The default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates if people external to the organization can send messages to the group. The default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             assignedLabels:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignedLabel'
-              description: 'The list of sensitivity label pairs (label ID, label name) associated with a Microsoft 365 group. Returned only on $select. This property can be updated only in delegated scenarios where the caller requires both the Microsoft Graph permission and a supported administrator role.'
+              description: 'The list of sensitivity label pairs (label ID, label name) associated with a Microsoft 365 group. Requires $select to retrieve. This property can be updated only in delegated scenarios where the caller requires both the Microsoft Graph permission and a supported administrator role.'
             assignedLicenses:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.assignedLicense'
-              description: The licenses that are assigned to the group. Returned only on $select. Supports $filter (eq). Read-only.
+              description: The licenses that are assigned to the group. Requires $select to retrieve. Supports $filter (eq). Read-only.
             autoSubscribeNewMembers:
               type: boolean
-              description: 'Indicates if new members added to the group are auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; don''t set it in the initial POST request that creates the group. Default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates if new members added to the group are auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; don''t set it in the initial POST request that creates the group. Default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             classification:
               type: string
@@ -100404,11 +115709,11 @@ components:
               nullable: true
             hideFromAddressLists:
               type: boolean
-              description: 'true if the group isn''t displayed in certain parts of the Outlook user interface: in the Address Book, in address lists for selecting message recipients, and in the Browse Groups dialog for searching groups; false otherwise. The default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'true if the group isn''t displayed in certain parts of the Outlook user interface: in the Address Book, in address lists for selecting message recipients, and in the Browse Groups dialog for searching groups; false otherwise. The default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             hideFromOutlookClients:
               type: boolean
-              description: 'true if the group isn''t displayed in Outlook clients, such as Outlook for Windows and Outlook on the web, false otherwise. The default value is false. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'true if the group isn''t displayed in Outlook clients, such as Outlook for Windows and Outlook on the web, false otherwise. The default value is false. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             infoCatalogs:
               type: array
@@ -100433,7 +115738,7 @@ components:
               nullable: true
             isSubscribedByMail:
               type: boolean
-              description: 'Indicates whether the signed-in user is subscribed to receive email conversations. The default value is true. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates whether the signed-in user is subscribed to receive email conversations. The default value is true. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             licenseProcessingState:
               $ref: '#/components/schemas/microsoft.graph.licenseProcessingState'
@@ -100463,6 +115768,8 @@ components:
               type: string
               description: 'Contains the on-premises domain FQDN, also called dnsDomainName synchronized from the on-premises directory. The property is only populated for customers synchronizing their on-premises directory to Microsoft Entra ID via Microsoft Entra Connect.Returned by default. Read-only.'
               nullable: true
+            onPremisesExtensionAttributes:
+              $ref: '#/components/schemas/microsoft.graph.onPremisesExtensionAttributes'
             onPremisesLastSyncDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
@@ -100521,7 +115828,7 @@ components:
               type: array
               items:
                 type: string
-              description: 'Specifies the group resources that are associated with the Microsoft 365 group. The possible value is Team. For more information, see Microsoft 365 group behaviors and provisioning options. Returned by default. Supports $filter (eq, not, startsWith.'
+              description: 'Specifies the group resources that are associated with the Microsoft 365 group. The possible value is Team. For more information, see Microsoft 365 group behaviors and provisioning options. Returned by default. Supports $filter (eq, not, startsWith).'
             securityEnabled:
               type: boolean
               description: 'Specifies whether the group is a security group. Required.Returned by default. Supports $filter (eq, ne, not, in).'
@@ -100547,21 +115854,21 @@ components:
               maximum: 2147483647
               minimum: -2147483648
               type: number
-              description: Count of conversations delivered one or more new posts since the signed-in user's last visit to the group. This property is the same as unseenCount. Returned only on $select.
+              description: Count of conversations delivered one or more new posts since the signed-in user's last visit to the group. This property is the same as unseenCount. Requires $select to retrieve.
               format: int32
               nullable: true
             unseenCount:
               maximum: 2147483647
               minimum: -2147483648
               type: number
-              description: 'Count of conversations that have received new posts since the signed-in user last visited the group. This property is the same as unseenConversationsCount.Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Count of conversations that have received new posts since the signed-in user last visited the group. This property is the same as unseenConversationsCount.Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               format: int32
               nullable: true
             unseenMessagesCount:
               maximum: 2147483647
               minimum: -2147483648
               type: number
-              description: Count of new posts that have been delivered to the group's conversations since the signed-in user's last visit to the group. Returned only on $select.
+              description: Count of new posts that have been delivered to the group's conversations since the signed-in user's last visit to the group. Requires $select to retrieve.
               format: int32
               nullable: true
             visibility:
@@ -100570,7 +115877,7 @@ components:
               nullable: true
             welcomeMessageEnabled:
               type: boolean
-              description: 'Indicates whether a welcome message is sent to new members when they are added to the group. The default value is true. Returned only on $select. Supported only on the Get group API (GET /groups/{ID}).'
+              description: 'Indicates whether a welcome message is sent to new members when they are added to the group. The default value is true. Requires $select to retrieve. Supported only on the Get group API (GET /groups/{ID}).'
               nullable: true
             writebackConfiguration:
               $ref: '#/components/schemas/microsoft.graph.groupWritebackConfiguration'
@@ -100746,7 +116053,7 @@ components:
           properties:
             aboutMe:
               type: string
-              description: A freeform text entry field for users to describe themselves. Returned only on $select.
+              description: A freeform text entry field for users to describe themselves. Requires $select to retrieve.
               nullable: true
             accountEnabled:
               type: boolean
@@ -100771,7 +116078,7 @@ components:
             birthday:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'The birthday of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z Returned only on $select.'
+              description: 'The birthday of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z Requires $select to retrieve.'
               format: date-time
             businessPhones:
               type: array
@@ -100869,13 +116176,15 @@ components:
             hireDate:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'The hire date of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.  Returned only on $select.  Note: This property is specific to SharePoint Online. We recommend using the native employeeHireDate property to set and update hire date values using Microsoft Graph APIs.'
+              description: 'The hire date of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.  Requires $select to retrieve.  Note: This property is specific to SharePoint Online. We recommend using the native employeeHireDate property to set and update hire date values using Microsoft Graph APIs.'
               format: date-time
             identities:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.objectIdentity'
               description: 'Represents the identities that can be used to sign in to this user account. An identity can be provided by Microsoft (also known as a local account), by organizations, or by social identity providers such as Facebook, Google, and Microsoft and tied to a user account. It may contain multiple items with the same signInType value.  Supports $filter (eq) with limitations.'
+            identityGovernance:
+              $ref: '#/components/schemas/microsoft.graph.identityGovernanceUserSettings'
             identityParentId:
               type: string
               description: 'The object ID of the parent identity for agent users. Always null for regular user accounts. For agentUser resources, this property references the object ID of the associated agent identity.'
@@ -100896,7 +116205,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for users to describe their interests. Returned only on $select.
+              description: A list for users to describe their interests. Requires $select to retrieve.
             isLicenseReconciliationNeeded:
               type: boolean
               description: Indicates whether the user is pending an exchange mailbox license assignment.  Read-only.  Supports $filter (eq where true only).
@@ -100907,7 +116216,7 @@ components:
               nullable: true
             isResourceAccount:
               type: boolean
-              description: Do not use – reserved for future use.
+              description: Do not use. Reserved for future use.
               nullable: true
             jobTitle:
               type: string
@@ -100916,18 +116225,18 @@ components:
             lastPasswordChangeDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
-              description: 'When this Microsoft Entra user last changed their password or when their password was created, whichever date the latest action was performed. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only. Returned only on $select.'
+              description: 'When this Microsoft Entra user last changed their password or when their password was created, whichever date the latest action was performed. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. Read-only. Requires $select to retrieve.'
               format: date-time
               nullable: true
             legalAgeGroupClassification:
               type: string
-              description: 'Used by enterprise applications to determine the legal age group of the user. This property is read-only and calculated based on ageGroup and consentProvidedForMinor properties. Allowed values: null, Undefined, MinorWithOutParentalConsent, MinorWithParentalConsent, MinorNoParentalConsentRequired, NotAdult, and Adult. For more information, see legal age group property definitions. Returned only on $select.'
+              description: 'Used by enterprise applications to determine the legal age group of the user. This property is read-only and calculated based on ageGroup and consentProvidedForMinor properties. Allowed values: null, Undefined, MinorWithOutParentalConsent, MinorWithParentalConsent, MinorNoParentalConsentRequired, NotAdult, and Adult. For more information, see legal age group property definitions. Requires $select to retrieve.'
               nullable: true
             licenseAssignmentStates:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.licenseAssignmentState'
-              description: State of license assignments for this user. It also indicates licenses that are directly assigned and the ones the user inherited through group memberships. Read-only. Returned only on $select.
+              description: State of license assignments for this user. It also indicates licenses that are directly assigned and the ones the user inherited through group memberships. Read-only. Requires $select to retrieve.
             mail:
               type: string
               description: 'The SMTP address for the user, for example, admin@contoso.com. Changes to this property also update the user''s proxyAddresses collection to include the value as an SMTP address. This property can''t contain accent characters.  NOTE: We don''t recommend updating this property for Azure AD B2C user profiles. Use the otherMails property instead.  Supports $filter (eq, ne, not, ge, le, in, startsWith, endsWith, and eq on null values).'
@@ -100944,7 +116253,7 @@ components:
               nullable: true
             mySite:
               type: string
-              description: The URL for the user's site. Returned only on $select.
+              description: The URL for the user's site. Requires $select to retrieve.
               nullable: true
             officeLocation:
               type: string
@@ -101009,7 +116318,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for users to enumerate their past projects. Returned only on $select.
+              description: A list for users to enumerate their past projects. Requires $select to retrieve.
             postalCode:
               type: string
               description: 'The postal code for the user''s postal address. The postal code is specific to the user''s country/region. In the United States of America, this attribute contains the ZIP code. Maximum length is 40 characters. Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values).'
@@ -101024,7 +116333,7 @@ components:
               nullable: true
             preferredName:
               type: string
-              description: The preferred name for the user. Not Supported. This attribute returns an empty string.Returned only on $select.
+              description: The preferred name for the user. Not Supported. This attribute returns an empty string.Requires $select to retrieve.
               nullable: true
             print:
               $ref: '#/components/schemas/microsoft.graph.userPrint'
@@ -101049,13 +116358,13 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for the user to enumerate their responsibilities. Returned only on $select.
+              description: A list for the user to enumerate their responsibilities. Requires $select to retrieve.
             schools:
               type: array
               items:
                 type: string
                 nullable: true
-              description: A list for the user to enumerate the schools they have attended. Returned only on $select.
+              description: A list for the user to enumerate the schools they have attended. Requires $select to retrieve.
             securityIdentifier:
               type: string
               description: 'Security identifier (SID) of the user, used in Windows scenarios. Read-only. Returned by default. Supports $select and $filter (eq, not, ge, le, startsWith).'
@@ -101082,7 +116391,7 @@ components:
               items:
                 type: string
                 nullable: true
-              description: A list for the user to enumerate their skills. Returned only on $select.
+              description: A list for the user to enumerate their skills. Requires $select to retrieve.
             state:
               type: string
               description: 'The state or province in the user''s address. Maximum length is 128 characters. Supports $filter (eq, ne, not, ge, le, in, startsWith, and eq on null values).'
@@ -101177,6 +116486,12 @@ components:
               x-ms-navigationProperty: true
             cloudClipboard:
               $ref: '#/components/schemas/microsoft.graph.cloudClipboardRoot'
+            cloudPcPools:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudPcPool'
+              description: The user's Cloud PC pools. Read-only. Nullable.
+              x-ms-navigationProperty: true
             cloudPCs:
               type: array
               items:
@@ -102425,6 +117740,12 @@ components:
                 $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallation'
               description: The apps installed in the personal scope of this user.
               x-ms-navigationProperty: true
+            sections:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSection'
+              description: The sections in the user's chat list.
+              x-ms-navigationProperty: true
           additionalProperties:
             type: object
     microsoft.graph.associatedTeamInfo:
@@ -102442,6 +117763,71 @@ components:
           properties:
             chat:
               $ref: '#/components/schemas/microsoft.graph.chat'
+          additionalProperties:
+            type: object
+    microsoft.graph.teamworkSection:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: teamworkSection
+          type: object
+          properties:
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the section was created. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            displayIcon:
+              $ref: '#/components/schemas/microsoft.graph.sectionDisplayIcon'
+            displayName:
+              type: string
+              description: 'The display name of the section. Required. Maximum length is 50 characters. Display names are case-sensitive and must be unique within a user''s sections. The following names are reserved for system-defined sections and can''t be used when creating a user-defined section: RecentChats, QuickViews, TeamsAndChannels, MutedChats, MeetingChats, EngageCommunities.'
+            isExpanded:
+              type: boolean
+              description: Indicates whether the section is expanded in the user interface. The default value is true.
+              nullable: true
+            isHierarchicalViewEnabled:
+              type: boolean
+              description: Indicates whether the hierarchical view is enabled for the section. Read-only.
+              nullable: true
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the section was last modified. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            sectionType:
+              $ref: '#/components/schemas/microsoft.graph.sectionType'
+            sortType:
+              $ref: '#/components/schemas/microsoft.graph.sectionSortType'
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.teamworkSectionItem'
+              description: 'The items (chats, channels, meetings, or communities) organized within the section.'
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+    microsoft.graph.teamworkSectionItem:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: teamworkSectionItem
+          type: object
+          properties:
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the item was added to the section. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
+            itemType:
+              $ref: '#/components/schemas/microsoft.graph.sectionItemType'
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'Date and time when the item was last modified. Read-only. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2024, is 2024-01-01T00:00:00Z.'
+              format: date-time
+              nullable: true
           additionalProperties:
             type: object
     microsoft.graph.entity:
@@ -103242,8 +118628,12 @@ components:
       title: file
       type: object
       properties:
+        archiveStatus:
+          $ref: '#/components/schemas/microsoft.graph.fileArchiveStatus'
         hashes:
           $ref: '#/components/schemas/microsoft.graph.hashes'
+        lockInfo:
+          $ref: '#/components/schemas/microsoft.graph.lockInfo'
         mimeType:
           type: string
           description: The MIME type for the file. This is determined by logic on the server and might not be the value provided when the file was uploaded. Read-only.
@@ -104163,6 +119553,45 @@ components:
       type: object
       additionalProperties:
         type: object
+    microsoft.graph.plannerTaskChatMention:
+      title: plannerTaskChatMention
+      type: object
+      properties:
+        mentioned:
+          type: string
+          description: The ID of the mentioned user.
+          nullable: true
+        mentionType:
+          $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMentionType'
+        position:
+          maximum: 2147483647
+          minimum: -2147483648
+          type: number
+          description: The zero-based position of the mention in the message content.
+          format: int32
+      additionalProperties:
+        type: object
+    microsoft.graph.plannerTaskChatMessageType:
+      title: plannerTaskChatMessageType
+      enum:
+        - richTextHtml
+        - plainText
+        - unknownFutureValue
+      type: string
+    microsoft.graph.plannerTaskChatReaction:
+      title: plannerTaskChatReaction
+      type: object
+      properties:
+        reactionEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.plannerTaskChatReactionEvent'
+        reactionType:
+          type: string
+          description: 'The type of reaction, such as like, heart, or emoji characters.'
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.plannerCategoryDescriptions:
       title: plannerCategoryDescriptions
       type: object
@@ -104413,6 +119842,72 @@ components:
           nullable: true
         status:
           $ref: '#/components/schemas/microsoft.graph.MembershipRuleProcessingStatusDetails'
+      additionalProperties:
+        type: object
+    microsoft.graph.onPremisesExtensionAttributes:
+      title: onPremisesExtensionAttributes
+      type: object
+      properties:
+        extensionAttribute1:
+          type: string
+          description: First customizable extension attribute.
+          nullable: true
+        extensionAttribute10:
+          type: string
+          description: Tenth customizable extension attribute.
+          nullable: true
+        extensionAttribute11:
+          type: string
+          description: Eleventh customizable extension attribute.
+          nullable: true
+        extensionAttribute12:
+          type: string
+          description: Twelfth customizable extension attribute.
+          nullable: true
+        extensionAttribute13:
+          type: string
+          description: Thirteenth customizable extension attribute.
+          nullable: true
+        extensionAttribute14:
+          type: string
+          description: Fourteenth customizable extension attribute.
+          nullable: true
+        extensionAttribute15:
+          type: string
+          description: Fifteenth customizable extension attribute.
+          nullable: true
+        extensionAttribute2:
+          type: string
+          description: Second customizable extension attribute.
+          nullable: true
+        extensionAttribute3:
+          type: string
+          description: Third customizable extension attribute.
+          nullable: true
+        extensionAttribute4:
+          type: string
+          description: Fourth customizable extension attribute.
+          nullable: true
+        extensionAttribute5:
+          type: string
+          description: Fifth customizable extension attribute.
+          nullable: true
+        extensionAttribute6:
+          type: string
+          description: Sixth customizable extension attribute.
+          nullable: true
+        extensionAttribute7:
+          type: string
+          description: Seventh customizable extension attribute.
+          nullable: true
+        extensionAttribute8:
+          type: string
+          description: Eighth customizable extension attribute.
+          nullable: true
+        extensionAttribute9:
+          type: string
+          description: Ninth customizable extension attribute.
+          nullable: true
       additionalProperties:
         type: object
     microsoft.graph.onPremisesProvisioningError:
@@ -105304,11 +120799,11 @@ components:
       properties:
         costCenter:
           type: string
-          description: The cost center associated with the user. Returned only on $select. Supports $filter.
+          description: The cost center associated with the user. Requires $select to retrieve. Supports $filter.
           nullable: true
         division:
           type: string
-          description: The name of the division in which the user works. Returned only on $select. Supports $filter.
+          description: The name of the division in which the user works. Requires $select to retrieve. Supports $filter.
           nullable: true
       additionalProperties:
         type: object
@@ -105328,6 +120823,14 @@ components:
           type: string
           description: 'Specifies the user sign-in types in your directory, such as emailAddress, userName, federated, or userPrincipalName. federated represents a unique identifier for a user from an issuer that can be in any format chosen by the issuer. Setting or updating a userPrincipalName identity updates the value of the userPrincipalName property on the user object. The validations performed on the userPrincipalName property on the user object, for example, verified domains and acceptable characters, are performed when setting or updating a userPrincipalName identity. Extra validation is enforced on issuerAssignedId when the sign-in type is set to emailAddress or userName. This property can also be set to any custom string.  For more information about filtering behavior for this property, see Filtering on the identities property of a user.'
           nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.identityGovernanceUserSettings:
+      title: identityGovernanceUserSettings
+      type: object
+      properties:
+        approverDelegate:
+          $ref: '#/components/schemas/microsoft.graph.approverDelegate'
       additionalProperties:
         type: object
     microsoft.graph.licenseAssignmentState:
@@ -105365,72 +120868,6 @@ components:
         state:
           type: string
           description: 'Indicate the current state of this assignment. Read-Only. The possible values are Active, ActiveWithError, Disabled, and Error.'
-          nullable: true
-      additionalProperties:
-        type: object
-    microsoft.graph.onPremisesExtensionAttributes:
-      title: onPremisesExtensionAttributes
-      type: object
-      properties:
-        extensionAttribute1:
-          type: string
-          description: First customizable extension attribute.
-          nullable: true
-        extensionAttribute10:
-          type: string
-          description: Tenth customizable extension attribute.
-          nullable: true
-        extensionAttribute11:
-          type: string
-          description: Eleventh customizable extension attribute.
-          nullable: true
-        extensionAttribute12:
-          type: string
-          description: Twelfth customizable extension attribute.
-          nullable: true
-        extensionAttribute13:
-          type: string
-          description: Thirteenth customizable extension attribute.
-          nullable: true
-        extensionAttribute14:
-          type: string
-          description: Fourteenth customizable extension attribute.
-          nullable: true
-        extensionAttribute15:
-          type: string
-          description: Fifteenth customizable extension attribute.
-          nullable: true
-        extensionAttribute2:
-          type: string
-          description: Second customizable extension attribute.
-          nullable: true
-        extensionAttribute3:
-          type: string
-          description: Third customizable extension attribute.
-          nullable: true
-        extensionAttribute4:
-          type: string
-          description: Fourth customizable extension attribute.
-          nullable: true
-        extensionAttribute5:
-          type: string
-          description: Fifth customizable extension attribute.
-          nullable: true
-        extensionAttribute6:
-          type: string
-          description: Sixth customizable extension attribute.
-          nullable: true
-        extensionAttribute7:
-          type: string
-          description: Seventh customizable extension attribute.
-          nullable: true
-        extensionAttribute8:
-          type: string
-          description: Eighth customizable extension attribute.
-          nullable: true
-        extensionAttribute9:
-          type: string
-          description: Ninth customizable extension attribute.
           nullable: true
       additionalProperties:
         type: object
@@ -105777,7 +121214,7 @@ components:
               description: 'The roles exposed by the application, which this service principal represents. For more information, see the appRoles property definition on the application entity. Not nullable.'
             createdByAppId:
               type: string
-              description: The appId (called Application (client) ID on the Microsoft Entra admin center) of the application used to create the service principal. Set internally by Microsoft Entra ID. Read-only.
+              description: The appId of the application that created this service principal. Set internally by Microsoft Entra ID. Read-only.
               nullable: true
             customSecurityAttributes:
               $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeValue'
@@ -106042,7 +121479,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.externalAuthenticationMethod'
-              description: Represents the external methods registered to a user for authentication.
+              description: Represents the external MFA registered to a user for authentication.
               x-ms-navigationProperty: true
             fido2Methods:
               type: array
@@ -106162,6 +121599,43 @@ components:
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
+    microsoft.graph.cloudPcPool:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: cloudPcPool
+          type: object
+          properties:
+            capabilities:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcPoolCapabilityConfiguration'
+            cloudPcConfiguration:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcConfiguration'
+            createdDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time when the pool was created. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2026 is 2026-01-01T00:00:00Z. Read-only.'
+              format: date-time
+            description:
+              type: string
+              description: The description of the pool. The maximum length is 512 characters.
+              nullable: true
+            displayName:
+              type: string
+              description: The display name of the pool. The name is unique across Cloud PC pools in an organization. The maximum length is 60 characters.
+            lastModifiedDateTime:
+              pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+              type: string
+              description: 'The date and time when the pool was last modified. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2026 is 2026-01-01T00:00:00Z. Read-only.'
+              format: date-time
+            networkConfiguration:
+              $ref: '#/components/schemas/microsoft.graph.cloudPcNetworkConfiguration'
+            assignments:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.cloudPcPoolAssignment'
+              description: The collection of assignments that grant user or service principal identities access to this pool.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
     microsoft.graph.cloudPC:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -106261,6 +121735,7 @@ components:
               items:
                 type: string
                 nullable: true
+              description: 'The scope IDs of the corresponding permission. Currently, it''s the Intune scope tag ID. Read-only.'
             servicePlanId:
               type: string
               description: The service plan ID of the Cloud PC.
@@ -106742,7 +122217,7 @@ components:
               nullable: true
             onPremisesSecurityIdentifier:
               type: string
-              description: The on-premises security identifier (SID) for the user who was synchronized from on-premises to the cloud. Read-only. Returned only on $select. Supports $filter (eq).
+              description: The on-premises security identifier (SID) for the user who was synchronized from on-premises to the cloud. Read-only. Requires $select to retrieve. Supports $filter (eq).
               nullable: true
             onPremisesSyncEnabled:
               type: boolean
@@ -106855,6 +122330,8 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.learningCourseActivity'
               x-ms-navigationProperty: true
+            storyline:
+              $ref: '#/components/schemas/microsoft.graph.storyline'
           additionalProperties:
             type: object
           description: Represents a container that exposes navigation properties for employee experience user resources.
@@ -107627,7 +123104,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.internetMessageHeader'
-              description: A collection of message headers defined by RFC5322. The set includes message headers indicating the network path taken by a message from the sender to the recipient. It can also contain custom message headers that hold app data for the message.  Returned only on applying a $select query option. Read-only.
+              description: A collection of message headers defined by RFC5322. The set includes message headers indicating the network path taken by a message from the sender to the recipient. It can also contain custom message headers that hold app data for the message.  Requires $select to retrieve. Read-only.
             internetMessageId:
               type: string
               description: The message ID in the format specified by RFC5322. Updatable only if isDraft is true.
@@ -109286,6 +124763,50 @@ components:
       type: string
       x-ms-enum-flags:
         isFlags: true
+    microsoft.graph.sectionDisplayIcon:
+      title: sectionDisplayIcon
+      type: object
+      properties:
+        contentUrl:
+          type: string
+          description: The URL to a custom icon image. Applicable when iconType is custom.
+          nullable: true
+        displayName:
+          type: string
+          description: The human-readable name of the icon.
+          nullable: true
+        iconType:
+          type: string
+          description: 'The type of icon. Use an emoji character such as 👍 for an emoji icon, or custom for a custom image icon.'
+        skinTone:
+          $ref: '#/components/schemas/microsoft.graph.sectionIconSkinTone'
+      additionalProperties:
+        type: object
+    microsoft.graph.sectionType:
+      title: sectionType
+      enum:
+        - userDefined
+        - systemDefined
+        - unknownFutureValue
+      type: string
+    microsoft.graph.sectionSortType:
+      title: sectionSortType
+      enum:
+        - mostRecent
+        - unreadThenMostRecent
+        - nameAlphabetical
+        - userDefinedCustomOrder
+        - unknownFutureValue
+      type: string
+    microsoft.graph.sectionItemType:
+      title: sectionItemType
+      enum:
+        - chat
+        - channel
+        - meeting
+        - community
+        - unknownFutureValue
+      type: string
     microsoft.graph.teamsAppCollectionResponse:
       title: Collection of teamsApp
       type: object
@@ -109454,6 +124975,19 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.targetedChatMessageCollectionResponse:
+      title: Collection of targetedChatMessage
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.targetedChatMessage'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.channelCollectionResponse:
       title: Collection of channel
       type: object
@@ -109501,6 +125035,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.plannerTask'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.plannerTaskChatMessageCollectionResponse:
+      title: Collection of plannerTaskChatMessage
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessage'
         '@odata.nextLink':
           type: string
           nullable: true
@@ -109857,6 +125404,32 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.teamworkSectionCollectionResponse:
+      title: Collection of teamworkSection
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.teamworkSection'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.teamworkSectionItemCollectionResponse:
+      title: Collection of teamworkSectionItem
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.teamworkSectionItem'
+        '@odata.nextLink':
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.teamsAppDashboardCardBotConfiguration:
       title: teamsAppDashboardCardBotConfiguration
       type: object
@@ -110067,6 +125640,14 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.fileArchiveStatus:
+      title: fileArchiveStatus
+      enum:
+        - notArchived
+        - fullyArchived
+        - reactivating
+        - unknownFutureValue
+      type: string
     microsoft.graph.hashes:
       title: hashes
       type: object
@@ -110087,6 +125668,28 @@ components:
           type: string
           description: This property isn't supported. Don't use.
           nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.lockInfo:
+      title: lockInfo
+      type: object
+      properties:
+        createdDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        expirationDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          format: date-time
+          nullable: true
+        lockType:
+          $ref: '#/components/schemas/microsoft.graph.lockType'
+        owners:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.userIdentity'
       additionalProperties:
         type: object
     microsoft.graph.folderView:
@@ -110352,6 +125955,8 @@ components:
           properties:
             group:
               $ref: '#/components/schemas/microsoft.graph.identity'
+            sharePointGroup:
+              $ref: '#/components/schemas/microsoft.graph.sharePointGroupIdentity'
             siteGroup:
               $ref: '#/components/schemas/microsoft.graph.sharePointIdentity'
             siteUser:
@@ -110823,6 +126428,26 @@ components:
       type: object
       additionalProperties:
         type: object
+    microsoft.graph.plannerTaskChatMentionType:
+      title: plannerTaskChatMentionType
+      enum:
+        - user
+        - application
+        - unknownFutureValue
+      type: string
+    microsoft.graph.plannerTaskChatReactionEvent:
+      title: plannerTaskChatReactionEvent
+      type: object
+      properties:
+        createdBy:
+          $ref: '#/components/schemas/microsoft.graph.identitySet'
+        createdDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The date and time when the reaction was added. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
+          format: date-time
+      additionalProperties:
+        type: object
     microsoft.graph.cloudLicensing.assignment:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -111244,6 +126869,13 @@ components:
             displayName:
               type: string
               description: The displayable title of the list.
+              nullable: true
+            itemCount:
+              maximum: 2147483647
+              minimum: -2147483648
+              type: number
+              description: The total count of items in the list. Read-only.
+              format: int32
               nullable: true
             list:
               $ref: '#/components/schemas/microsoft.graph.listInfo'
@@ -112023,6 +127655,16 @@ components:
               $ref: '#/components/schemas/microsoft.graph.directoryObject'
           additionalProperties:
             type: object
+    microsoft.graph.approverDelegate:
+      title: approverDelegate
+      type: object
+      properties:
+        delegate:
+          $ref: '#/components/schemas/microsoft.graph.userSet'
+        schedule:
+          $ref: '#/components/schemas/microsoft.graph.requestSchedule'
+      additionalProperties:
+        type: object
     microsoft.graph.printerShare:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.printerBase'
@@ -112411,7 +128053,7 @@ components:
           nullable: true
         key:
           type: string
-          description: 'Value for the key credential. Should be a Base64 encoded value. Returned only on $select for a single object, that is, GET applications/{applicationId}?$select=keyCredentials or GET servicePrincipals/{servicePrincipalId}?$select=keyCredentials; otherwise, it''s always null.  From a .cer certificate, you can read the key using the Convert.ToBase64String() method. For more information, see Get the certificate key.'
+          description: 'Value for the key credential. Should be a Base64 encoded value. Requires $select to retrieve; only available for single object requests (GET /applications/{applicationId}?$select=keyCredentials or GET /servicePrincipals/{servicePrincipalId}?$select=keyCredentials); otherwise, it''s always null.  From a .cer certificate, you can read the key using the Convert.ToBase64String() method. For more information, see Get the certificate key.'
           format: base64url
           nullable: true
         keyId:
@@ -112690,12 +128332,13 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.approvedClientApp'
+              description: The collection of approved client apps that are associated with the RDS configuration. Supports $expand.
               x-ms-navigationProperty: true
             targetDeviceGroups:
               type: array
               items:
                 $ref: '#/components/schemas/microsoft.graph.targetDeviceGroup'
-              description: The collection of target device groups that are associated with the RDS security configuration that will be enabled for SSO when a client connects to the target device over RDP using the new Microsoft Entra ID RDS authentication protocol. <br/<Supports $expand.
+              description: The collection of target device groups that are associated with the RDS security configuration that will be enabled for SSO when a client connects to the target device over RDP using the new Microsoft Entra ID RDS authentication protocol.
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
@@ -112817,7 +128460,7 @@ components:
               description: A unique identifier used to manage the external auth method within Microsoft Entra ID.
             displayName:
               type: string
-              description: Custom name given to the registered external authentication method.
+              description: Custom name given to the registered external MFA.
           additionalProperties:
             type: object
     microsoft.graph.fido2AuthenticationMethod:
@@ -113101,6 +128744,41 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.cloudClipboardItemPayload'
               description: A cloudClipboardItem can have multiple cloudClipboardItemPayload objects in the payloads. A window can place more than one clipboard object on the clipboard. Each one represents the same information in a different clipboard format.
+          additionalProperties:
+            type: object
+    microsoft.graph.cloudPcPoolCapabilityConfiguration:
+      title: cloudPcPoolCapabilityConfiguration
+      type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.cloudPcConfiguration:
+      title: cloudPcConfiguration
+      type: object
+      properties:
+        imageDisplayName:
+          type: string
+          description: The display name of the image. Read-only.
+          nullable: true
+        imageId:
+          type: string
+          description: 'The unique identifier of the operating system image used for provisioning new Cloud PCs. The format for a gallery type image is: {publisherNameofferNameskuName}.'
+        imageType:
+          $ref: '#/components/schemas/microsoft.graph.cloudPcProvisioningPolicyImageType'
+        osLocale:
+          type: string
+          description: The operating system locale for the Cloud PC.
+      additionalProperties:
+        type: object
+    microsoft.graph.cloudPcNetworkConfiguration:
+      title: cloudPcNetworkConfiguration
+      type: object
+      additionalProperties:
+        type: object
+    microsoft.graph.cloudPcPoolAssignment:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: cloudPcPoolAssignment
+          type: object
           additionalProperties:
             type: object
     microsoft.graph.cloudPcConnectionSetting:
@@ -113811,6 +129489,27 @@ components:
               $ref: '#/components/schemas/microsoft.graph.courseStatus'
           additionalProperties:
             type: object
+    microsoft.graph.storyline:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: storyline
+          type: object
+          properties:
+            followers:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.storylineFollower'
+              description: The users who are following this user.
+              x-ms-navigationProperty: true
+            followings:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.storylineFollowing'
+              description: The users that this user is following.
+              x-ms-navigationProperty: true
+          additionalProperties:
+            type: object
+          description: User's storyline singleton container.
     microsoft.graph.inferenceClassificationOverride:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -115809,6 +131508,10 @@ components:
               type: string
               description: Current anti malware version
               nullable: true
+            controlledConfigurationEnabled:
+              type: boolean
+              description: 'When TRUE indicates the Windows Defender controlled configuration feature is enabled, when FALSE indicates the Windows Defender controlled configuration feature is not enabled. Defaults to setting on client device.'
+              nullable: true
             deviceState:
               $ref: '#/components/schemas/microsoft.graph.windowsDeviceHealthState'
             engineVersion:
@@ -116131,6 +131834,8 @@ components:
               $ref: '#/components/schemas/microsoft.graph.chatInfo'
             chatRestrictions:
               $ref: '#/components/schemas/microsoft.graph.chatRestrictions'
+            cloudVideoInteropInfo:
+              $ref: '#/components/schemas/microsoft.graph.cloudVideoInteropInfo'
             expiryDateTime:
               pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
               type: string
@@ -117460,6 +133165,7 @@ components:
           properties:
             inPlaceArchiveMailboxId:
               type: string
+              description: The unique identifier for the user's In-Place Archive mailbox.
               nullable: true
             primaryMailboxId:
               type: string
@@ -117602,6 +133308,12 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.extension'
               description: The collection of open extensions defined for the task list. Nullable.
+              x-ms-navigationProperty: true
+            singleValueExtendedProperties:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.singleValueExtendedProperty'
+              description: The collection of single-value extended properties defined for the task list. Read-only. Nullable.
               x-ms-navigationProperty: true
             tasks:
               type: array
@@ -117977,6 +133689,16 @@ components:
         - sharedSecret
         - unknownFutureValue
       type: string
+    microsoft.graph.sectionIconSkinTone:
+      title: sectionIconSkinTone
+      enum:
+        - light
+        - mediumLight
+        - medium
+        - mediumDark
+        - dark
+        - unknownFutureValue
+      type: string
     microsoft.graph.ODataErrors.MainError:
       required:
         - code
@@ -118014,6 +133736,30 @@ components:
         - $ref: '#/components/schemas/microsoft.graph.identity'
         - title: teamworkTagIdentity
           type: object
+          additionalProperties:
+            type: object
+    microsoft.graph.lockType:
+      title: lockType
+      enum:
+        - none
+        - exclusive
+        - shared
+        - unknownFutureValue
+      type: string
+    microsoft.graph.userIdentity:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.identity'
+        - title: userIdentity
+          type: object
+          properties:
+            ipAddress:
+              type: string
+              description: Indicates the client IP address associated with the user performing the activity (audit log only).
+              nullable: true
+            userPrincipalName:
+              type: string
+              description: The userPrincipalName attribute of the user.
+              nullable: true
           additionalProperties:
             type: object
     microsoft.graph.mediaSourceContentCategory:
@@ -118237,6 +133983,22 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.sharePointGroupIdentity:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.identity'
+        - title: sharePointGroupIdentity
+          type: object
+          properties:
+            principalId:
+              type: string
+              description: The principal ID of the SharePoint group in the tenant. Read-only.
+              nullable: true
+            title:
+              type: string
+              description: The title of the SharePoint group. Read-only.
+              nullable: true
+          additionalProperties:
+            type: object
     microsoft.graph.sharePointIdentity:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.identity'
@@ -118906,6 +134668,7 @@ components:
         archivedDateTime:
           pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
           type: string
+          description: 'Time when the container was archived. The timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.'
           format: date-time
           nullable: true
         archiveStatus:
@@ -119478,6 +135241,32 @@ components:
               x-ms-navigationProperty: true
           additionalProperties:
             type: object
+    microsoft.graph.userSet:
+      title: userSet
+      type: object
+      properties:
+        isBackup:
+          type: boolean
+          description: 'For a user in an approval stage, this property indicates whether the user is a backup fallback approver.'
+          nullable: true
+      additionalProperties:
+        type: object
+    microsoft.graph.requestSchedule:
+      title: requestSchedule
+      type: object
+      properties:
+        expiration:
+          $ref: '#/components/schemas/microsoft.graph.expirationPattern'
+        recurrence:
+          $ref: '#/components/schemas/microsoft.graph.patternedRecurrence'
+        startDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z. In PIM, when the  eligible or active assignment becomes active.'
+          format: date-time
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.printerBase:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -119777,6 +135566,7 @@ components:
           properties:
             displayName:
               type: string
+              description: Display name for the client application.
               nullable: true
           additionalProperties:
             type: object
@@ -120077,6 +135867,13 @@ components:
           description: For a list of possible values see formatName values.
       additionalProperties:
         type: object
+    microsoft.graph.cloudPcProvisioningPolicyImageType:
+      title: cloudPcProvisioningPolicyImageType
+      enum:
+        - gallery
+        - custom
+        - unknownFutureValue
+      type: string
     microsoft.graph.cloudPcHealthCheckItem:
       title: cloudPcHealthCheckItem
       type: object
@@ -120106,6 +135903,8 @@ components:
         - availableWithWarning
         - unavailable
         - unknownFutureValue
+        - underServiceMaintenance
+        - inUse
       type: string
     microsoft.graph.cloudPcDisasterRecoveryCapabilityType:
       title: cloudPcDisasterRecoveryCapabilityType
@@ -120324,6 +136123,28 @@ components:
         - completed
         - unknownFutureValue
       type: string
+    microsoft.graph.storylineFollower:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: storylineFollower
+          type: object
+          properties:
+            follower:
+              $ref: '#/components/schemas/microsoft.graph.engagementIdentitySet'
+          additionalProperties:
+            type: object
+          description: Engagement storyline follower.
+    microsoft.graph.storylineFollowing:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: storylineFollowing
+          type: object
+          properties:
+            following:
+              $ref: '#/components/schemas/microsoft.graph.engagementIdentitySet'
+          additionalProperties:
+            type: object
+          description: Engagement storyline following.
     microsoft.graph.bitlockerRecoveryKey:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -121953,6 +137774,21 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.cloudVideoInteropInfo:
+      title: cloudVideoInteropInfo
+      type: object
+      properties:
+        moreInfoWebUrl:
+          type: string
+          nullable: true
+        tenantKey:
+          type: string
+          nullable: true
+        videoTeleconferenceId:
+          type: string
+          nullable: true
+      additionalProperties:
+        type: object
     microsoft.graph.joinMeetingIdSettings:
       title: joinMeetingIdSettings
       type: object
@@ -122126,6 +137962,11 @@ components:
               type: string
               description: Email address of the user associated with this attendance record.
               nullable: true
+            engagements:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.meetingEngagement'
+              description: The list of real-time participant interaction behaviors during a meeting.
             externalRegistrationInformation:
               $ref: '#/components/schemas/microsoft.graph.virtualEventExternalRegistrationInformation'
             identity:
@@ -122270,22 +138111,6 @@ components:
         - managerOrSponsor
         - unknownFutureValue
       type: string
-    microsoft.graph.userIdentity:
-      allOf:
-        - $ref: '#/components/schemas/microsoft.graph.identity'
-        - title: userIdentity
-          type: object
-          properties:
-            ipAddress:
-              type: string
-              description: Indicates the client IP address associated with the user performing the activity (audit log only).
-              nullable: true
-            userPrincipalName:
-              type: string
-              description: The userPrincipalName attribute of the user.
-              nullable: true
-          additionalProperties:
-            type: object
     microsoft.graph.accessReviewInstanceDecisionItemPermission:
       title: accessReviewInstanceDecisionItemPermission
       type: object
@@ -122592,7 +138417,7 @@ components:
       properties:
         abbreviation:
           type: string
-          description: 'Shortened name of the degree or program (example: PhD, MBA)'
+          description: 'Shortened name of the degree or program, for example, PhD and MBA.'
           nullable: true
         activities:
           type: array
@@ -122619,14 +138444,14 @@ components:
           items:
             type: string
             nullable: true
-          description: Majors and minors associated with the program. (if applicable)
+          description: 'Majors and minors associated with the program, if applicable.'
         grade:
           type: string
-          description: 'The final grade, class, GPA, or score.'
+          description: 'The final grade, class, grade point average (GPA), or score.'
           nullable: true
         notes:
           type: string
-          description: More notes the user provided.
+          description: More notes provided by the user.
           nullable: true
         webUrl:
           type: string
@@ -123091,6 +138916,18 @@ components:
         - flaggedEmails
         - unknownFutureValue
       type: string
+    microsoft.graph.singleValueExtendedProperty:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - title: singleValueExtendedProperty
+          type: object
+          properties:
+            value:
+              type: string
+              description: The value of the property.
+              nullable: true
+          additionalProperties:
+            type: object
     microsoft.graph.todoTask:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -123203,6 +139040,12 @@ components:
               items:
                 $ref: '#/components/schemas/microsoft.graph.virtualEventExternalInformation'
               description: 'The external information of a virtual event. Returned only for event organizers or coorganizers; otherwise, null.'
+            isRegistrationEnabled:
+              type: boolean
+              nullable: true
+            isRegistrationRequired:
+              type: boolean
+              nullable: true
             settings:
               $ref: '#/components/schemas/microsoft.graph.virtualEventSettings'
             startDateTime:
@@ -123247,13 +139090,6 @@ components:
         - $ref: '#/components/schemas/microsoft.graph.virtualEventRegistrationConfiguration'
         - title: virtualEventWebinarRegistrationConfiguration
           type: object
-          properties:
-            isManualApprovalEnabled:
-              type: boolean
-              nullable: true
-            isWaitlistEnabled:
-              type: boolean
-              nullable: true
           additionalProperties:
             type: object
     microsoft.graph.virtualEventRegistration:
@@ -123334,6 +139170,29 @@ components:
         - darkPink
         - darkYellow
         - unknownFutureValue
+        - darkRed
+        - cranberry
+        - darkOrange
+        - bronze
+        - peach
+        - gold
+        - lime
+        - forest
+        - lightGreen
+        - jade
+        - lightTeal
+        - darkTeal
+        - steel
+        - skyBlue
+        - blueGray
+        - lavender
+        - lilac
+        - plum
+        - magenta
+        - darkBrown
+        - beige
+        - charcoal
+        - silver
       type: string
     microsoft.graph.teamworkOnPremisesCalendarSyncConfiguration:
       title: teamworkOnPremisesCalendarSyncConfiguration
@@ -124030,6 +139889,26 @@ components:
               $ref: '#/components/schemas/microsoft.graph.termStore.term'
           additionalProperties:
             type: object
+    microsoft.graph.expirationPattern:
+      title: expirationPattern
+      type: object
+      properties:
+        duration:
+          pattern: '^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$'
+          type: string
+          description: 'The requestor''s desired duration of access represented in ISO 8601 format for durations. For example, PT3H refers to three hours.  If specified in a request, endDateTime shouldn''t be present and the type property should be set to afterDuration.'
+          format: duration
+          nullable: true
+        endDateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'Timestamp of date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014, is 2014-01-01T00:00:00Z.'
+          format: date-time
+          nullable: true
+        type:
+          $ref: '#/components/schemas/microsoft.graph.expirationPatternType'
+      additionalProperties:
+        type: object
     microsoft.graph.printerCapabilities:
       title: printerCapabilities
       type: object
@@ -124561,12 +140440,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.keyCredentialConfiguration'
-          x-ms-navigationProperty: true
+          description: Collection of certificate restrictions settings to be applied to an application or service principal.
         passwordCredentials:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.passwordCredentialConfiguration'
-          x-ms-navigationProperty: true
+          description: Collection of password restrictions settings to be applied to an application or service principal.
       additionalProperties:
         type: object
     microsoft.graph.customAppManagementApplicationConfiguration:
@@ -124901,7 +140780,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.processContentMetadataBase'
-          description: A collection of content entries to be processed. Each entry contains the content itself and its metadata. Use conversation metadata for content like prompts and responses and file metadata for files. Required.
+          description: 'A collection of content entries to be processed. Each entry contains the content itself and its metadata. Use conversation metadata for content like prompts and responses, file metadata for files, and content activity metadata for enforcement result status entries. Required.'
         deviceMetadata:
           $ref: '#/components/schemas/microsoft.graph.deviceMetadata'
         integratedAppMetadata:
@@ -124931,6 +140810,19 @@ components:
           - value: exclude
             description: 'Indicates out-filter, rule matching will not offer the payload to devices.'
             name: exclude
+    microsoft.graph.engagementIdentitySet:
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.identitySet'
+        - title: engagementIdentitySet
+          type: object
+          properties:
+            audience:
+              $ref: '#/components/schemas/microsoft.graph.identity'
+            group:
+              $ref: '#/components/schemas/microsoft.graph.identity'
+          additionalProperties:
+            type: object
+          description: The Viva Engage identities.
     microsoft.graph.volumeType:
       title: volumeType
       enum:
@@ -125630,6 +141522,24 @@ components:
           nullable: true
       additionalProperties:
         type: object
+    microsoft.graph.meetingEngagement:
+      title: meetingEngagement
+      type: object
+      properties:
+        dateTime:
+          pattern: '^[0-9]{4,}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]([.][0-9]{1,12})?(Z|[+-][0-9][0-9]:[0-9][0-9])$'
+          type: string
+          description: 'The UTC date and time when the engagement event occurred, in ISO 8601 format.'
+          format: date-time
+          nullable: true
+        engagementSubType:
+          type: string
+          description: 'The specific engagement action within the type (e.g., like, love, applause, laugh, surprised for reactions; raiseHand for hand; cameraOn for camera; unmute, mute for microphone).'
+          nullable: true
+        engagementType:
+          $ref: '#/components/schemas/microsoft.graph.meetingEngagementType'
+      additionalProperties:
+        type: object
     microsoft.graph.virtualEventExternalRegistrationInformation:
       title: virtualEventExternalRegistrationInformation
       type: object
@@ -125927,18 +141837,6 @@ components:
               nullable: true
           additionalProperties:
             type: object
-    microsoft.graph.singleValueExtendedProperty:
-      allOf:
-        - $ref: '#/components/schemas/microsoft.graph.entity'
-        - title: singleValueExtendedProperty
-          type: object
-          properties:
-            value:
-              type: string
-              description: The value of the property.
-              nullable: true
-          additionalProperties:
-            type: object
     microsoft.graph.communicationsIdentitySet:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.identitySet'
@@ -126008,6 +141906,13 @@ components:
         - title: virtualEventSession
           type: object
           properties:
+            capacity:
+              maximum: 2147483647
+              minimum: -2147483648
+              type: number
+              description: Represents the expected number of attendees for town hall session.
+              format: int32
+              nullable: true
             endDateTime:
               $ref: '#/components/schemas/microsoft.graph.dateTimeTimeZone'
             startDateTime:
@@ -126040,6 +141945,14 @@ components:
               type: number
               description: Total capacity of the virtual event.
               format: int32
+              nullable: true
+            isManualApprovalEnabled:
+              type: boolean
+              description: Indicates whether registrations require organizer approval before a participant is confirmed.
+              nullable: true
+            isWaitlistEnabled:
+              type: boolean
+              description: Indicates whether more registrants are automatically placed on a waitlist when capacity is reached.
               nullable: true
             registrationWebUrl:
               type: string
@@ -126423,6 +142336,14 @@ components:
       enum:
         - pin
         - reuse
+      type: string
+    microsoft.graph.expirationPatternType:
+      title: expirationPatternType
+      enum:
+        - notSpecified
+        - noExpiration
+        - afterDateTime
+        - afterDuration
       type: string
     microsoft.graph.printColorMode:
       title: printColorMode
@@ -127712,7 +143633,7 @@ components:
         maxLifetime:
           pattern: '^-?P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?([0-9]+([.][0-9]+)?S)?)?$'
           type: string
-          description: 'String value that indicates the maximum lifetime for key expiration, defined as an ISO 8601 duration. For example, P4DT12H30M5S represents four days, 12 hours, 30 minutes, and five seconds. This property is required when restrictionType is set to keyLifetime.'
+          description: 'String value that indicates the maximum lifetime for key expiration, defined as an ISO 8601 duration. For example, P4DT12H30M5S represents four days, 12 hours, 30 minutes, and five seconds. This property is required when restrictionType is set to asymmetricKeyLifetime.'
           format: duration
           nullable: true
         restrictForAppsCreatedAfterDateTime:
@@ -128082,6 +144003,8 @@ components:
       properties:
         content:
           $ref: '#/components/schemas/microsoft.graph.contentBase'
+        contentCategory:
+          $ref: '#/components/schemas/microsoft.graph.contentCategory'
         correlationId:
           type: string
           description: 'An identifier used to group multiple related content entries (for example, different parts of the same file upload, messages in a conversation).'
@@ -128203,6 +144126,15 @@ components:
         - deviceIntent
       type: string
       description: Authoring source of a policy
+    microsoft.graph.meetingEngagementType:
+      title: meetingEngagementType
+      enum:
+        - reaction
+        - hand
+        - camera
+        - microphone
+        - unknownFutureValue
+      type: string
     microsoft.graph.storageQuotaBreakdown:
       allOf:
         - $ref: '#/components/schemas/microsoft.graph.entity'
@@ -128546,7 +144478,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeExemption'
-          x-ms-navigationProperty: true
+          description: The collection of customSecurityAttributeExemption to exempt from the policy enforcement. Limit of 5.
       additionalProperties:
         type: object
     microsoft.graph.appKeyCredentialRestrictionType:
@@ -128607,7 +144539,7 @@ components:
           $ref: '#/components/schemas/microsoft.graph.appManagementPolicyActorExemptions'
         excludeAppsReceivingV2Tokens:
           type: boolean
-          description: 'If true, the restriction isn''t enforced for applications that are configured to receive V2 tokens in Microsoft Entra ID; else, the restriction isn''t enforced for those applications.'
+          description: 'If true, the restriction isn''t enforced for applications that are configured to receive V2 tokens in Microsoft Entra ID; else, the restriction is enforced for those applications.'
           nullable: true
         excludeSaml:
           type: boolean
@@ -128928,6 +144860,7 @@ components:
         - uploadFile
         - downloadText
         - downloadFile
+        - copyToClipboard
         - unknownFutureValue
       type: string
     microsoft.graph.contentBase:
@@ -128935,6 +144868,13 @@ components:
       type: object
       additionalProperties:
         type: object
+    microsoft.graph.contentCategory:
+      title: contentCategory
+      enum:
+        - none
+        - ai
+        - unknownFutureValue
+      type: string
     microsoft.graph.operatingSystemSpecifications:
       title: operatingSystemSpecifications
       type: object
@@ -128991,6 +144931,8 @@ components:
         - title: customSecurityAttributeExemption
           type: object
           properties:
+            id:
+              type: string
             operator:
               $ref: '#/components/schemas/microsoft.graph.customSecurityAttributeComparisonOperator'
           additionalProperties:
@@ -129450,6 +145392,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/microsoft.graph.teamsTabCollectionResponse'
+    microsoft.graph.targetedChatMessageCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.targetedChatMessageCollectionResponse'
     microsoft.graph.channelCollectionResponse:
       description: Retrieved collection
       content:
@@ -129474,6 +145422,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/microsoft.graph.plannerTaskCollectionResponse'
+    microsoft.graph.plannerTaskChatMessageCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.plannerTaskChatMessageCollectionResponse'
     microsoft.graph.sharedWithChannelTeamInfoCollectionResponse:
       description: Retrieved collection
       content:
@@ -129636,6 +145590,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/microsoft.graph.userScopeTeamsAppInstallationCollectionResponse'
+    microsoft.graph.teamworkSectionCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.teamworkSectionCollectionResponse'
+    microsoft.graph.teamworkSectionItemCollectionResponse:
+      description: Retrieved collection
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/microsoft.graph.teamworkSectionItemCollectionResponse'
   parameters:
     top:
       name: $top

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -14,6 +14,7 @@ Param(
     [switch] $EnableSigning,
     [switch] $ExcludeExampleTemplates,
     [switch] $ExcludeNotesSection,
+    [switch] $AllowUnsupportedNode,
     [switch] $Isolated
 )
 $ErrorActionPreference = 'Stop'
@@ -48,6 +49,13 @@ if (-not (Test-Path $ModuleMappingPath)) {
 
 # Build AutoREST.PowerShell submodule.
 Set-Location (Join-Path $ScriptRoot "../autorest.powershell")
+
+# Rush in autorest.powershell requires Node <20 per rush.json.
+# Allow bypassing this check when using Node 20+ for long path support.
+if ($AllowUnsupportedNode) {
+    $env:RUSH_ALLOW_UNSUPPORTED_NODEJS = '1'
+}
+
 npx --no-install rush install
 if ($LASTEXITCODE -ne 0) {
     throw "Command 'npx --no-install rush install' failed with exit code $LASTEXITCODE."

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -158,6 +158,16 @@ $Results = $ModuleToGenerate | ForEach-Object -Parallel {
     $Module = $_
     Write-Host -ForegroundColor Green "-------------'Generating $Module'-------------"
 
+    # ForEach-Object -Parallel runs each iteration in a separate runspace that does NOT inherit
+    # modules imported in the parent process. Re-import the Authentication module here so that
+    # Update-ModuleManifest (in BuildModule.ps1) can resolve the 'Microsoft.Graph.Authentication'
+    # RequiredModules entry; otherwise it fails with "module is not imported in the session" and
+    # the manifest is reported as invalid.
+    $AuthModuleManifest = $using:AuthModuleManifest
+    if (Test-Path $AuthModuleManifest) {
+        Import-Module $AuthModuleManifest -ErrorAction SilentlyContinue
+    }
+
     $ServiceModuleParams = @{
         Module                  = $Module
         ModulesSrc              = $using:ModulesSrc

--- a/tools/GenerateModules.ps1
+++ b/tools/GenerateModules.ps1
@@ -56,14 +56,19 @@ if ($AllowUnsupportedNode) {
     $env:RUSH_ALLOW_UNSUPPORTED_NODEJS = '1'
 }
 
-npx --no-install rush install
-if ($LASTEXITCODE -ne 0) {
-    throw "Command 'npx --no-install rush install' failed with exit code $LASTEXITCODE."
+$rushBootstrapScript = Join-Path (Get-Location) "common/scripts/install-run-rush.js"
+if (-not (Test-Path $rushBootstrapScript)) {
+    throw "Rush bootstrap script not found: $rushBootstrapScript"
 }
 
-npx --no-install rush build
+node $rushBootstrapScript install
 if ($LASTEXITCODE -ne 0) {
-    throw "Command 'npx --no-install rush build' failed with exit code $LASTEXITCODE."
+    throw "Command 'node common/scripts/install-run-rush.js install' failed with exit code $LASTEXITCODE."
+}
+
+node $rushBootstrapScript build
+if ($LASTEXITCODE -ne 0) {
+    throw "Command 'node common/scripts/install-run-rush.js build' failed with exit code $LASTEXITCODE."
 }
 
 # Diagnostic: show autorest cache state and npm registry config before generation.
@@ -117,8 +122,11 @@ if ($ModuleToGenerate.Count -eq 0) {
 
 #This is to ensure that the autorest temp folder is cleared before generating the modules
 $TempPath = [System.IO.Path]::GetTempPath()
-# Check if there is any folder with autorest in the name
-$AutoRestTempFolder = Get-ChildItem -Path $TempPath -Recurse -Directory | Where-Object { $_.Name -match "autorest" }
+# Check if there is any folder with autorest in the name.
+# Use -ErrorAction SilentlyContinue so that access-denied errors on temp entries owned or
+# locked by other users/processes (common on shared build agents) don't abort the whole run
+# because of $ErrorActionPreference = 'Stop'.
+$AutoRestTempFolder = Get-ChildItem -Path $TempPath -Recurse -Directory -ErrorAction SilentlyContinue | Where-Object { $_.Name -match "autorest" }
 
 # Go through each folder and forcefully delete autorest related files
 $AutoRestTempFolder | ForEach-Object {
@@ -126,12 +134,18 @@ $AutoRestTempFolder | ForEach-Object {
     #Delete files and folders if they exist
     if (Test-Path $AutoRestTempFolder.FullName) {
         #Check if each file in the folder exists
-        Get-ChildItem -Path $AutoRestTempFolder.FullName -Recurse | ForEach-Object {
+        Get-ChildItem -Path $AutoRestTempFolder.FullName -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
             $File = $_
             Write-Debug "Removing cached file $File"
             if (Test-Path $File.FullName) {
-                #Remove the file
-                Remove-Item -Path $File.FullName -Force -confirm:$false
+                #Remove the file. Skip entries we can't delete (locked/owned by another
+                #process) instead of failing the entire generation with an access-denied error.
+                try {
+                    Remove-Item -Path $File.FullName -Force -Confirm:$false -ErrorAction Stop
+                }
+                catch {
+                    Write-Warning "Skipping cached file that could not be removed: $($File.FullName). $($_.Exception.Message)"
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

The CI build fails with \ENOENT\ errors on generated files with paths exceeding 260 characters (e.g., the Reports module has paths ~309 chars long). The previously added \eg add\ for \LongPathsEnabled\ had no effect.

## Root Cause

The Windows \LongPathsEnabled\ registry key only works for applications that declare \longPathAware\ in their PE manifest. **Node.js 18 does not include this flag** — it was added in Node.js 20. Since autorest (which generates the C# files) runs on Node.js, the registry key was silently ignored.

## Fix

- Upgrade Node.js from 18.x to 20.x in the pipeline
- Add \RUSH_ALLOW_UNSUPPORTED_NODEJS=1\ for Rush commands (rush.json in the autorest.powershell submodule constrains to \<20\, but this is a soft guard)
- Pass \-AllowUnsupportedNode\ to all \GenerateModules.ps1\ calls (which sets the same env var internally)

## Risk

Low — Node 20 is backward-compatible with 18 for the npm/rush/autorest ecosystem. The autorest.powershell packages declare \ngines.node: >=10.12.0\ with no upper bound. If any issue arises, it would manifest as an immediate build failure (not a subtle regression).