### PR TITLE
Also fail on Pester block/container failures (not just failed tests)

### DIFF
--- a/tools/TestModule.ps1
+++ b/tools/TestModule.ps1
@@ -36,4 +36,4 @@ $PesterConfiguration.TestResult.Enabled = $true
 $PesterConfiguration.TestResult.OutputPath = (Join-Path $ModuleTestsPath "$moduleName-TestResults.xml")
 
 $TestResults = Invoke-Pester -Configuration $PesterConfiguration
-If ($TestResults.FailedCount -gt 0) { Write-Error "$($TestResults.FailedCount) tests failed." }
+If (($TestResults.FailedCount + $TestResults.FailedBlocksCount + $TestResults.FailedContainersCount) -gt 0) { Write-Error "Pester run failed: $($TestResults.FailedCount) failed test(s), $($TestResults.FailedBlocksCount) failed block(s), $($TestResults.FailedContainersCount) failed container(s), of $($TestResults.TotalCount) total tests" }


### PR DESCRIPTION
> ⚠️ This PR was generated by an AI agent (GitHub Copilot CLI). Please review accordingly.

I've been seeing this commonly across Pester 5 build scripts and I'm fixing it where it looks like it could hide real failures.

In Pester 5 a run reports three independent failure counts:

- `FailedCount` — failed tests (`It`)
- `FailedBlocksCount` — failed `BeforeAll` / `AfterAll`
- `FailedContainersCount` — files that error during discovery / fail to load

Gating on only `FailedCount` means a `BeforeAll` that throws, or a test file that fails to load, leaves `FailedCount = 0` and the build passes green despite real failures. Pester itself derives the overall pass/fail from the sum of all three.

This includes all three counts in the gate, and surfaces each count (failed tests, blocks, containers) in the reported output instead of only the failed test count.
