### PR TITLE
release: bump module version to 2.38.1

### DIFF
--- a/config/ModuleMetadata.json
+++ b/config/ModuleMetadata.json
@@ -27,15 +27,15 @@
   "versions": {
     "authentication": {
       "prerelease": "",
-      "version": "2.38.0"
+      "version": "2.38.1"
     },
     "beta": {
       "prerelease": "",
-      "version": "2.38.0"
+      "version": "2.38.1"
     },
     "v1.0": {
       "prerelease": "",
-      "version": "2.38.0"
+      "version": "2.38.1"
     }
   }
 }


### PR DESCRIPTION
## Summary

Bumps the module version from 2.38.0 to 2.38.1 in `config/ModuleMetadata.json` for the `authentication`, `beta`, and `v1.0` modules.

This patch release ships the latest auth changes (clear persisted MSAL token cache on `Disconnect-MgGraph`, #3649). The prior `v2.38.1` tag-triggered release failed because the version was not bumped in the config; this PR corrects that so the tag can be re-cut against the merged commit.

No `MgCommandMetadata.json` regeneration is required — this is an auth-only patch with no changes to command signatures, URIs, or output types.