### PR TITLE
fix: use x-access-token form for GitHub App token git push

### DIFF
--- a/.azure-pipelines/command-metadata-refresh.yml
+++ b/.azure-pipelines/command-metadata-refresh.yml
@@ -148,7 +148,7 @@ extends:
                 git status
                 git add "$(System.DefaultWorkingDirectory)/config/ModuleMetadata.json"
                 git commit -m 'Bump module versions after metadata generation.'
-                git push "https://$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git"
+                git push "https://x-access-token:$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git"
                 git status
                   
         - ${{ if eq(parameters.CreatePullRequest, true) }}:

--- a/.azure-pipelines/common-templates/create-pr.yml
+++ b/.azure-pipelines/common-templates/create-pr.yml
@@ -33,5 +33,5 @@ steps:
 
         git status
         gh auth login
-        git push "https://$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git"
+        git push "https://x-access-token:$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git"
         gh pr create -t $Title -b $Body -B $BaseBranchName -H $Head

--- a/.azure-pipelines/common-templates/download-openapi-docs.yml
+++ b/.azure-pipelines/common-templates/download-openapi-docs.yml
@@ -92,7 +92,7 @@ steps:
         git add .
         git commit -m 'Weekly OpenApiDocs Download.'
         git status
-        git push --set-upstream "https://$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git" $(Branch)
+        git push --set-upstream "https://x-access-token:$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git" $(Branch)
         git status
 
 # References

--- a/.azure-pipelines/generation-templates/generate-command-metadata.yml
+++ b/.azure-pipelines/generation-templates/generate-command-metadata.yml
@@ -30,5 +30,5 @@ steps:
         git status
         git add "$(System.DefaultWorkingDirectory)/src/Authentication/Authentication/custom/common/MgCommandMetadata.json"
         git commit -m 'Add generated MgCommandMetadata.json. [run ci]'
-        git push "https://$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git"
+        git push "https://x-access-token:$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git"
         git status

--- a/.azure-pipelines/weekly-examples-update.yml
+++ b/.azure-pipelines/weekly-examples-update.yml
@@ -96,7 +96,7 @@ extends:
               git status
               git add .
               git commit -m "Updating examples"
-              git push --set-upstream https://$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git $(ComputeBranch.WeeklyExamplesBranch)
+              git push --set-upstream "https://x-access-token:$(GITHUB_TOKEN)@github.com/microsoftgraph/msgraph-sdk-powershell.git" $(ComputeBranch.WeeklyExamplesBranch)
               git status
         - template: .azure-pipelines/common-templates/create-pr.yml@self
           parameters:


### PR DESCRIPTION
## Summary

Fixes the weekly generation pipelines failing to `git push` after the PAT was removed from ADO, following the move to GitHub App auth (#3657).

## Root cause

GitHub App **installation tokens** must authenticate as the **password** with the username `x-access-token`:

```
https://x-access-token:<token>@github.com/owner/repo.git
```

The previous form — `https://<token>@github.com/...` — puts the token in the **username** position with no password. That works for a **PAT** (which is why pushes succeeded while the PAT still existed in ADO), but an installation token in that position is rejected, so git falls back to prompting for a password and fails non-interactively:

```
The value of the GITHUB_TOKEN environment variable is being used for authentication.
fatal: Cannot prompt because user interactivity has been disabled.
fatal: could not read Password for 'https://***@github.com': terminal prompts disabled
```

## Fix

Prefixed all five pipeline push URLs with `x-access-token:`:

- `common-templates/create-pr.yml`
- `common-templates/download-openapi-docs.yml`
- `generation-templates/generate-command-metadata.yml`
- `weekly-examples-update.yml`
- `command-metadata-refresh.yml`

The `x-access-token:<token>` form is also valid for PATs, so this is backward compatible. `gh pr create` was unaffected (it uses `GITHUB_TOKEN` via the REST API, not a git URL).

**Note:** This pull request was created with assistance from GitHub Copilot.
