### PR TITLE
Update DevX API host name to graph-devx-api.microsoft.com

### DIFF
--- a/tools/DownloadOpenApiDoc.ps1
+++ b/tools/DownloadOpenApiDoc.ps1
@@ -13,7 +13,7 @@ if (-not (Test-Path $OpenApiDocOutput)) {
     New-Item -Path $OpenApiDocOutput -Type Directory
 }
 
-$OpenApiBaseUrl = "https://devxapi-func-prod-eastus.azurewebsites.net"
+$OpenApiBaseUrl = "https://graph-devx-api.microsoft.com"
 $OpenApiServiceUrl = ("$OpenApiBaseUrl/`$openapi?tags={0}&title=$ModuleName&openapiversion=3&style=Powershell&fileName=powershell_v2&graphVersion=$GraphVersion" -f $ModuleRegex)
 if ($ForceRefresh.IsPresent) {
     $OpenApiServiceUrl = "$OpenApiServiceUrl&forceRefresh=true"

--- a/tools/PostGeneration/NewCommandMetadata.ps1
+++ b/tools/PostGeneration/NewCommandMetadata.ps1
@@ -38,7 +38,7 @@ $OpenApiTagPattern = '\[OpenAPI\].s*(.*)=>(.*):\"(.*)\"'
 $ExternalDocsPattern = 'https://learn.microsoft.com/graph/api/(.*?(graph-rest-1.0|graph-rest-beta))'
 $AliasPattern = '\[global::System.Management.Automation.Alias(.*?)\]'
 $ActionFunctionFQNPattern = "\/Microsoft.Graph.(.*)$"
-$PermissionsUrl = "https://devxapi-func-prod-eastus.azurewebsites.net/permissions"
+$PermissionsUrl = "https://graph-devx-api.microsoft.com/permissions"
 
 Write-Debug "Crawling cmdlets in $CmdletPathPattern."
 $Stopwatch = [system.diagnostics.stopwatch]::StartNew()


### PR DESCRIPTION
## Description
Updates the DevX API host name following an infrastructure change.

- **Old:** `devxapi-func-prod-eastus.azurewebsites.net`
- **New:** `graph-devx-api.microsoft.com`

## Changes
- `tools/DownloadOpenApiDoc.ps1` — `\` now `https://graph-devx-api.microsoft.com`
- `tools/PostGeneration/NewCommandMetadata.ps1` — `\` now `https://graph-devx-api.microsoft.com/permissions`

Scheme (`https`) and all paths/query strings (`/permissions`, `/\...`) are preserved. These scripts are invoked by the OpenAPI generation, command-metadata-refresh, and weekly-examples-update pipelines; no pipeline YAML changes were required.

## Verification
`git grep` for the old host returns zero matches; the new host appears only in the two expected locations.

Fixes #3663