### PR TITLE
Fix docker-image-refresh: build via ACR Tasks to avoid Docker Hub on isolated pool

### DIFF
--- a/.azure-pipelines/docker-image-refresh.yml
+++ b/.azure-pipelines/docker-image-refresh.yml
@@ -24,6 +24,7 @@ parameters:
 
 variables:
   REGISTRY: 'msgraphprodregistry.azurecr.io'
+  REGISTRY_NAME: 'msgraphprodregistry'   # ACR resource name (az acr build uses this, not the FQDN)
   IMAGE_NAME: 'public/microsoftgraph/powershell'
 
 # Rebuild weekly so the image regularly picks up patched OS layers. `always: true` forces a run
@@ -71,31 +72,22 @@ extends:
         steps:
         - checkout: self
 
+        # Build server-side with ACR Tasks: no local Docker daemon, no buildx/QEMU, and no
+        # Docker Hub dependency (which the network-isolated 1ES pool can't reach). ACR pulls the
+        # base image from MCR and pushes the result back to the registry.
         - task: AzureCLI@2
-          displayName: 'Log in to Azure Container Registry'
+          displayName: 'Build and push patched image (ACR Tasks)'
           inputs:
             azureSubscription: 'ACR Images Push Service Connection'
             scriptType: 'bash'
             scriptLocation: 'inlineScript'
             inlineScript: |
-              az acr login --name $(REGISTRY)
-
-        - script: |
-            docker run --privileged --rm tonistiigi/binfmt --install all
-          displayName: 'Enable multi-platform builds'
-
-        - script: |
-            docker buildx create --use --name refreshbuilder
-          displayName: 'Set up Docker BuildX'
-
-        - bash: |
-            set -euo pipefail
-            formatted_date=$(date +"%Y%m%d%H%M%S")
-            echo "Rebuilding $(REGISTRY)/$(IMAGE_NAME) on a patched base"
-            docker buildx build \
-              --platform linux/amd64 \
-              --push \
-              -t "$(REGISTRY)/$(IMAGE_NAME):latest" \
-              -t "$(REGISTRY)/$(IMAGE_NAME):$formatted_date" \
-              "$(Build.SourcesDirectory)"
-          displayName: 'Build and push refreshed image'
+              set -euo pipefail
+              formatted_date=$(date +"%Y%m%d%H%M%S")
+              echo "Rebuilding $(REGISTRY_NAME) / $(IMAGE_NAME) on a patched base via ACR Tasks"
+              az acr build \
+                --registry $(REGISTRY_NAME) \
+                --image "$(IMAGE_NAME):latest" \
+                --image "$(IMAGE_NAME):$formatted_date" \
+                --platform linux/amd64 \
+                "$(Build.SourcesDirectory)"


### PR DESCRIPTION
Follow-up to the `docker-image-refresh` pipeline. On the network-isolated 1ES pool the build fails with:

> Unable to find image 'tonistiigi/binfmt:latest' locally
> docker: Error response from daemon: Get "https://registry-1.docker.io/v2/": ... Client.Timeout exceeded

**Cause:** `docker run … tonistiigi/binfmt` and `docker buildx create` pull helper images (`tonistiigi/binfmt`, `moby/buildkit`) from **Docker Hub**, which the isolated pool can't reach.

**Fix:** Build server-side with **ACR Tasks** (`az acr build`). ACR pulls the base from **MCR** and pushes the result back to the registry — no local Docker daemon, no buildx/QEMU, and no Docker Hub dependency. Single `linux/amd64` target, so no multi-arch emulation needed.

**Permissions note:** `az acr build` schedules an ACR Task run, so the `ACR Images Push Service Connection` identity needs task-scheduling rights (`Microsoft.ContainerRegistry/registries/scheduleRun/action` — included in **Contributor**), in addition to AcrPush. If the SP only has AcrPush, either grant that action or fall back to classic `docker build` + `docker push` (which pulls the base from MCR only).
