### PR TITLE
Change branch protection pattern to 'powershell-v3'

### DIFF
--- a/.github/policies/msgraph-sdk-powershell-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-powershell-branch-protection.yml
@@ -9,7 +9,7 @@ resource: repository
 configuration:
   branchProtectionRules:
 
-  - branchNamePattern: features/[0-9]*
+  - branchNamePattern: powershell-v3
     # This branch pattern applies to the following branches as of approximately 08/25/2023 14:07:25:
     # features/2.0
 


### PR DESCRIPTION
powershell-v3 is the not branch for developing v3 of powershell. Adjusting branch protection rules to target this branch specifically. 