### PR TITLE
Stop autorest upgrade-check from egressing to npmjs (CFSClean)

### DIFF
--- a/tools/GenerateServiceModule.ps1
+++ b/tools/GenerateServiceModule.ps1
@@ -88,7 +88,22 @@ $ApiVersion | ForEach-Object {
             }
 
             $autorestLog = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "autorest-$($ModuleFullName -replace '[^a-zA-Z0-9-]', '-').log")
-            npx --no-install autorest @modelerFourUseFlag --verbose --max-memory-size=$MaxMemorySize --module-version:$FullModuleVersion --module-name:$ModuleFullName --service-name:$Module --input-file:$OpenApiFile $AutoRestModuleConfig --max-cpu=2 --network-calls=2 2>&1 | Out-File -FilePath $autorestLog -Encoding utf8
+
+            # Belt-and-suspenders for 1ES network isolation (CFSClean): make autorest's internal
+            # npm-registry-fetch use the authenticated private feed configured in ~/.npmrc
+            # (set up by install-tools.yml) rather than defaulting to registry.npmjs.org.
+            if (-not $env:npm_config_registry) {
+                $userNpmrc = Join-Path $env:USERPROFILE ".npmrc"
+                if (Test-Path $userNpmrc) {
+                    $regLine = Select-String -Path $userNpmrc -Pattern '^registry=' | Select-Object -First 1
+                    if ($regLine) { $env:npm_config_registry = ($regLine.Line -replace '^registry=', '').Trim() }
+                }
+            }
+
+            # --skip-upgrade-check stops autorest core from querying registry.npmjs.org to check
+            # for a newer @autorest/core version (the residual CFSClean network-isolation leak;
+            # the @autorest/modelerfour extension is already supplied as a local --use above).
+            npx --no-install autorest @modelerFourUseFlag --skip-upgrade-check --verbose --max-memory-size=$MaxMemorySize --module-version:$FullModuleVersion --module-name:$ModuleFullName --service-name:$Module --input-file:$OpenApiFile $AutoRestModuleConfig --max-cpu=2 --network-calls=2 2>&1 | Out-File -FilePath $autorestLog -Encoding utf8
             $autorestExitCode = $LASTEXITCODE
             if ($autorestExitCode -ne 0) {
                 Write-Host -ForegroundColor Red "AutoREST failed (exit $autorestExitCode) generating '$ModuleFullName'."


### PR DESCRIPTION
## What
Stops the residual **CFSClean** network-isolation violation on the PowerShell generation pipelines (187 PowerShell V2 Build, 221 Weekly PowerShell V2 Build, 663 Command-Metadata-Refresh): `node.exe` -> `registry.npmjs.org` during autorest generation.

## Why
The repo already has a thorough private-feed npm setup (`Configure-PrivateNpmFeed.ps1`, `install-tools.yml` copying an authenticated `.npmrc` to `~/.npmrc`, `PrePopulateAutorestCache.ps1`, and `@autorest/modelerfour` passed as a local `--use:` path). The `PowerShell_V2_Build` feed serves the autorest packages from itself (verified), so package downloads don't leak.

The residual egress is autorest **core's upgrade check**. In `Azure/autorest`, `check-autorest-update.ts` queries the public npm registry unless `--skip-upgrade-check` is set:

```ts
if ((await networkEnabled) && !args["skip-upgrade-check"]) {
  // isAutorestUpdateAvailable(...) -> hits registry.npmjs.org
}
```

The generation invocation in `GenerateServiceModule.ps1` didn't set that flag, so every autorest run pinged npmjs to check for a newer `@autorest/core`.

## Changes (`tools/GenerateServiceModule.ps1`)
- Add **`--skip-upgrade-check`** to the `npx --no-install autorest ...` command (gates the exact code path above).
- Set **`npm_config_registry`** from the authenticated `~/.npmrc` before the call — belt-and-suspenders so any autorest `npm-registry-fetch` uses the private feed instead of defaulting to `registry.npmjs.org`. (No feed URL is hard-coded; it's read from the `.npmrc` that `install-tools.yml` already produced.)

## Notes
- The pre-populate cache already covers the only two npm extensions autorest resolves (`@autorest/core`, `@autorest/modelerfour`), and the PowerShell generator is a local submodule (`use:` local path) — so no cache expansion was needed; the leak was purely the upgrade check.
- Separately, these pipelines also trip **CFSClean2** on PowerShell Gallery (`www/cdn.powershellgallery.com`) — a looser tier, out of scope here.
- Needs a validation run on `main` post-merge to confirm the `registry.npmjs.org` egress is gone.

Relates to S360 KPI 527fb616-07aa-8198-6419-50d04ef1c2f3 (1ES network isolation).
