### PR TITLE
Force autorest cache pre-population onto the private npm feed (CFSClean)

### DIFF
--- a/tools/Utilities/PrePopulateAutorestCache.ps1
+++ b/tools/Utilities/PrePopulateAutorestCache.ps1
@@ -22,6 +22,21 @@ $extensions = @(
     "@autorest/modelerfour@4.24.3"
 )
 
+# Force these installs onto the authenticated private feed. `npm install --prefix <dir>` does not
+# reliably pick up the registry/auth from ~/.npmrc (it was observed hitting registry.npmjs.org
+# directly, breaking CFSClean network isolation), so pass --userconfig and --registry explicitly,
+# derived from the authenticated ~/.npmrc that install-tools.yml produced.
+$npmFeedArgs = @()
+$userNpmrc = Join-Path $env:USERPROFILE ".npmrc"
+if (Test-Path $userNpmrc) {
+    $npmFeedArgs += @('--userconfig', $userNpmrc)
+    $regLine = Select-String -Path $userNpmrc -Pattern '^registry=' | Select-Object -First 1
+    if ($regLine) { $npmFeedArgs += @('--registry', ($regLine.Line -replace '^registry=', '').Trim()) }
+}
+else {
+    Write-Host "WARNING: ~/.npmrc not found; npm install may reach the public registry (CFSClean risk)."
+}
+
 foreach ($ext in $extensions) {
     $parts   = $ext -split '@(?=[^@]+$)'   # split on last @
     $pkg     = $parts[0]
@@ -36,7 +51,8 @@ foreach ($ext in $extensions) {
 
     New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
     Write-Host "Pre-installing $ext into $cacheDir"
-    npm install $ext --prefix $cacheDir
+    npm install $ext --prefix $cacheDir @npmFeedArgs
     if ($LASTEXITCODE -ne 0) { throw "Failed to pre-install $ext (exit $LASTEXITCODE)" }
     Write-Host "Done: $ext"
 }
+


### PR DESCRIPTION
## What
Fixes the residual **CFSClean** network-isolation violation on the PowerShell pipelines (187/221/663): 2 `registry.npmjs.org` requests per build that remained after the autorest `--skip-upgrade-check` fix (#3696).

## Root cause
Traced from build telemetry + task logs: the 2 hits come from the **"Pre-populate autorest extension cache"** task. `PrePopulateAutorestCache.ps1` runs:

```powershell
npm install @autorest/core@3.10.4      --prefix <cacheDir>
npm install @autorest/modelerfour@4.24.3 --prefix <cacheDir>
```

With `--prefix`, npm did **not** honor the registry/auth in the authenticated `~/.npmrc` (produced by `install-tools.yml`) and reached `registry.npmjs.org` directly — each `npm install` = 1 hit, 2 total. The task meant to *prevent* autorest's npm calls was itself the leak.

## Change (`tools/Utilities/PrePopulateAutorestCache.ps1`)
Derive `--userconfig` and `--registry` from the authenticated `~/.npmrc` and pass them explicitly to each `npm install`, so both installs use the `PowerShell_V2_Build` private feed (no hard-coded URL). Warn if `~/.npmrc` is missing.

## Notes
- Complements #3696 (autorest core upgrade-check) — together these should clear the `registry.npmjs.org` CFSClean egress for 187/221/663.
- The private feed already serves these packages (verified), so the installs will resolve through it.
- Needs a validation run on `main` post-merge to confirm zero `registry.npmjs.org` hits.

Relates to S360 KPI 527fb616-07aa-8198-6419-50d04ef1c2f3 (1ES network isolation).
