### PR TITLE
Disable npm audit to stop registry.npmjs.org egress in Rush self-install (CFSClean)

### DIFF
--- a/tools/Configure-PrivateNpmFeed.ps1
+++ b/tools/Configure-PrivateNpmFeed.ps1
@@ -24,7 +24,10 @@ param(
     [string]$Registry = "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/PowerShell_V2_Build/npm/registry/"
 )
 
-$npmrcContent = "registry=$Registry`nalways-auth=true"
+# Disable npm audit and funding messages: Rush self-installs Rush and pnpm via `npm install`,
+# and npm audit posts to the public registry.npmjs.org audit endpoint (the private feed does not
+# serve it), which breaks CFSClean network isolation. always-auth keeps auth on the private feed.
+$npmrcContent = "registry=$Registry`nalways-auth=true`naudit=false`nfund=false"
 
 # Create .npmrc at repo root for global npm installs (autorest, rush)
 $rootNpmrc = Join-Path $SourcesDirectory ".npmrc"


### PR DESCRIPTION
## Stop remaining registry.npmjs.org egress in the Generation pipeline (CFSClean)

### Context
PRs #3696 and #3697 routed autorest's npm calls and the Rush package registry to the private CFS feed (`PowerShell_V2_Build`). Validation run **231003** (pipeline 187, on the merged #3697 content) **built successfully** and confirmed the autorest pre-populate leak is gone — but the `Microsoft Graph PowerShell SDK CI Build` job still showed **2 `registry.npmjs.org` hits**, traced (network-isolation telemetry + build log) to the **`Rush Build`** step.

### Root cause
`rush install` first **self-installs Rush and pnpm via `npm install`**, and each of those runs **`npm audit`**:
```
Running "npm install" in ...\rush-5.170.1
Running "npm install" in ...\pnpm-10.32.1
  added 1 package, and audited 2 packages in 5s
  1 high severity vulnerability
```
`npm audit` POSTs the dependency set to the **public `registry.npmjs.org` audit endpoint** (the private Azure Artifacts feed doesn't implement it), so the registry redirect alone can't stop it. Two self-installs ⇒ two npmjs hits.

### Fix
Add `audit=false` (and `fund=false`) to the `.npmrc` content written by `Configure-PrivateNpmFeed.ps1`. Rush copies/transforms `common/config/rush/.npmrc` to each self-install location, so these settings propagate to the offending `npm install` calls. `always-auth=true` and the private `registry=` are unchanged, so package resolution stays on the CFS feed.

### Validation
Re-run pipeline 187 after merge and confirm `registry.npmjs.org` = 0 in the CI Build job. (PowerShell Gallery hits are a separate, looser CFSClean2 tier.)
