### PR TITLE
ci: update ESRP code signing to v6

### DIFF
--- a/.azure-pipelines/common-templates/esrp/codesign-nuget.yml
+++ b/.azure-pipelines/common-templates/esrp/codesign-nuget.yml
@@ -10,7 +10,7 @@ parameters:
     default: "*.nupkg"
 
 steps:
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+  - task: EsrpCodeSigning@6
     displayName: ESRP NuGet CodeSigning
     enabled: true
     inputs:

--- a/.azure-pipelines/common-templates/esrp/codesign.yml
+++ b/.azure-pipelines/common-templates/esrp/codesign.yml
@@ -10,7 +10,7 @@ parameters:
       default: ".*.dll"
 
 steps:
-    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+    - task: EsrpCodeSigning@6
       displayName: ESRP DLL CodeSigning
       enabled: true
       inputs:

--- a/.azure-pipelines/common-templates/esrp/strongname.yml
+++ b/.azure-pipelines/common-templates/esrp/strongname.yml
@@ -10,7 +10,7 @@ parameters:
     default: ".*.dll"
 
 steps:
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+  - task: EsrpCodeSigning@6
     displayName: ESRP DLL Strong Name
     enabled: true
     inputs:


### PR DESCRIPTION
Updates ESRP code signing pipeline tasks from v5 to v6. The v5 task runs on Node16, which is getting deprecated.