### PR TITLE
CFSClean: Rush toolchain private-feed fix + transient tool-install retries

### DIFF
--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -96,6 +96,21 @@ steps:
       pwsh: true
       workingDirectory: "autorest.powershell"
       script: |
+        # Belt-and-suspenders for 1ES network isolation (CFSClean): force npm_config_registry to
+        # the authenticated private feed so Rush's self-install of its own toolchain (the Rush and
+        # pnpm packages it downloads into ~/.rush via `npm install`) resolves from the private feed
+        # instead of defaulting to registry.npmjs.org. The env var is the highest-precedence npm
+        # config source and is inherited by every child process, so it covers the self-install npm
+        # calls that do not pick up the transformed common/config/rush/.npmrc.
+        if (-not $env:npm_config_registry) {
+            $userNpmrc = Join-Path $env:USERPROFILE ".npmrc"
+            if (Test-Path $userNpmrc) {
+                $regLine = Select-String -Path $userNpmrc -Pattern '^registry=' | Select-Object -First 1
+                if ($regLine) { $env:npm_config_registry = ($regLine.Line -replace '^registry=', '').Trim() }
+            }
+        }
+        Write-Host "npm_config_registry = $env:npm_config_registry"
+
         npx --no-install rush install
         if ($LASTEXITCODE -ne 0) { throw "rush install failed with exit code $LASTEXITCODE" }
         npx --no-install rush link

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -4,11 +4,13 @@
 steps:
   - task: UseDotNet@2
     displayName: Use .NET SDK
+    retryCountOnTaskFailure: 2
     inputs:
       version: 8.x 
 
   - task: UseDotNet@2
     displayName: Use .NET SDK
+    retryCountOnTaskFailure: 2
     inputs:
       version: 6.x 
       
@@ -27,6 +29,7 @@ steps:
 
   - task: NodeTool@0
     displayName: Install NodeJs
+    retryCountOnTaskFailure: 2
     inputs:
       versionSpec: 18.x
 
@@ -63,6 +66,7 @@ steps:
 
   - task: Npm@1
     displayName: Install AutoRest
+    retryCountOnTaskFailure: 2
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
@@ -70,6 +74,7 @@ steps:
 
   - task: Npm@1
     displayName: Install AutorestCore
+    retryCountOnTaskFailure: 2
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)
@@ -84,6 +89,7 @@ steps:
 
   - task: Npm@1
     displayName: Install Rush
+    retryCountOnTaskFailure: 2
     inputs:
       command: custom
       workingDir: $(Build.SourcesDirectory)


### PR DESCRIPTION
## CFSClean: fix Rush toolchain self-install npm egress + harden transient tool installs

Two related changes to the shared `common-templates/install-tools.yml` (used by pipelines **187**, **221**, **663**).

### 1. Force the Rush toolchain self-install onto the private npm feed (CFSClean, strict tier)
After #3696 / #3697 / #3703, the SDK dependency restore is clean, but a validation run (build 231349) still showed **2 residual `registry.npmjs.org` hits** (PolicyViolation = **CFSClean**, the strict tier) in the Rush Build step. They are **Rush self-installing its own toolchain** — `rush install` bootstraps the pinned Rush (`5.170.1`) and pnpm (`10.32.1`) by running `npm install` into `~/.rush/...`, and those self-install calls do not honor the transformed `common/config/rush/.npmrc` registry, so they fall back to `registry.npmjs.org`.

Fix: set `$env:npm_config_registry` to the authenticated private feed (read from `~/.npmrc`) at the top of the **Rush Build** step — the same technique already used in `GenerateServiceModule.ps1` for autorest's internal npm calls. `npm_config_registry` is the highest-precedence npm config source and is inherited by every child process (`npx` → `rush` → `npm`).

### 2. Retry transient tool-install steps (build reliability)
The Weekly build (221) intermittently fails at network-dependent installs in this template (observed: `UseDotNet@2` extraction collision `dotnet.exe already exists`, and `Install Rush`). Added `retryCountOnTaskFailure: 2` to the `UseDotNet@2` (x2), `NodeTool@0`, and the three `Npm@1` install steps so a transient failure retries instead of failing the whole generation build — improving the odds of a clean, trustworthy CFSClean validation run.

### Scope / tiers
- This removes the **strict-tier (`CFSClean`) `registry.npmjs.org`** egress for 187/221/663.
- The **PowerShell Gallery** egress (`www.powershellgallery.com` / CDN) is a separate **CFSClean2**-tier item, remediated in a follow-up (route module installs through a private PSResource feed).

### Validation
187 build 233065 (this branch) in progress; expect `registry.npmjs.org = 0` in the Rush Build step. Then re-run 221/663.
