### PR TITLE
Rewrite override-package tarball URLs to private feed in Rush build

### DIFF
--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -117,6 +117,16 @@ steps:
         }
         Write-Host "npm_config_registry = $env:npm_config_registry"
 
+        # Point the .pnpmfile.cjs tarball rewrite at the private feed. The pnpmfile only rewrites
+        # the tarball URLs of its version-override packages (serialize-javascript, js-yaml) when
+        # this env var is present, and uses its value as the replacement registry base. The feed
+        # emits public registry.npmjs.org tarball URLs for those overridden versions, which would
+        # otherwise be fetched directly from public npm (blocked under 1ES/CFSClean isolation).
+        # Setting it to $env:npm_config_registry keeps the destination tied to the same feed the
+        # pipeline authenticated against. Leaving it unset disables the rewrite (local dev).
+        $env:MG_PNPM_TARBALL_REGISTRY = $env:npm_config_registry
+        Write-Host "MG_PNPM_TARBALL_REGISTRY = $env:MG_PNPM_TARBALL_REGISTRY"
+
         npx --no-install rush install
         if ($LASTEXITCODE -ne 0) { throw "rush install failed with exit code $LASTEXITCODE" }
         npx --no-install rush link


### PR DESCRIPTION
## What

Two coordinated changes so the Rush build can rewrite the public-npm tarball URLs of its version-override packages to the authenticated private feed:

1. **Submodule bump** — `autorest.powershell` → `c42e7f8e` (tip of `powershell-v2`, from [autorest.powershell#20](https://github.com/microsoftgraph/autorest.powershell/pull/20)). That commit adds an env-var-gated `afterAllResolved` hook to `common/config/rush/.pnpmfile.cjs`.
2. **Pipeline env var** — `.azure-pipelines/common-templates/install-tools.yml` now sets `MG_PNPM_TARBALL_REGISTRY` in the Rush Build step.

## Why

The private Azure Artifacts feed emits public `registry.npmjs.org` tarball URLs for the two version-overridden packages (`serialize-javascript`, `js-yaml`). Those would be fetched directly from public npm, which is blocked under 1ES/CFSClean network isolation.

The new `.pnpmfile.cjs` hook rewrites **only** those two packages' tarball URLs (matched by exact package name, so `@types/js-yaml` is excluded) from the public-npm prefixes to the base given by `MG_PNPM_TARBALL_REGISTRY`.

## Design

- `MG_PNPM_TARBALL_REGISTRY` is set to `$env:npm_config_registry`, the same authenticated feed the pipeline configured — so the rewrite destination is tied to the feed the pipeline authenticated against.
- **The env var value is the replacement registry base**, so the calling pipeline controls the destination.
- Unset ⇒ rewrite disabled (local dev against public npm is unaffected).

## Note on scope of effect

`afterAllResolved` only runs on **resolving** installs (`rush update`); it is skipped on the frozen `rush install` these templates use. This is correct — the direct public-npm download only happens during re-resolution. The env var is set and inherited so the rewrite fires wherever a resolving install runs.

## Related

- Depends on merged PR: microsoftgraph/autorest.powershell#20