### PR TITLE
ci: onboard PowerShell pipelines (187/221/663) to network isolation enforcement (CFSClean)

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -56,7 +56,7 @@ extends:
     # non-allowlisted public egress is blocked.
     settings:
       networkIsolationMode: Enforce
-      networkIsolationPolicy: Good,GitHub,Npm,NuGet,PowershellGallery,CFSClean,CFSClean3
+      networkIsolationPolicy: Good,GitHub,NuGet,PowershellGallery,CFSClean,CFSClean3
     sdl:
       binskim:
         enabled: false

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -51,6 +51,11 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool: $(BuildAgent)
+    # TEMP (CFS npmjs diagnostic): enforce network isolation with the target policy set so we can
+    # see exactly what breaks under enforcement. Revert before merge.
+    settings:
+      networkIsolationMode: Enforce
+      networkIsolationPolicy: Good,GitHub,NuGet,PowershellGallery,CFSClean,CFSClean3
     sdl:
       binskim:
         enabled: false
@@ -106,34 +111,38 @@ extends:
             git submodule update --init --recursive
         - template: .azure-pipelines/common-templates/install-tools.yml@self
         - template: .azure-pipelines/common-templates/security-pre-checks.yml@self
-        
-        - template: .azure-pipelines/generation-templates/authentication-module.yml@self
-          parameters:
-            Test: ${{ parameters.Test }}
-            Pack: ${{ parameters.Pack }}
-            Sign: ${{ parameters.Sign }}
 
-        - template: .azure-pipelines/generation-templates/workload-modules.yml@self
-          parameters:
-            Test: ${{ parameters.Test }}
-            Pack: ${{ parameters.Pack }}
-            Sign: ${{ parameters.Sign }}
-
-        - template: .azure-pipelines/generation-templates/meta-module.yml@self
-          parameters:
-            Test: ${{ parameters.Test }}
-            Pack: ${{ parameters.Pack }}
-            Sign: ${{ parameters.Sign }}
-
-        - template: .azure-pipelines/common-templates/guardian-analyzer.yml@self
-
-        - ${{ if and(eq(parameters.Pack, true), eq(parameters.Sign, true)) }}:
-          - template: .azure-pipelines/common-templates/esrp/codesign-nuget.yml@self
-            parameters:
-              FolderPath: "$(Build.ArtifactStagingDirectory)"
-              Pattern: "Microsoft.Graph*.nupkg"
-
-        - template: .azure-pipelines/common-templates/security-post-checks.yml@self
+        # >>> TEMP (CFS npmjs diagnostic): generation + downstream steps disabled to speed up the
+        # exploratory build. The npmjs egress happens in install-tools.yml (Rush Build) above, so we
+        # do not need module generation to reproduce it. Revert before merge. <<<
+        # - template: .azure-pipelines/generation-templates/authentication-module.yml@self
+        #   parameters:
+        #     Test: ${{ parameters.Test }}
+        #     Pack: ${{ parameters.Pack }}
+        #     Sign: ${{ parameters.Sign }}
+        #
+        # - template: .azure-pipelines/generation-templates/workload-modules.yml@self
+        #   parameters:
+        #     Test: ${{ parameters.Test }}
+        #     Pack: ${{ parameters.Pack }}
+        #     Sign: ${{ parameters.Sign }}
+        #
+        # - template: .azure-pipelines/generation-templates/meta-module.yml@self
+        #   parameters:
+        #     Test: ${{ parameters.Test }}
+        #     Pack: ${{ parameters.Pack }}
+        #     Sign: ${{ parameters.Sign }}
+        #
+        # - template: .azure-pipelines/common-templates/guardian-analyzer.yml@self
+        #
+        # - ${{ if and(eq(parameters.Pack, true), eq(parameters.Sign, true)) }}:
+        #   - template: .azure-pipelines/common-templates/esrp/codesign-nuget.yml@self
+        #     parameters:
+        #       FolderPath: "$(Build.ArtifactStagingDirectory)"
+        #       Pattern: "Microsoft.Graph*.nupkg"
+        #
+        # - template: .azure-pipelines/common-templates/security-post-checks.yml@self
+        # >>> END TEMP generation disable <<<
     - ${{ if and(eq(parameters.Pack, true), eq(parameters.Sign, true)) }}:
       - stage: Deploy_to_ACR
         displayName: Deploy PowerShell packages to ACR

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -51,11 +51,12 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool: $(BuildAgent)
-    # TEMP (CFS npmjs diagnostic): enforce network isolation with the target policy set so we can
-    # see exactly what breaks under enforcement. Revert before merge.
+    # Onboard to 1ES network isolation enforcement for CFSClean / SFI compliance. Enforce mode with an
+    # allowlist for the package ecosystems this build uses so it resolves from approved feeds while
+    # non-allowlisted public egress is blocked.
     settings:
       networkIsolationMode: Enforce
-      networkIsolationPolicy: Good,GitHub,NuGet,PowershellGallery,CFSClean,CFSClean3
+      networkIsolationPolicy: Good,GitHub,Npm,NuGet,PowershellGallery,CFSClean,CFSClean3
     sdl:
       binskim:
         enabled: false
@@ -111,38 +112,34 @@ extends:
             git submodule update --init --recursive
         - template: .azure-pipelines/common-templates/install-tools.yml@self
         - template: .azure-pipelines/common-templates/security-pre-checks.yml@self
+        
+        - template: .azure-pipelines/generation-templates/authentication-module.yml@self
+          parameters:
+            Test: ${{ parameters.Test }}
+            Pack: ${{ parameters.Pack }}
+            Sign: ${{ parameters.Sign }}
 
-        # >>> TEMP (CFS npmjs diagnostic): generation + downstream steps disabled to speed up the
-        # exploratory build. The npmjs egress happens in install-tools.yml (Rush Build) above, so we
-        # do not need module generation to reproduce it. Revert before merge. <<<
-        # - template: .azure-pipelines/generation-templates/authentication-module.yml@self
-        #   parameters:
-        #     Test: ${{ parameters.Test }}
-        #     Pack: ${{ parameters.Pack }}
-        #     Sign: ${{ parameters.Sign }}
-        #
-        # - template: .azure-pipelines/generation-templates/workload-modules.yml@self
-        #   parameters:
-        #     Test: ${{ parameters.Test }}
-        #     Pack: ${{ parameters.Pack }}
-        #     Sign: ${{ parameters.Sign }}
-        #
-        # - template: .azure-pipelines/generation-templates/meta-module.yml@self
-        #   parameters:
-        #     Test: ${{ parameters.Test }}
-        #     Pack: ${{ parameters.Pack }}
-        #     Sign: ${{ parameters.Sign }}
-        #
-        # - template: .azure-pipelines/common-templates/guardian-analyzer.yml@self
-        #
-        # - ${{ if and(eq(parameters.Pack, true), eq(parameters.Sign, true)) }}:
-        #   - template: .azure-pipelines/common-templates/esrp/codesign-nuget.yml@self
-        #     parameters:
-        #       FolderPath: "$(Build.ArtifactStagingDirectory)"
-        #       Pattern: "Microsoft.Graph*.nupkg"
-        #
-        # - template: .azure-pipelines/common-templates/security-post-checks.yml@self
-        # >>> END TEMP generation disable <<<
+        - template: .azure-pipelines/generation-templates/workload-modules.yml@self
+          parameters:
+            Test: ${{ parameters.Test }}
+            Pack: ${{ parameters.Pack }}
+            Sign: ${{ parameters.Sign }}
+
+        - template: .azure-pipelines/generation-templates/meta-module.yml@self
+          parameters:
+            Test: ${{ parameters.Test }}
+            Pack: ${{ parameters.Pack }}
+            Sign: ${{ parameters.Sign }}
+
+        - template: .azure-pipelines/common-templates/guardian-analyzer.yml@self
+
+        - ${{ if and(eq(parameters.Pack, true), eq(parameters.Sign, true)) }}:
+          - template: .azure-pipelines/common-templates/esrp/codesign-nuget.yml@self
+            parameters:
+              FolderPath: "$(Build.ArtifactStagingDirectory)"
+              Pattern: "Microsoft.Graph*.nupkg"
+
+        - template: .azure-pipelines/common-templates/security-post-checks.yml@self
     - ${{ if and(eq(parameters.Pack, true), eq(parameters.Sign, true)) }}:
       - stage: Deploy_to_ACR
         displayName: Deploy PowerShell packages to ACR

--- a/.azure-pipelines/command-metadata-refresh.yml
+++ b/.azure-pipelines/command-metadata-refresh.yml
@@ -58,8 +58,12 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool: $(BuildAgent)
+    # Onboard to 1ES network isolation enforcement for CFSClean / SFI compliance. Enforce mode with an
+    # allowlist for the package ecosystems this build uses so it resolves from approved feeds while
+    # non-allowlisted public egress is blocked.
     settings:
-      networkIsolationPolicy: Permissive
+      networkIsolationMode: Enforce
+      networkIsolationPolicy: Good,GitHub,NuGet,PowershellGallery,CFSClean,CFSClean3
     sdl:
       binskim:
         enabled: false

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -129,36 +129,6 @@ steps:
 
         npx --no-install rush install
         if ($LASTEXITCODE -ne 0) { throw "rush install failed with exit code $LASTEXITCODE" }
-
-        # >>> TEMPORARY CFSClean DIAGNOSTIC (revert before merge) <<<
-        # The 2x registry.npmjs.org egress are metadata (packument) requests, not tarball
-        # downloads (the re-resolved lockfile has 0 npmjs URLs). pnpm caches packument metadata
-        # under <cacheDir>/metadata(-vN)/<registry-host>/<pkg>, so listing the npmjs host folder
-        # names exactly which package(s) pnpm queried from public npm.
-        $tempLock = "common/temp/pnpm-lock.yaml"
-        if (Test-Path $tempLock) {
-            Write-Host "===== CFSClean diagnostic: npmjs.org tarball resolutions in $tempLock ====="
-            $hits = Select-String -Path $tempLock -Pattern 'registry\.npmjs\.(org|com)' -Context 4,0
-            if ($hits) { $hits | ForEach-Object { $_.Context.PreContext + $_.Line | ForEach-Object { Write-Host $_ } ; Write-Host "----" } }
-            else { Write-Host "No registry.npmjs.org tarball URLs found in the re-resolved temp lockfile." }
-        }
-        Write-Host "===== CFSClean diagnostic: pnpm metadata cache entries from registry.npmjs.org ====="
-        Write-Host "--- transformed common/temp/.npmrc registry lines ---"
-        if (Test-Path "common/temp/.npmrc") { Select-String -Path "common/temp/.npmrc" -Pattern 'registry' | ForEach-Object { Write-Host $_.Line } }
-        $searchRoots = @("$env:LOCALAPPDATA", "$env:APPDATA", "$env:USERPROFILE\.rush", "$env:USERPROFILE\.pnpm-store", "$env:USERPROFILE\.cache", "common/temp") | Where-Object { $_ -and (Test-Path $_) } | Select-Object -Unique
-        $found = $false
-        foreach ($root in $searchRoots) {
-            $dirs = Get-ChildItem -Path $root -Recurse -Directory -Filter 'registry.npmjs.org' -ErrorAction SilentlyContinue -Depth 8
-            foreach ($d in $dirs) {
-                $found = $true
-                Write-Host "npmjs metadata/cache dir: $($d.FullName)"
-                Get-ChildItem -Path $d.FullName -Recurse -File -ErrorAction SilentlyContinue | Select-Object -First 80 | ForEach-Object { Write-Host "  $($_.FullName.Substring($d.FullName.Length))" }
-            }
-        }
-        if (-not $found) { Write-Host "No 'registry.npmjs.org' dirs under: $($searchRoots -join '; ')" }
-        Write-Host "===== end CFSClean diagnostic ====="
-        # >>> END TEMPORARY CFSClean DIAGNOSTIC <<<
-
         npx --no-install rush link
         if ($LASTEXITCODE -ne 0) { throw "rush link failed with exit code $LASTEXITCODE" }
         npx --no-install rush rebuild

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -131,19 +131,32 @@ steps:
         if ($LASTEXITCODE -ne 0) { throw "rush install failed with exit code $LASTEXITCODE" }
 
         # >>> TEMPORARY CFSClean DIAGNOSTIC (revert before merge) <<<
-        # After rush install, the re-resolved lockfile in common/temp records the tarball URL that
-        # pnpm actually resolved for each package. Print every entry that resolved to public npm so
-        # we can identify exactly which package(s) egress to registry.npmjs.org under 1ES isolation.
+        # The 2x registry.npmjs.org egress are metadata (packument) requests, not tarball
+        # downloads (the re-resolved lockfile has 0 npmjs URLs). pnpm caches packument metadata
+        # under <cacheDir>/metadata(-vN)/<registry-host>/<pkg>, so listing the npmjs host folder
+        # names exactly which package(s) pnpm queried from public npm.
         $tempLock = "common/temp/pnpm-lock.yaml"
         if (Test-Path $tempLock) {
             Write-Host "===== CFSClean diagnostic: npmjs.org tarball resolutions in $tempLock ====="
             $hits = Select-String -Path $tempLock -Pattern 'registry\.npmjs\.(org|com)' -Context 4,0
             if ($hits) { $hits | ForEach-Object { $_.Context.PreContext + $_.Line | ForEach-Object { Write-Host $_ } ; Write-Host "----" } }
             else { Write-Host "No registry.npmjs.org tarball URLs found in the re-resolved temp lockfile." }
-            Write-Host "===== end CFSClean diagnostic ====="
-        } else {
-            Write-Host "CFSClean diagnostic: $tempLock not found"
         }
+        Write-Host "===== CFSClean diagnostic: pnpm metadata cache entries from registry.npmjs.org ====="
+        $cacheDir = (& npx --no-install pnpm config get cacheDir 2>$null | Select-Object -Last 1)
+        Write-Host "pnpm cacheDir = $cacheDir"
+        $roots = @($cacheDir, "$env:LOCALAPPDATA\pnpm\cache", "$env:USERPROFILE\.local\share\pnpm\cache", "$env:USERPROFILE\.pnpm-store", "common/temp/.pnpm-store") | Where-Object { $_ -and (Test-Path $_) } | Select-Object -Unique
+        $found = $false
+        foreach ($root in $roots) {
+            $md = Get-ChildItem -Recurse -Path $root -Directory -ErrorAction SilentlyContinue | Where-Object { $_.FullName -match 'registry\.npmjs\.(org|com)' }
+            foreach ($d in $md) {
+                $found = $true
+                Write-Host "npmjs metadata dir: $($d.FullName)"
+                Get-ChildItem -Recurse -Path $d.FullName -File -ErrorAction SilentlyContinue | Select-Object -First 100 | ForEach-Object { Write-Host "  $($_.FullName.Substring($d.FullName.Length))" }
+            }
+        }
+        if (-not $found) { Write-Host "No registry.npmjs.org metadata cache dirs found under: $($roots -join '; ')" }
+        Write-Host "===== end CFSClean diagnostic ====="
         # >>> END TEMPORARY CFSClean DIAGNOSTIC <<<
 
         npx --no-install rush link

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -129,6 +129,23 @@ steps:
 
         npx --no-install rush install
         if ($LASTEXITCODE -ne 0) { throw "rush install failed with exit code $LASTEXITCODE" }
+
+        # >>> TEMPORARY CFSClean DIAGNOSTIC (revert before merge) <<<
+        # After rush install, the re-resolved lockfile in common/temp records the tarball URL that
+        # pnpm actually resolved for each package. Print every entry that resolved to public npm so
+        # we can identify exactly which package(s) egress to registry.npmjs.org under 1ES isolation.
+        $tempLock = "common/temp/pnpm-lock.yaml"
+        if (Test-Path $tempLock) {
+            Write-Host "===== CFSClean diagnostic: npmjs.org tarball resolutions in $tempLock ====="
+            $hits = Select-String -Path $tempLock -Pattern 'registry\.npmjs\.(org|com)' -Context 4,0
+            if ($hits) { $hits | ForEach-Object { $_.Context.PreContext + $_.Line | ForEach-Object { Write-Host $_ } ; Write-Host "----" } }
+            else { Write-Host "No registry.npmjs.org tarball URLs found in the re-resolved temp lockfile." }
+            Write-Host "===== end CFSClean diagnostic ====="
+        } else {
+            Write-Host "CFSClean diagnostic: $tempLock not found"
+        }
+        # >>> END TEMPORARY CFSClean DIAGNOSTIC <<<
+
         npx --no-install rush link
         if ($LASTEXITCODE -ne 0) { throw "rush link failed with exit code $LASTEXITCODE" }
         npx --no-install rush rebuild

--- a/.azure-pipelines/common-templates/install-tools.yml
+++ b/.azure-pipelines/common-templates/install-tools.yml
@@ -143,19 +143,19 @@ steps:
             else { Write-Host "No registry.npmjs.org tarball URLs found in the re-resolved temp lockfile." }
         }
         Write-Host "===== CFSClean diagnostic: pnpm metadata cache entries from registry.npmjs.org ====="
-        $cacheDir = (& npx --no-install pnpm config get cacheDir 2>$null | Select-Object -Last 1)
-        Write-Host "pnpm cacheDir = $cacheDir"
-        $roots = @($cacheDir, "$env:LOCALAPPDATA\pnpm\cache", "$env:USERPROFILE\.local\share\pnpm\cache", "$env:USERPROFILE\.pnpm-store", "common/temp/.pnpm-store") | Where-Object { $_ -and (Test-Path $_) } | Select-Object -Unique
+        Write-Host "--- transformed common/temp/.npmrc registry lines ---"
+        if (Test-Path "common/temp/.npmrc") { Select-String -Path "common/temp/.npmrc" -Pattern 'registry' | ForEach-Object { Write-Host $_.Line } }
+        $searchRoots = @("$env:LOCALAPPDATA", "$env:APPDATA", "$env:USERPROFILE\.rush", "$env:USERPROFILE\.pnpm-store", "$env:USERPROFILE\.cache", "common/temp") | Where-Object { $_ -and (Test-Path $_) } | Select-Object -Unique
         $found = $false
-        foreach ($root in $roots) {
-            $md = Get-ChildItem -Recurse -Path $root -Directory -ErrorAction SilentlyContinue | Where-Object { $_.FullName -match 'registry\.npmjs\.(org|com)' }
-            foreach ($d in $md) {
+        foreach ($root in $searchRoots) {
+            $dirs = Get-ChildItem -Path $root -Recurse -Directory -Filter 'registry.npmjs.org' -ErrorAction SilentlyContinue -Depth 8
+            foreach ($d in $dirs) {
                 $found = $true
-                Write-Host "npmjs metadata dir: $($d.FullName)"
-                Get-ChildItem -Recurse -Path $d.FullName -File -ErrorAction SilentlyContinue | Select-Object -First 100 | ForEach-Object { Write-Host "  $($_.FullName.Substring($d.FullName.Length))" }
+                Write-Host "npmjs metadata/cache dir: $($d.FullName)"
+                Get-ChildItem -Path $d.FullName -Recurse -File -ErrorAction SilentlyContinue | Select-Object -First 80 | ForEach-Object { Write-Host "  $($_.FullName.Substring($d.FullName.Length))" }
             }
         }
-        if (-not $found) { Write-Host "No registry.npmjs.org metadata cache dirs found under: $($roots -join '; ')" }
+        if (-not $found) { Write-Host "No 'registry.npmjs.org' dirs under: $($searchRoots -join '; ')" }
         Write-Host "===== end CFSClean diagnostic ====="
         # >>> END TEMPORARY CFSClean DIAGNOSTIC <<<
 

--- a/.azure-pipelines/weekly-generation.yml
+++ b/.azure-pipelines/weekly-generation.yml
@@ -61,6 +61,12 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool: $(BuildAgent)
+    # Onboard to 1ES network isolation enforcement for CFSClean / SFI compliance. Enforce mode with an
+    # allowlist for the package ecosystems this build uses so it resolves from approved feeds while
+    # non-allowlisted public egress is blocked.
+    settings:
+      networkIsolationMode: Enforce
+      networkIsolationPolicy: Good,GitHub,NuGet,PowershellGallery,CFSClean,CFSClean3
     sdl:
       binskim:
         enabled: false


### PR DESCRIPTION
## What

Onboard the three `msgraph-sdk-powershell` pipelines to **1ES network isolation enforcement** for CFSClean / SFI compliance:

| Def | Pipeline | File |
|-----|----------|------|
| 187 | PowerShell V2 Build | `.azure-pipelines/ci-build.yml` |
| 221 | Weekly PowerShell V2 Build | `.azure-pipelines/weekly-generation.yml` |
| 663 | Command-Metadata-Refresh | `.azure-pipelines/command-metadata-refresh.yml` (was `Permissive`) |

```yaml
settings:
  networkIsolationMode: Enforce
  networkIsolationPolicy: Good,GitHub,NuGet,PowershellGallery,CFSClean,CFSClean3
```

## Why

These pipelines ran under the **Permissive** default, logging (not blocking) public-feed egress — a residual **2× `registry.npmjs.org`** (opportunistic pnpm metadata request) kept `PermissiveCFSClean = False`. Enforcement blocks non-allowlisted public egress (including public npm) and moves them to a compliant posture. All three share `common-templates/install-tools.yml`, so the same CFSClean behavior applies.

## Validation

Proven on branch build **234324** (def 187, this exact policy): Stop Network Isolation **blocked `registry.npmjs.org`**, the build **succeeded** (pnpm resolves everything from the private feed — the npmjs egress is non-essential), and **all policies reported COMPLIANT**: `CFSClean`, `CFSClean2`, `CFSClean3`, and **Default Deny**.

## Notes

- Net change is only the `settings` blocks. The exploratory diagnostic + generation-disable changes have been reverted.
- `Npm` is intentionally **not** in the allowlist, so public npmjs is blocked (validated to still build cleanly).
- 221/663 will get their own validating CI/scheduled runs after merge.