### PR TITLE
fix(wrapper-generator): make wrapper packages installable from a feed

### DIFF
--- a/tools/Build-WrapperModule.ps1
+++ b/tools/Build-WrapperModule.ps1
@@ -55,6 +55,11 @@ dotnet build configuration. Default: Debug.
 .PARAMETER SkipKiota
 Reuse the previously generated client (fast inner loop when only the wrappers changed).
 
+.PARAMETER Prerelease
+Prerelease label carried by every package (alphanumeric, never empty). Wrapper packages are
+previews by definition; a stable-versioned one would collide with the service-module release
+train, so the label is not optional.
+
 .PARAMETER Pack
 Also produce a package per module under <ArtifactsLocation>/<Module>/.
 
@@ -79,6 +84,13 @@ param(
     [string]$Configuration = 'Debug',
     [string]$ModuleMappingConfigPath,
     [string]$ArtifactsLocation,
+    # Wrapper packages always carry a prerelease label: their ModuleVersion deliberately tracks
+    # the service-module release train (ModuleMetadata.json), so a stable-versioned wrapper
+    # package would collide number-for-number with the real SDK release it will eventually
+    # replace. The label is alphanumeric only - the PowerShellGet prerelease grammar allows
+    # nothing else.
+    [ValidatePattern('^[A-Za-z0-9]+$')]
+    [string]$Prerelease = 'wrapperpreview01',
     [switch]$SkipKiota,
     [switch]$Pack
 )
@@ -91,7 +103,7 @@ $generatorProject = Join-Path $repoRoot 'tools\WrapperGenerator'
 $authCsproj = Join-Path $repoRoot 'src\Authentication\Authentication\Microsoft.Graph.Authentication.csproj'
 $runtimeCsproj = Join-Path $repoRoot 'src\GraphWrapperRuntime\Runtime\Microsoft.Graph.Wrapper.Runtime.csproj'
 # The Authentication version the wrappers compile against, for the manifest's RequiredModules
-# minimum. Read from the project, never written here.
+# minimum and the nuspec dependency floor. Read from the project, never written here.
 $authVersion = ([xml](Get-Content $authCsproj -Raw)).Project.PropertyGroup.Version |
     Where-Object { $_ } | Select-Object -First 1
 if (-not $authVersion) { throw "no Version in $authCsproj" }
@@ -118,8 +130,10 @@ $moduleMetadataPath = Join-Path $repoRoot 'config\ModuleMetadata.json'
 $versionEntry = $moduleMetadata.versions[$ApiVersion]
 if (-not $versionEntry -or -not $versionEntry.version) { throw "No version configured for '$ApiVersion' in $moduleMetadataPath." }
 $moduleVersion = $versionEntry.version
-$modulePrerelease = $versionEntry.prerelease
-$fullVersion = if ($modulePrerelease) { "$moduleVersion-$modulePrerelease" } else { $moduleVersion }
+# The metadata prerelease field belongs to the service-module release train and is deliberately
+# not read; the wrapper label (validated non-empty) is appended unconditionally, because a
+# wrapper package without one cannot exist.
+$fullVersion = "$moduleVersion-$Prerelease"
 
 # The population is the specs this generator can actually read, intersected with the modules the
 # repository is configured to ship - the same two inputs tools/GenerateServiceModule.ps1 uses.
@@ -160,6 +174,32 @@ function New-ProjectFromTemplate {
         throw "unresolved placeholder(s) in $TemplatePath`: $($unresolved -join ', ')"
     }
     Set-Content -Path $DestinationPath -Value $content -Encoding utf8
+}
+
+# The manifest GUID is a module's identity for ModuleSpecification matching (RequiredModules,
+# Import-Module -FullyQualifiedName), so it must be the SAME across builds. The shipped SDK
+# locks GUIDs to the published gallery entry (tools/BuildModule.ps1, autorest.powershell#981);
+# a never-published wrapper has no gallery entry to lock to, so its identity is DERIVED
+# instead: an RFC 4122 name-based (v5) UUID - SHA-1 over a fixed namespace GUID plus the module
+# name - identical on every build with no lookup table to maintain. The namespace constant and
+# the algorithm ARE the identity contract: changing either orphans every previously installed
+# wrapper module.
+function Get-WrapperModuleGuid {
+    param([Parameter(Mandatory)][string]$ModuleName)
+
+    $namespaceBytes = ([guid]'8a11e1b5-95b3-4dbf-b0ba-6d58b0f6f6a4').ToByteArray()
+    # Guid.ToByteArray() emits the first three fields little-endian; RFC 4122 hashes network order.
+    [Array]::Reverse($namespaceBytes, 0, 4); [Array]::Reverse($namespaceBytes, 4, 2); [Array]::Reverse($namespaceBytes, 6, 2)
+    $sha1 = [System.Security.Cryptography.SHA1]::Create()
+    try {
+        $hash = $sha1.ComputeHash([byte[]]($namespaceBytes + [System.Text.Encoding]::UTF8.GetBytes($ModuleName)))
+    }
+    finally { $sha1.Dispose() }
+    $guidBytes = $hash[0..15]
+    $guidBytes[6] = ($guidBytes[6] -band 0x0F) -bor 0x50   # version 5
+    $guidBytes[8] = ($guidBytes[8] -band 0x3F) -bor 0x80   # RFC 4122 variant
+    [Array]::Reverse($guidBytes, 0, 4); [Array]::Reverse($guidBytes, 4, 2); [Array]::Reverse($guidBytes, 6, 2)
+    [guid][byte[]]$guidBytes
 }
 
 function Get-CompiledCmdletNames {
@@ -340,7 +380,9 @@ function Build-Module {
         $manifestArgs = @{
             Path              = $psd1Path
             RootModule        = "$moduleName.dll"
+            Guid              = Get-WrapperModuleGuid -ModuleName $moduleName
             ModuleVersion     = $moduleVersion
+            Prerelease        = $Prerelease
             RequiredModules   = @(@{ ModuleName = 'Microsoft.Graph.Authentication'; ModuleVersion = $authVersion })
             Author            = 'Microsoft Graph'
             CompanyName       = 'Microsoft'
@@ -350,14 +392,15 @@ function Build-Module {
             AliasesToExport   = @()
             VariablesToExport = @()
         }
-        if ($modulePrerelease) { $manifestArgs.Prerelease = $modulePrerelease }
-        # Std.UriTemplate is requested by the kiota HTTP library, which lives in Authentication's
-        # isolated load context - a requester whose directory probing can never reach this module
-        # folder, and whose request Authentication cannot serve because its Dependencies folder
-        # does not ship the assembly. Preloading it here puts it in the default context, where
-        # the isolated context's fallback resolution unifies with it. The Multipart serializer
-        # needs no entry: its requester is the client assembly in this folder, so normal
-        # module-directory probing finds it. Proven live in Test-LiveSmoke on the session path.
+        # Std.UriTemplate is requested by Microsoft.Kiota.Abstractions (measured: the AssemblyRef
+        # lives there, not in the HTTP library). That requester sits in Authentication's isolated
+        # load context, so its directory probing can never reach this module folder - and
+        # Authentication cannot serve the request either, because its Dependencies folder does
+        # not ship the assembly. Preloading it here puts it in the default context, where the
+        # isolated context's fallback resolution unifies with it. The Multipart serializer needs
+        # no entry: its requester is the client assembly in this folder, so normal
+        # module-directory probing finds it. Proven live by tools/Test-WrapperLive.ps1 on the
+        # session path.
         $manifestArgs.RequiredAssemblies = @('Std.UriTemplate.dll')
         New-ModuleManifest @manifestArgs
 
@@ -368,6 +411,12 @@ function Build-Module {
             # and the shared Authentication/kiota closure via the PruneModuleBin target - both at
             # the project level, the only place that intent can be expressed. See
             # tools/Templates/WrapperModule.csproj.template for why the closure must not ship.
+            # The nuspec must declare the Authentication dependency even though the psd1 already
+            # does: Install-Module resolves dependencies from NUGET metadata, not the manifest,
+            # so without this element a clean machine gets the wrapper with no Authentication and
+            # import fails. Declared as an open floor, not the shipped SDK's exact bracket pin -
+            # matching the manifest's RequiredModules minimum and the use-latest ruling (Ramses,
+            # 2026-08-19: pins existed only for AutoRest limitations).
             $nuspecPath = Join-Path $binDir "$moduleName.nuspec"
             $tags = ($moduleMetadata['tags']) -join ' '
             # Native runtime payloads only exist when a dependency ships them; dotnet pack fails
@@ -392,6 +441,9 @@ function Build-Module {
     <releaseNotes>$($moduleMetadata['releaseNotes'])</releaseNotes>
     <copyright>$($moduleMetadata['copyright'])</copyright>
     <tags>$tags</tags>
+    <dependencies>
+      <dependency id="Microsoft.Graph.Authentication" version="$authVersion" />
+    </dependencies>
   </metadata>
   <files>
     <file src="$moduleName.psd1" />

--- a/tools/Build-WrapperModule.ps1
+++ b/tools/Build-WrapperModule.ps1
@@ -55,10 +55,16 @@ dotnet build configuration. Default: Debug.
 .PARAMETER SkipKiota
 Reuse the previously generated client (fast inner loop when only the wrappers changed).
 
+.PARAMETER ModuleVersion
+Three-part version for the wrapper packages. Default 3.0.0 - the wrapper modules are the v3
+line, not a build of the v2 service-module release train whose version lives in
+config/ModuleMetadata.json.
+
 .PARAMETER Prerelease
-Prerelease label carried by every package (alphanumeric, never empty). Wrapper packages are
-previews by definition; a stable-versioned one would collide with the service-module release
-train, so the label is not optional.
+Prerelease label carried by every package (alphanumeric, never empty). Defaults to
+alpha<BuildId> in CI and alpha<UTC timestamp> locally, so no two builds ever publish the same
+id and version with different contents. Wrapper packages stay prereleases until the quality
+bar for public distribution is agreed.
 
 .PARAMETER Pack
 Also produce a package per module under <ArtifactsLocation>/<Module>/.
@@ -84,13 +90,21 @@ param(
     [string]$Configuration = 'Debug',
     [string]$ModuleMappingConfigPath,
     [string]$ArtifactsLocation,
-    # Wrapper packages always carry a prerelease label: their ModuleVersion deliberately tracks
-    # the service-module release train (ModuleMetadata.json), so a stable-versioned wrapper
-    # package would collide number-for-number with the real SDK release it will eventually
-    # replace. The label is alphanumeric only - the PowerShellGet prerelease grammar allows
-    # nothing else.
+    # The wrapper modules are the v3 line, not a build of the v2 service-module release train,
+    # so their version is their own rather than ModuleMetadata.json's (which belongs to v2 and
+    # is still read here for authors, tags and the rest of the package identity).
+    [ValidatePattern('^\d+\.\d+\.\d+$')]
+    [string]$ModuleVersion = '3.0.0',
+    # Wrapper packages always carry a prerelease label, and every build gets a DISTINCT one:
+    # two packages that share an id and version but not their contents are indistinguishable to
+    # a feed and to anyone who already installed one. The build id supplies that distinctness in
+    # CI; a UTC timestamp does locally, where no build id exists.
+    # The pattern is the documented PowerShellGet grammar, not a preference: the prerelease
+    # string may contain only ASCII alphanumerics and a hyphen, the hyphen only as the FIRST
+    # character, and never a period - so 'alpha-4472' and 'alpha.4472' are both invalid, while
+    # 'alpha4472' is the shape the documentation's own examples use (-update20171020).
     [ValidatePattern('^[A-Za-z0-9]+$')]
-    [string]$Prerelease = 'wrapperpreview01',
+    [string]$Prerelease = "alpha$(if ($env:BUILD_BUILDID) { $env:BUILD_BUILDID } else { (Get-Date).ToUniversalTime().ToString('yyyyMMddHHmm') })",
     [switch]$SkipKiota,
     [switch]$Pack
 )
@@ -122,18 +136,17 @@ $targetFramework = "$targetFramework".Trim()
 if (-not $ModuleMappingConfigPath) { $ModuleMappingConfigPath = Join-Path $repoRoot 'config\ModulesMapping.jsonc' }
 if (-not $ArtifactsLocation) { $ArtifactsLocation = Join-Path $repoRoot 'artifacts' }
 
-# Package metadata comes from the same single source the AutoRest service modules use, so a
-# wrapper package and the module it will eventually replace cannot disagree about version or
-# ownership.
+# Package identity (authors, owners, licence, tags) comes from the same single source the
+# AutoRest service modules use, so a wrapper package and the module it will eventually replace
+# cannot disagree about ownership. The VERSION is deliberately not taken from there: that
+# entry tracks the v2 release train, and a wrapper package stamped with it would claim a
+# version the real SDK is about to publish.
 $moduleMetadataPath = Join-Path $repoRoot 'config\ModuleMetadata.json'
 [hashtable]$moduleMetadata = Get-Content $moduleMetadataPath -Raw | ConvertFrom-Json -AsHashTable
-$versionEntry = $moduleMetadata.versions[$ApiVersion]
-if (-not $versionEntry -or -not $versionEntry.version) { throw "No version configured for '$ApiVersion' in $moduleMetadataPath." }
-$moduleVersion = $versionEntry.version
 # The metadata prerelease field belongs to the service-module release train and is deliberately
 # not read; the wrapper label (validated non-empty) is appended unconditionally, because a
 # wrapper package without one cannot exist.
-$fullVersion = "$moduleVersion-$Prerelease"
+$fullVersion = "$ModuleVersion-$Prerelease"
 
 # The population is the specs this generator can actually read, intersected with the modules the
 # repository is configured to ship - the same two inputs tools/GenerateServiceModule.ps1 uses.
@@ -381,7 +394,7 @@ function Build-Module {
             Path              = $psd1Path
             RootModule        = "$moduleName.dll"
             Guid              = Get-WrapperModuleGuid -ModuleName $moduleName
-            ModuleVersion     = $moduleVersion
+            ModuleVersion     = $ModuleVersion
             Prerelease        = $Prerelease
             RequiredModules   = @(@{ ModuleName = 'Microsoft.Graph.Authentication'; ModuleVersion = $authVersion })
             Author            = 'Microsoft Graph'
@@ -460,7 +473,7 @@ function Build-Module {
             # a PowerShell module package. NuspecBasePath resolves the globs against the build
             # output so the nuspec need not know how deep bin/<Config>/<TFM> is.
             $packArgs = @($csprojPath, '-c', $Configuration, '--no-build', '--nologo', '-v', 'minimal',
-                "-p:NuspecFile=$nuspecPath", "-p:NuspecBasePath=$binDir", "-p:Version=$moduleVersion",
+                "-p:NuspecFile=$nuspecPath", "-p:NuspecBasePath=$binDir", "-p:Version=$ModuleVersion",
                 '-p:NoPackageAnalysis=true', '-o', $moduleArtifacts)
             $packOut = & dotnet pack @packArgs 2>&1
             if ($LASTEXITCODE -ne 0) {

--- a/tools/Build-WrapperModule.ps1
+++ b/tools/Build-WrapperModule.ps1
@@ -99,10 +99,12 @@ param(
     # two packages that share an id and version but not their contents are indistinguishable to
     # a feed and to anyone who already installed one. The build id supplies that distinctness in
     # CI; a UTC timestamp does locally, where no build id exists.
-    # The pattern is the documented PowerShellGet grammar, not a preference: the prerelease
-    # string may contain only ASCII alphanumerics and a hyphen, the hyphen only as the FIRST
-    # character, and never a period - so 'alpha-4472' and 'alpha.4472' are both invalid, while
-    # 'alpha4472' is the shape the documentation's own examples use (-update20171020).
+    # The pattern is DELIBERATELY narrower than the PowerShellGet prerelease grammar rather than a
+    # restatement of it: PowerShellGet also accepts a hyphen, which this rejects. A label is joined
+    # to the version by a hyphen already, so one that itself begins with a hyphen reads as
+    # '3.0.0--label', and one containing a hyphen splits the label when a version string is parsed
+    # by eye. Alphanumeric-only keeps every generated label unambiguous, and both defaults above
+    # ('alpha' plus a build id or a UTC timestamp) satisfy it by construction.
     [ValidatePattern('^[A-Za-z0-9]+$')]
     [string]$Prerelease = "alpha$(if ($env:BUILD_BUILDID) { $env:BUILD_BUILDID } else { (Get-Date).ToUniversalTime().ToString('yyyyMMddHHmm') })",
     [switch]$SkipKiota,

--- a/tools/WrapperGenerator/README.md
+++ b/tools/WrapperGenerator/README.md
@@ -127,7 +127,94 @@ Filtered OpenAPI (Graph)
    └─► [2] WrapperGenerator ─► the cmdlet wrappers        (this tool)
 ```
 
-The wrappers compile and run only alongside step 1's output. Wiring the two into one buildable module is later work (see Gaps).
+The wrappers compile and run only alongside step 1's output. `tools/Build-WrapperModule.ps1` runs both steps and wires the result into one buildable module; the next section is that path end to end.
+
+## Build a module end to end
+
+`tools/Build-WrapperModule.ps1` runs both steps above and everything after them, so one command
+takes a module from an OpenAPI document to something `Import-Module` accepts.
+
+**Prerequisites** — the .NET SDK, PowerShell 7+, and the kiota CLI on `PATH`:
+
+```powershell
+dotnet tool install --global Microsoft.OpenApi.Kiota
+```
+
+**Build one module:**
+
+```powershell
+.\tools\Build-WrapperModule.ps1 -Module Mail
+```
+
+Everything lands in `src/Mail/wrapper/v1.0/`. Per module the script runs:
+
+| Step | Produces |
+|---|---|
+| 1. `kiota generate` | `Client/` — the `ApiClient` and its models |
+| 2. WrapperGenerator | `Cmdlets/` — one `*.g.cs` per cmdlet, plus `Shared.g.cs` |
+| 3–4. project files from `tools/Templates/` | `Client/Client.csproj` and `Microsoft.Graph.Wrapper.Mail.csproj` |
+| 5. `dotnet build` | `bin/{Configuration}/netstandard2.0/Microsoft.Graph.Wrapper.Mail.dll` |
+| 6. `New-ModuleManifest` | `Microsoft.Graph.Wrapper.Mail.psd1`, next to the dll |
+| 7. `dotnet pack` (only with `-Pack`) | `artifacts/Mail/Microsoft.Graph.Wrapper.Mail.{version}.nupkg` |
+
+Steps 1 and 2 read the **same** OpenAPI document, so the wrappers always match the client they
+compile against — that is the reason one script owns both rather than two run in sequence.
+
+**Import what you just built:**
+
+```powershell
+Import-Module .\src\Mail\wrapper\v1.0\bin\Debug\netstandard2.0\Microsoft.Graph.Wrapper.Mail.psd1
+```
+
+The module is named `Microsoft.Graph.Wrapper.{Module}`, so it imports side by side with an
+installed `Microsoft.Graph.{Module}` without colliding.
+
+**The switches you will actually reach for:**
+
+| To | Use |
+|---|---|
+| build every module configured for the API version | omit `-Module` |
+| re-run only the wrappers, reusing the client on disk | `-SkipKiota` |
+| build what the gates build | `-Configuration Release` |
+| read a different spec root | `-SpecRoot` (default `openApiDocs_KiotaCompat`) |
+
+`Get-Help .\tools\Build-WrapperModule.ps1 -Full` documents each parameter and why its default is
+what it is.
+
+**Package it** — `-Pack` writes one nupkg per module under `artifacts/{Module}/`:
+
+```powershell
+.\tools\Build-WrapperModule.ps1 -ApiVersion v1.0 -Pack
+```
+
+Packages are `3.0.0` (`-ModuleVersion`) and always carry a prerelease label (`-Prerelease`,
+defaulting to `alpha{build id}` in CI and `alpha{UTC timestamp}` locally). Neither default is
+cosmetic. The wrappers are the v3 line, not a build of the v2 service-module release train whose
+version lives in `config/ModuleMetadata.json`, so a stable-versioned wrapper package would
+collide number-for-number with a real SDK release; and two packages sharing an id and version but
+not their contents are indistinguishable to a feed and to anyone who already installed one.
+
+Three properties are what make a package installable rather than merely produced, and each is
+there because its absence was observed: the nuspec declares `Microsoft.Graph.Authentication` as a
+dependency, because `Install-Module` resolves from NuGet metadata and not from the manifest, so
+without it a clean machine gets a wrapper that cannot import; the prerelease label is mandatory
+rather than optional; and the manifest GUID is derived from the module name — a name-based RFC
+4122 UUID, identical on every build — so `Update-Module` keeps its identity across handouts
+instead of seeing a new module each time.
+
+**Check it** — the smoke test reads the **package**, not `bin/`, in a fresh pwsh process per
+module. Importing build output proves the compiler ran; it does not prove the artifact a user
+installs carries the assembly, its dependencies and a manifest that agrees with them. So pack
+first:
+
+```powershell
+.\tools\Build-WrapperModule.ps1 -Module Mail -Pack
+.\tools\Test-WrapperModule.ps1 -Module Mail
+```
+
+It refuses a package packed before any of its compile inputs under `src` — a green run cannot be
+a stale one — and reports `n/a` rather than a pass for a shape the module never binds. The full
+gate set, in order and with a population reported per gate, is `.\tools\Invoke-WrapperGates.ps1`.
 
 ## The source files
 
@@ -144,7 +231,10 @@ The wrappers compile and run only alongside step 1's output. Wiring the two into
 | `OperationInfo.cs`, `EmitContext.cs`, `GeneratorConfig.cs` | Small data/config carriers |
 | `GeneratorExtensions.cs` | String + schema helper methods |
 
-## Build, run, test
+## Run the generator on its own
+
+Step 2 by itself — for changing the generator, or emitting a handful of operations without
+building a whole module.
 
 **Build:**
 
@@ -207,8 +297,7 @@ diff shows exactly what the change did to the output:
 .\tools\New-WrapperOutputManifest.ps1        # refresh docs/WrapperCmdlets-V1.0*.csv
 ```
 
-Omit `-Module` to build every module configured for the API version; add `-Pack` to produce a
-package per module under `artifacts/{Module}/`.
+The switches are the same ones described under [Build a module end to end](#build-a-module-end-to-end).
 
 `docs/WrapperCmdlets-V1.0.csv` is the reviewable inventory of that output — one row per emitted
 cmdlet with its module, verb, noun and request path — with per-module totals in
@@ -233,12 +322,12 @@ dotnet test tools/WrapperGenerator.Tests
 .\tools\Test-BodyBindingCoverage.ps1
 
 # 5. Runtime gate: the module imports and each bound shape accepts what a person would type
-.\tools\Test-WrapperModule.ps1 -Module <names> -Configuration Release
+.\tools\Test-WrapperModule.ps1 -Module <names>          # needs -Pack output; see above
 ```
 
 The unit tests guard the naming and classification rules (their expected values are real published names from `src/Authentication/Authentication/custom/common/MgCommandMetadata.json`). The parity gate checks actual generated output against that same inventory; names on the deliberate-corrections list ([docs/edge-cases/naming-edge-cases.md](docs/edge-cases/naming-edge-cases.md)) are reported as `[CORRECTED]` instead of failing.
 
-The generated cmdlets **are** compiled: `Build-WrapperModule.ps1` builds each module against the kiota client it was generated with, the only authority on whether an emitted parameter's CLR type matches the member it assigns. Compilation cannot see an *omitted* member, so the omission oracle exists separately; neither can see whether PowerShell converts a value at runtime, so the runtime gate exists separately again. Naming parity is enforced independently by `Compare-WrapperCmdletNames.ps1`. The runtime gate refuses a binary older than any of its compiled inputs — `Build-` and `Test-` both default to `Debug`, so a Release-only build once left it validating a three-day-old assembly and reporting green.
+The generated cmdlets **are** compiled: `Build-WrapperModule.ps1` builds each module against the kiota client it was generated with, the only authority on whether an emitted parameter's CLR type matches the member it assigns. Compilation cannot see an *omitted* member, so the omission oracle exists separately; neither can see whether PowerShell converts a value at runtime, so the runtime gate exists separately again. Naming parity is enforced independently by `Compare-WrapperCmdletNames.ps1`. The runtime gate reads the packed artifact rather than `bin/`, and refuses one packed before any of its compile inputs under `src`, so it cannot validate a stale build and report green.
 
 ## Gaps / not done yet
 


### PR DESCRIPTION
Changes proposed:

Declare Microsoft.Graph.Authentication as a NuGet dependency in every wrapper nuspec (open floor matching the manifest minimum) — Install-Module resolves from package metadata, not the manifest, so without this a clean machine got a wrapper that could not import
Version every package as a prerelease (-Prerelease, default wrapperpreview01) so previews can never collide with the service-module release train's stable versions
Derive a stable RFC 4122 name-based module GUID from the module name — identical across builds with no lookup table, extending the shipped SDK's locked-GUID convention to never-published modules
Correct two comments (Std.UriTemplate's actual requester; the live gate's committed name)
Validation:
 38/38 packages verified three rounds each (dependency, label, distinct stable GUIDs, with negative controls); clean-machine proof three rounds — Save-Module from a folder repository auto-resolves Authentication and the saved layout imports and completes a live Graph call in a host that can see nothing else; package gate PASS ×3; GUID algorithm verified against the RFC 4122 canonical test vector.
